### PR TITLE
Add 'using' function

### DIFF
--- a/src/batPervasives.mli
+++ b/src/batPervasives.mli
@@ -468,6 +468,10 @@ val finally : (unit -> unit) -> ('a -> 'b) -> 'a -> 'b
   (** [finally fend f x] calls [f x] and then [fend()] even if [f x] raised
       an exception. *)
 
+val using : ?dispose:('a -> unit) -> 'a -> ('a -> 'b) -> 'b
+  (** [using x f] invokes [f] on [a], calling [dispose x] when [f] terminates
+      (either with a return value or an exception). *)
+
 val args : unit -> string BatEnum.t
   (** An enumeration of the arguments passed to this program through the command line.
 

--- a/src/batStd.ml
+++ b/src/batStd.ml
@@ -181,6 +181,11 @@ let finally handler f x =
 	handler();
 	r
 
+let using ?dispose x f =
+  match dispose with
+      Some c -> finally (fun () -> c x) f x
+    | None -> f x
+
 let __unique_counter = ref 0
 
 let unique() =

--- a/src/batStd.mli
+++ b/src/batStd.mli
@@ -76,6 +76,10 @@ val finally : (unit -> unit) -> ('a -> 'b) -> 'a -> 'b
   (** [finally fend f x] calls [f x] and then [fend()] even if [f x] raised
       an exception. *)
 
+val using : ?dispose:('a -> unit) -> 'a -> ('a -> 'b) -> 'b
+  (** [using x f] invokes [f] on [a], calling [dispose x] when [f] terminates
+      (either with a return value or an exception). *)
+
 val args : unit -> string BatEnum.t
   (** An enumeration of the arguments passed to this program through the command line.
 

--- a/testsuite/main.ml
+++ b/testsuite/main.ml
@@ -2,6 +2,7 @@ open OUnit
 
 let all_tests =
   [
+    Test_std.tests;
     Test_base64.tests;
     Test_unix.tests;
 (*    Test_print.tests;

--- a/testsuite/test_std.ml
+++ b/testsuite/test_std.ml
@@ -1,0 +1,17 @@
+open OUnit
+open Batteries_uni
+
+let test_using () =
+  let obj = (ref 0), (ref 0) in
+  let dispose (_,closed) = closed := 5 in
+  let f (run,_) = run := 7; 42 in
+  let r = using ~dispose obj f in
+  let printer = string_of_int in
+  let run, closed = obj in
+  assert_equal ~printer 42 r;
+  assert_equal ~printer 7 (!run);
+  assert_equal ~printer 5 (!closed)
+
+let tests = "Std" >::: [
+  "using" >:: test_using
+];;


### PR DESCRIPTION
This patch adds a `using` function to BatStd and BatPervasives, providing a generic `with_foo` capability mirroring that of `with_file_in` and friends.  It takes a disposal function, called `dispose`, a value, and a function; it invokes the function on the value, calls the diposer with the value, and returns the return value of the function.  It makes certain patterns with `finally` easier, as the function's argument is passed to the disposal function.  It also has a slightly different argument order, so that the invocation reads 'using `val` do `f`'.

I am running this through as a pull request so that the following decisions can be reviewed:
- Choice of the name `using`.  `with` is a reserved word, so it cannot be used for the name of this function to mirror the various specific `with_file_in` and friends.  `using` is the keyword employed by C# for this functionality, based around `IDisposable` instances (also informing my choice of `dispose`).  I do not like the discontinuity between `using` and `with_foo`, but do not see good options that are not excessively verbose (like `generic_with`).
- Making the disposal optional.  I don't have a use case for it.  Making it labelled but non-optional keeps the labelling for clarity, but also allows for application without a label if memory serves.  I think that this change would be good.
- The argument order.  It is inconsistent with `finally` but IMO more readable (and consistent with its friends `with_foo`).
