### PR TITLE
enumerating for Std.cache

### DIFF
--- a/src/batStd.ml
+++ b/src/batStd.ml
@@ -259,18 +259,25 @@ let exe =
 
 let argv = Sys.argv
 
-type ('a,'b) cache = {get : 'a -> 'b; del : 'a -> unit}
+type ('a,'b) cache = {
+  get : 'a -> 'b;
+  del : 'a -> unit;
+  enum : unit -> ('a * 'b) BatEnum.t;
+}
+
 let cache_ht ~gen init_size =
-  let ht = Hashtbl.create init_size in
+  let ht = BatHashtbl.create init_size in
   {get = (fun k -> 
-    try Hashtbl.find ht k
+    try BatHashtbl.find ht k
     with Not_found -> gen k |> tap (Hashtbl.add ht k));
-   del = (fun k -> Hashtbl.remove ht k)}
+   del = (fun k -> BatHashtbl.remove ht k);
+   enum = (fun () -> BatHashtbl.enum ht)}
 
 let cache_map ~gen =
   let m = ref BatMap.empty in
   {get = (fun k -> 
     try BatMap.find k !m
     with Not_found -> gen k |> tap (fun v -> m := BatMap.add k v !m));
-   del = (fun k -> m := BatMap.remove k !m)}
+   del = (fun k -> m := BatMap.remove k !m);
+   enum = (fun () -> BatMap.enum !m)}
 

--- a/src/batStd.mli
+++ b/src/batStd.mli
@@ -206,7 +206,12 @@ return value or the [Bad] exception. *)
    {6 Caches}
 *)
 
-type ('a,'b) cache = {get : 'a -> 'b; del : 'a -> unit}
+type ('a,'b) cache = {
+  get : 'a -> 'b;
+  del : 'a -> unit;
+  enum : unit -> ('a * 'b) BatEnum.t;
+}
+
 val cache_ht : gen:('a -> 'b) -> int -> ('a,'b) cache
 val cache_map : gen:('a -> 'b) -> ('a,'b) cache
 (** These functions build a cache with either a hashtbl or a map.  The


### PR DESCRIPTION
It's pretty much all about this hunk:

-type ('a,'b) cache = {get : 'a -> 'b; del : 'a -> unit}
+type ('a,'b) cache = {
+  get : 'a -> 'b;
+  del : 'a -> unit;
+  enum : unit -> ('a * 'b) BatEnum.t;
+}
