### PR TITLE
Batstream improvements

### DIFF
--- a/src/batStream.ml
+++ b/src/batStream.ml
@@ -60,17 +60,17 @@ open Stream
       
     let to_string fl =
       let buf = Buffer.create 16
-      in (iter (Buffer.add_char buf) s; Buffer.contents buf)
+      in (iter (Buffer.add_char buf) fl; Buffer.contents buf)
 
-    let to_string_fmt fmt st =
+    let to_string_fmt fmt fl =
       let buf = Buffer.create 16
       in (Stream.iter (fun it ->
-        Buffer.add_string buf (Printf.sprintf fmt st)) st; Buffer.contents buf)
+        Buffer.add_string buf (Printf.sprintf fmt it)) fl; Buffer.contents buf)
 
-    let to_string_fun fn st =
+    let to_string_fun fn fl =
       let buf = Buffer.create 16
       in (Stream.iter (fun it ->
-        Buffer.add_string buf (fn it)) st; Buffer.contents buf)
+        Buffer.add_string buf (fn it)) fl; Buffer.contents buf)
       
     let on_channel ch = iter (output_char ch)
       

--- a/src/batStream.mli
+++ b/src/batStream.mli
@@ -76,7 +76,7 @@ val to_list : 'a t -> 'a list
 val to_string : char t -> string
 (** convert stream of chars to string, using buffer *)
 
-val to_string_fmt : ('a t -> string, unit, string) format -> 'a t -> string
+val to_string_fmt : ('a -> string, unit, string) format -> 'a t -> string
 (** convert stream to string, using Printf with given format *)
 
 val to_string_fun : ('a -> string) -> 'a t -> string
@@ -86,6 +86,7 @@ val to_string_fun : ('a -> string) -> 'a t -> string
 
 val on_output:   'a BatIO.output-> char t -> unit
 (** Convert an [output] to a stream.*)
+
 
 (** {6 Stream builders}
 
@@ -245,7 +246,7 @@ module StreamLabels : sig
 
 val iter : f:('a -> unit) -> 'a t -> unit
 
-val to_string_fmt : fmt:('a t -> string, unit, string) format -> 'a t -> string
+val to_string_fmt : fmt:('a -> string, unit, string) format -> 'a t -> string
 
 val to_string_fun : fn:('a -> string) -> 'a t -> string
 


### PR DESCRIPTION
Some improvements of batStream module:
to_string and to_list became public;
to_string improved to use Buffer;
to_string_fmt and to_string_fun added to allow generic conversions;
small fixes in docs.
