### PR TITLE
What about having /@/ for filter_map in BatPervasive?

### DIFF
--- a/src/batEnum.ml
+++ b/src/batEnum.ml
@@ -731,6 +731,8 @@ let ( // ) e f = filter f e
 
 let ( /@ ) e f        = map f e
 let ( @/ )            = map
+let ( //@ ) e f       = filter_map f e
+let ( @// )           = filter_map
 
 let uniq e = 
   match peek e with 

--- a/src/batEnum.mli
+++ b/src/batEnum.mli
@@ -539,6 +539,12 @@ val ( @/ ) : ('a -> 'b) -> 'a t -> 'b t
      several transformations in a row.
   *)
 
+val ( //@ ) : 'a t -> ('a -> 'b option) -> 'b t
+
+val ( @// ) : ('a -> 'b option) -> 'a t -> 'b t
+  (**
+    Map combined with filter. Same as {!filter_map}.
+  *)
 
 val dup : 'a t -> 'a t * 'a t
   (** [dup stream] returns a pair of streams which are identical to [stream]. Note

--- a/src/batPervasives.ml
+++ b/src/batPervasives.ml
@@ -96,6 +96,7 @@ open Pervasives
   let junk              = junk
   let map               = map
   let filter            = filter
+  let filter_map        = filter_map
   let concat            = concat
   let ( -- )            = ( -- )
   let ( --^ )            = ( --^ )
@@ -105,6 +106,8 @@ open Pervasives
   let ( // )            = ( // )
   let ( /@ ) e f        = map f e
   let ( @/ )            = map
+  let ( //@ ) e f       = filter_map f e
+  let ( @// )           = filter_map
   let print             = print
   let get               = get
   let iter              = iter

--- a/src/batPervasives.mli
+++ b/src/batPervasives.mli
@@ -617,7 +617,14 @@ val map : ('a -> 'b) -> 'a BatEnum.t -> 'b BatEnum.t
       Similarly, if [square] is the function [fun x -> x * x],
       [map square (1 -- 10)] produces the enumeration of the
       square numbers of all numbers between [1] and [10].
-*)
+  *)
+
+
+val filter_map : ('a -> 'b option) -> 'a BatEnum.t -> 'b BatEnum.t
+  (** Similar to a map, except that you can skip over some items of the
+      incoming enumeration by returning None instead of Some value.
+      Think of it as a {!filter} combined with a {!map}.
+  *)
 
 
 val reduce : ('a -> 'a -> 'a) -> 'a BatEnum.t -> 'a
@@ -691,6 +698,13 @@ val ( @/ ) : ('a -> 'b) -> 'a BatEnum.t -> 'b BatEnum.t
      These operators have the same meaning as function {!map} but are
      sometimes more readable than this function, when chaining
      several transformations in a row.
+  *)
+
+val ( //@ ) : 'a BatEnum.t -> ('a -> 'b option) -> 'b BatEnum.t
+
+val ( @// ) : ('a -> 'b option) -> 'a BatEnum.t -> 'b BatEnum.t
+  (**
+    Map combined with filter. Same as {!filter_map}.
   *)
 
 (**


### PR DESCRIPTION
Import filter_map from BatEnum into BatPervasive and make it available via /@/ alias.
