### PR TITLE
Global replace for BatString

### DIFF
--- a/src/batString.ml
+++ b/src/batString.ml
@@ -567,12 +567,12 @@ let replace ~str ~sub ~by =
 **)
 
 
-let global_replace ~str ~sub ~by =
+let nreplace ~str ~sub ~by =
   let parts = nsplit str sub in
   String.concat by parts
-(**T String.global_replace
-   global_replace ~str:"bar foo aaa bar" ~sub:"aa" ~by:"foo" = "bar foo afoo bar"
-   global_replace ~str:"bar foo bar" ~sub:"bar" ~by:"foo" = "foo foo foo"
+(**T String.nreplace
+   nreplace ~str:"bar foo aaa bar" ~sub:"aa" ~by:"foo" = "bar foo afoo bar"
+   nreplace ~str:"bar foo bar" ~sub:"bar" ~by:"foo" = "foo foo foo"
 **)
 
 
@@ -820,7 +820,7 @@ let concat        = concat
 let escaped       = escaped
 let replace_chars = replace_chars
 let replace       = replace
-let global_replace= global_replace
+let nreplace      = nreplace
 let split         = split
 let repeat        = repeat
 let rsplit        = rsplit

--- a/src/batString.mli
+++ b/src/batString.mli
@@ -374,12 +374,12 @@ val replace : str:string -> sub:string -> by:string -> bool * string
       Example: [String.replace "foobarbaz" "bar" "rab" = (true, "foorabbaz")]
 *)
 
-val global_replace : str:string -> sub:string -> by:string -> string
-  (** [global_replace ~str ~sub ~by] returns a string obtained by iteratively
+val nreplace : str:string -> sub:string -> by:string -> string
+  (** [nreplace ~str ~sub ~by] returns a string obtained by iteratively
       replacing each occurrence of [sub] by [by] in [str], from right to left.
       It returns a copy of [str] if [sub] has no occurrence in [str].
 
-      Example: [global_replace ~str:"bar foo aaa bar" ~sub:"aa" ~by:"foo" = "bar foo afoo bar"]
+      Example: [nreplace ~str:"bar foo aaa bar" ~sub:"aa" ~by:"foo" = "bar foo afoo bar"]
 *)
 
 val repeat: string -> int -> string
@@ -778,7 +778,7 @@ val replace_chars : (char -> [> `Read] t) -> [> `Read] t -> _ t
 
 val replace : str:[> `Read] t -> sub:[> `Read] t -> by:[> `Read] t -> bool * _ t
 
-val global_replace : str:[> `Read] t -> sub:[> `Read] t -> by:[> `Read] t -> _ t
+val nreplace : str:[> `Read] t -> sub:[> `Read] t -> by:[> `Read] t -> _ t
 
 val repeat: [> `Read] t -> int -> _ t
 


### PR DESCRIPTION
Replaces all occurrences of a substring by something else. It is named nreplace to match split/nsplit

<pre>
val nreplace : str:string -> sub:string -> by:string -> string
  (** [nreplace ~str ~sub ~by] returns a string obtained by iteratively
      replacing each occurrence of [sub] by [by] in [str], from right to left.
      It returns a copy of [str] if [sub] has no occurrence in [str].

      Example: [nreplace ~str:"bar foo aaa bar" ~sub:"aa" ~by:"foo" = "bar foo afoo bar"]
*)
</pre>


Two possible enhancements
- replace occurs from right to left, which matters only if two occurrences of the string to be removed can overlap (aa can, but ab cannot, for instance). This is due to the way nsplit cuts strings (also from right to left).
- the main argument (~str) should not be labeled, however it is labeled in the replace function, so I keep it that way.
