### PR TITLE
Some improvements to BatLazyList to avoid paying through the nose for laziness when not needed

### DIFF
--- a/src/batLazyList.mli
+++ b/src/batLazyList.mli
@@ -1,7 +1,7 @@
-(* 
+(*
  * LazyList - Lazily-computed lists of possibly infinite size
  * Copyright (C) 2009 David Rajchenbach-Teller, LIFO, Universite d'Orleans
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
@@ -21,7 +21,7 @@
 
      Lazy lists are similar to lists, with the exception that their contents are
      only computed whenever requested. This makes them particularly useful in
-     contexts where streams of data are to be handled. 
+     contexts where streams of data are to be handled.
 
      {b Note} For this documentation, we will assume the existence of
      a lazy list syntax extension such that [[^ ^]] is the empty lazy
@@ -47,15 +47,15 @@
 exception Empty_list
   (** [Empty_list] is raised when an operation applied on an empty list
       is invalid. For instance, [hd nil] will raise [Empty_list]. *)
-  
+
 exception Invalid_index of int
   (** [Invalid_index] is raised when an indexed access on a list is
       out of list bounds. *)
-  
+
 exception Different_list_size of string
   (** [Different_list_size] is raised when applying functions such as
       [iter2] on two lists having different size. *)
-  
+
 exception No_more_elements
   (** See {!from} and {!from_loop} for more information on this exception.*)
 
@@ -64,10 +64,10 @@ exception No_more_elements
    {b Note} The types are kept concrete so as to allow pattern-matching.
    However, it is generally easier to manipulate {!nil} and {!cons}.*)
 
-type 'a t = ('a node_t) Lazy.t 
+type +'a t
 (**The type of a lazy list.*)
 
-and 'a node_t = | Nil | Cons of 'a * 'a t 
+and 'a node_t = | Nil | Cons of 'a * 'a t
 (**The type of an item in the list.*)
 
 include BatEnum.Enumerable with type 'a enumerable = 'a t
@@ -80,6 +80,9 @@ val nil : 'a t
 
 val cons : 'a -> 'a t -> 'a t
 (**Build a list from a head and a tail.*)
+
+val lcons : (unit -> 'a node_t) -> 'a t
+(**Build a list from a thunk*)
 
 val ( ^:^ ) : 'a -> 'a t -> 'a t
 (**As [cons]: [x^:^l] is the lazy list with head [x] and tail [l]*)
@@ -95,10 +98,10 @@ val get : 'a t -> ('a * 'a t) option
 *)
 
 
-val from: (unit -> 'a) -> 'a t  
+val from: (unit -> 'a) -> 'a t
   (**[from next] creates a (possibly infinite) lazy list from the successive
-     results of [next]. 
-     The function {i may} raise {!LazyList.No_more_elements} to denote the end of the 
+     results of [next].
+     The function {i may} raise {!LazyList.No_more_elements} to denote the end of the
      list.*)
 
 val from_while: (unit -> 'a option) -> 'a t
@@ -109,7 +112,7 @@ val from_while: (unit -> 'a option) -> 'a t
 val from_loop: 'b -> ('b -> ('a * 'b)) -> 'a t
   (**[from_loop data next] creates a (possibly infinite) lazy list from
      the successive results of applying [next] to [data], then to the
-     result, etc. The list ends whenever the function raises 
+     result, etc. The list ends whenever the function raises
      {!LazyList.No_more_elements}*)
 
 val seq: 'a -> ('a -> 'a) -> ('a -> bool) -> 'a t
@@ -124,7 +127,7 @@ val unfold: 'b -> ('b -> ('a * 'b) option) -> 'a t
      result, etc. The list ends whenever the function returns [None]*)
 
 val init : int -> (int -> 'a) -> 'a t
-  (** Similar to [Array.init], [init n f] returns the lazy list 
+  (** Similar to [Array.init], [init n f] returns the lazy list
       containing the results of (f 0),(f 1).... (f (n-1)).
       Raise [Invalid_arg "LazyList.init"] if n < 0.*)
 
@@ -136,13 +139,13 @@ val range : int -> int -> int t
 (**Compute lazily a range of integers a .. b as a lazy list.
 
    The range is empty if a <= b.*)
-  
+
 
 (**
    {6 Higher-order functions}
 *)
 
-val iter : ('a -> 'b) -> 'a t -> unit 
+val iter : ('a -> 'b) -> 'a t -> unit
 (**
    Eager iteration
 
@@ -150,7 +153,7 @@ val iter : ('a -> 'b) -> 'a t -> unit
    a1; ...; an].  It is equivalent to [begin f a0; f a1; ...; f an; ()
    end]. In particular, it causes all the elements of the list to be
    evaluated.*)
-  
+
 val iteri : (int -> 'a -> 'b) -> 'a t -> unit
 (**Eager iteration, with indices
 
@@ -168,7 +171,7 @@ val map : ('a -> 'b) -> 'a t -> 'b t
    with the results returned by [f]. Not tail-recursive. Evaluations
    of [f] take place only when the contents of the list are forced.*)
 
-  
+
 val mapi : (int -> 'a -> 'b) -> 'a t -> 'b t
 (**Lazy map, with indices
 
@@ -231,7 +234,7 @@ val rfindi : (int -> 'a -> bool) -> 'a t -> (int * 'a)
 
 val index_of : 'a -> 'a t -> int option
   (** [index_of e l] returns the index of the first occurrence of [e]
-      in [l], or [None] if there is no occurrence of [e] in [l] *)  
+      in [l], or [None] if there is no occurrence of [e] in [l] *)
 
 val index_ofq : 'a -> 'a t -> int option
   (** [index_ofq e l] behaves as [index_of e l] except it uses
@@ -239,7 +242,7 @@ val index_ofq : 'a -> 'a t -> int option
 
 val rindex_of : 'a -> 'a t -> int option
   (** [index_of e l] returns the index of the last occurrence of [e]
-      in [l], or [None] if there is no occurrence of [e] in [l] *)  
+      in [l], or [None] if there is no occurrence of [e] in [l] *)
 
 val rindex_ofq : 'a -> 'a t -> int option
   (** [rindex_ofq e l] behaves as [rindex_of e l] except it uses
@@ -262,7 +265,7 @@ val would_at_fail: 'a t -> int -> bool
   (**[would_at_fail l n] returns [true] if [l] contains strictly less
      than [n] elements, [false] otherwise*)
 
-val hd : 'a t -> 'a  
+val hd : 'a t -> 'a
 (**Return the first element of the given list. Raise [Empty_list] if the list is empty.
 
    Note: this function does not comply with the usual exceptionless error-management
@@ -323,7 +326,7 @@ val eager_append : 'a t -> 'a t -> 'a t
 (**Evaluate a list and append another list after this one.
 
    Cost is linear in the length of the first list, not tail-recursive.*)
-  
+
 val rev_append : 'a t -> 'a t -> 'a t
 (**Eager reverse-and-append
 
@@ -339,7 +342,7 @@ val append : 'a t -> 'a t -> 'a t
 val ( ^@^ ) : 'a t -> 'a t -> 'a t
   (**As lazy append*)
 
-  
+
 val concat : ('a t) t -> 'a t
   (**Lazy concatenation of a lazy list of lazy lists*)
 
@@ -350,7 +353,7 @@ val split_at : int -> 'a t -> 'a t * 'a t
   (** [split_at n l] returns two lists [l1] and [l2], [l1] containing the
       first [n] elements of [l] and [l2] the others. Raise [Invalid_index] if
       [n] is outside of [l] size bounds. *)
-  
+
 val split_nth : int -> 'a t -> 'a t * 'a t
   (** Obsolete. As [split_at]. *)
 
@@ -363,7 +366,7 @@ val unique : ?cmp:('a -> 'a -> int) -> 'a t -> 'a t
 val unique_eq : ?eq:('a -> 'a -> bool) -> 'a t -> 'a t
 (** as [unique] except only uses an equality function.  Use for
     short lists when comparing is expensive compared to equality
-    testing 
+    testing
     @since 1.3.0
 *)
 
@@ -371,11 +374,11 @@ val remove : 'a -> 'a t -> 'a t
 (** [remove l x] returns the list [l] without the first element [x] found
     or returns  [l] if no element is equal to [x]. Elements are compared
     using ( = ). *)
-  
+
 val remove_if : ('a -> bool) -> 'a t -> 'a t
   (** [remove_if cmp l] is similar to [remove], but with [cmp] used
       instead of ( = ). *)
-  
+
 val remove_all : 'a -> 'a t -> 'a t
   (** [remove_all l x] is similar to [remove] but removes all elements that
       are equal to [x] and not only the first one. *)
@@ -383,15 +386,15 @@ val remove_all : 'a -> 'a t -> 'a t
 val remove_all_such : ('a -> bool) -> 'a t -> 'a t
   (** [remove_all l x] is similar to [remove] but removes all elements that
       are equal to [x] and not only the first one. *)
-  
+
 val take : int -> 'a t -> 'a t
   (** [take n l] returns up to the [n] first elements from list [l], if
       available. *)
-  
+
 val drop : int -> 'a t -> 'a t
   (** [drop n l] returns [l] without the first [n] elements, or the empty
       list if [l] have less than [n] elements. *)
-  
+
 val take_while : ('a -> bool) -> 'a t -> 'a t
   (** [take_while f xs] returns the first elements of list [xs]
       which satisfy the predicate [f]. *)
@@ -399,17 +402,17 @@ val take_while : ('a -> bool) -> 'a t -> 'a t
 val drop_while : ('a -> bool) -> 'a t -> 'a t
   (** [drop_while f xs] returns the list [xs] with the first
       elements satisfying the predicate [f] dropped. *)
-  
+
 
 (**
    {6  Conversions}
 *)
 
 val to_list : 'a t -> 'a list
-(**Eager conversion to string.*)  
+(**Eager conversion to string.*)
 
 val to_stream : 'a t -> 'a Stream.t
-(**Lazy conversion to stream.*)  
+(**Lazy conversion to stream.*)
 
 val to_array : 'a t -> 'a array
 (** Eager conversion to array.*)
@@ -418,29 +421,17 @@ val enum  : 'a t -> 'a BatEnum.t
 (**Lazy conversion to enumeration*)
 
 val of_list : 'a list -> 'a t
-(**Lazy conversion from lists
-
-   Albeit slower than eager conversion, this is the default mechanism for converting from regular 
-   lists to lazy lists.  This for two reasons :
-   * if you're using lazy lists, total speed probably isn't as much an issue as start-up speed
-   * this will let you convert regular infinite lists to lazy lists.*)
-  
+(** Conversion from lists. O(1) *)
 
 val of_stream : 'a Stream.t -> 'a t
 (**Lazy conversion from stream.*)
 
-val of_enum : 'a BatEnum.t -> 'a t  
+val of_enum : 'a BatEnum.t -> 'a t
 (**Lazy conversion from enum.*)
-
-val eager_of_list : 'a list -> 'a t
-(**Eager conversion from lists.
-
-   This function is much faster than {!of_list} but will freeze on cyclic lists.
-*)
 
 val of_array : 'a array -> 'a t
 (**Eager conversion from array*)
-  
+
 (**
    {6  Predicates}
 *)
@@ -448,20 +439,20 @@ val of_array : 'a array -> 'a t
 val filter : ('a -> bool) -> 'a t -> 'a t
 (**Lazy filtering.
 
-   [filter p l] returns all the elements of the list [l]  that satisfy the predicate [p]. 
-   The order of the elements in the input list is preserved.*)  
+   [filter p l] returns all the elements of the list [l]  that satisfy the predicate [p].
+   The order of the elements in the input list is preserved.*)
 
 val exists : ('a -> bool) -> 'a t -> bool
 (**Eager existential.
 
-   [exists p [^ a0; a1; ... ^]] checks if at least one element of the list satisfies the predicate [p]. 
-   That is, it returns [ (p a0) || (p a1) || ... ].*)  
+   [exists p [^ a0; a1; ... ^]] checks if at least one element of the list satisfies the predicate [p].
+   That is, it returns [ (p a0) || (p a1) || ... ].*)
 
 val for_all : ('a -> bool) -> 'a t -> bool
 (**Eager universal.
 
-   [for_all p [^ a0; a1; ... ^]] checks if all elements of the list satisfy the predicate [p]. 
-   That is, it returns [(p a0) && (p a1) && ... ].*)  
+   [for_all p [^ a0; a1; ... ^]] checks if all elements of the list satisfy the predicate [p].
+   That is, it returns [(p a0) && (p a1) && ... ].*)
 
 val filter_map : ('a -> 'b option) -> 'a t -> 'b t
 (**Lazily eliminate some elements and transform others.
@@ -475,15 +466,15 @@ val filter_map : ('a -> 'b option) -> 'a t -> 'b t
    [match f a0 with
      | Some x0 -> x0 ^:^ (match f a1 with
             | Some x1 -> x1 ^:^ ...
-            | None -> [^ ^]) 
+            | None -> [^ ^])
      | None   -> [^ ^] ].*)
 
 
-(**{6 Misc.}*)    
+(**{6 Misc.}*)
 
 val eternity : unit t
 (** An infinite list of nothing*)
-  
+
 (**{6 Sorting}*)
 
 val sort : ?cmp:('a -> 'a -> int) -> 'a t -> 'a t
@@ -498,7 +489,7 @@ val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
     different lengths. Not tail-recursive, lazy. In particular, the
     exception is raised only after the shortest list has been
     entirely consumed. *)
-  
+
 val iter2 : ('a -> 'b -> unit) -> 'a t -> 'b t -> unit
 (** [iter2 f [^ a0; ...; an ^] [^ b0; ...; bn ^]] calls in turn
     [f a0 b0; ...; f an bn]. Tail-recursive, eager.
@@ -547,63 +538,63 @@ end
 (** {6 Boilerplate code}*)
 
 (** {7 Printing}*)
-  
+
 val print : ?first:string -> ?last:string -> ?sep:string ->('a BatInnerIO.output -> 'b -> unit) ->  'a BatInnerIO.output -> 'b t -> unit
 
 
 (** {6 Override modules}*)
-  
+
 (**
    The following modules replace functions defined in {!LazyList} with functions
    behaving slightly differently but having the same name. This is by design:
    the functions meant to override the corresponding functions of {!LazyList}.
-   
+
 *)
 
 (** Exceptionless counterparts for error-raising operations*)
 module Exceptionless : sig
-  
+
   val find : ('a -> bool) -> 'a t -> 'a option
-    (** [rfind p l] returns [Some x] where [x] is the first element of [l] such 
-	that [p x] returns [true] or [None] if such element as not been found. *)
+    (** [rfind p l] returns [Some x] where [x] is the first element of [l] such
+        that [p x] returns [true] or [None] if such element as not been found. *)
 
   val rfind : ('a -> bool) -> 'a t -> 'a option
-    (** [rfind p l] returns [Some x] where [x] is the last element of [l] such 
-	that [p x] returns [true] or [None] if such element as not been found. *)
-    
+    (** [rfind p l] returns [Some x] where [x] is the last element of [l] such
+        that [p x] returns [true] or [None] if such element as not been found. *)
+
   val findi : (int -> 'a -> bool) -> 'a t -> (int * 'a) option
-    (** [findi p e l] returns [Some (i, ai)] where [ai] and [i] are respectively the 
-	first element of [l] and its index, such that [p i ai] is true, 
-	or [None] if no	such element has been found. *)
+    (** [findi p e l] returns [Some (i, ai)] where [ai] and [i] are respectively the
+        first element of [l] and its index, such that [p i ai] is true,
+        or [None] if no such element has been found. *)
 
   val rfindi : (int -> 'a -> bool) -> 'a t -> (int * 'a) option
-    (** [findi p e l] returns [Some (i, ai)] where [ai] and [i] are respectively the 
-	last element of [l] and its index, such that [p i ai] is true, 
-	or [None] if no	such element has been found. *)
+    (** [findi p e l] returns [Some (i, ai)] where [ai] and [i] are respectively the
+        last element of [l] and its index, such that [p i ai] is true,
+        or [None] if no such element has been found. *)
 
   val split_at : int -> 'a t -> [`Ok of ('a t * 'a t) | `Invalid_index of int]
-    (** Whenever [n] is inside of [l] size bounds, [split_at n l] returns 
-	[`Ok (l1,l2)], where [l1] contains the first [n] elements of [l] and [l2] 
-	contains the others. Otherwise, returns [`Invalid_index n] *)
+    (** Whenever [n] is inside of [l] size bounds, [split_at n l] returns
+        [`Ok (l1,l2)], where [l1] contains the first [n] elements of [l] and [l2]
+        contains the others. Otherwise, returns [`Invalid_index n] *)
 
   val at : 'a t -> int -> [`Ok of 'a | `Invalid_index of int]
     (** If [n] is inside the bounds of [l], [at l n] returns [`Ok x], where
-	[x] is the n-th element of the list [l]. Otherwise, returns 
-	[`Invalid_index n].*) 
+        [x] is the n-th element of the list [l]. Otherwise, returns
+        [`Invalid_index n].*)
 
   val assoc : 'a -> ('a * 'b) t -> 'b option
-    (** [assoc a l] returns [Some b] where [b] is the value associated with key [a] 
-	in the list of pairs [l]. That is, [assoc a [ ...; (a,b); ...] = Some b]
-	if [(a,b)] is the leftmost binding of [a] in list [l].
-	Return [None] if there is no value associated with [a] in the
-		list [l]. *)
+    (** [assoc a l] returns [Some b] where [b] is the value associated with key [a]
+        in the list of pairs [l]. That is, [assoc a [ ...; (a,b); ...] = Some b]
+        if [(a,b)] is the leftmost binding of [a] in list [l].
+        Return [None] if there is no value associated with [a] in the
+                list [l]. *)
 
   val assq : 'a -> ('a * 'b) t -> 'b option
-    (** As {!assoc} but with physical equality *)	    
+    (** As {!assoc} but with physical equality *)
 end
 
 (** Operations on {!LazyList} with labels.
-    
+
     This module overrides a number of functions of {!List} by
     functions in which some arguments require labels. These labels are
     there to improve readability and safety and to let you change the
@@ -611,7 +602,7 @@ end
     function is identical to that of the corresponding function of {!LazyList}.
 *)
 module Labels : sig
-  val iter : f:('a -> 'b) -> 'a t -> unit 
+  val iter : f:('a -> 'b) -> 'a t -> unit
   val iteri : f:(int -> 'a -> 'b) -> 'a t -> unit
   val map : f:('a -> 'b) -> 'a t -> 'b t
   val mapi : f:(int -> 'a -> 'b) -> 'a t -> 'b t

--- a/src/batParserCo.ml
+++ b/src/batParserCo.ml
@@ -24,9 +24,9 @@ struct
   let of_lazy_list l init f =
     let rec aux l acc = match get l with
       | None        -> nil
-      | Some (h, t) -> 
+      | Some (h, t) ->
 	  let acc' = f h acc in
-	  lazy( Cons ((h, acc'), (aux t acc')))
+	  BatLazyList.lcons (fun () -> Cons ((h, acc'), (aux t acc')))
     in aux l init
 
   let of_enum l =
@@ -50,7 +50,7 @@ struct
       | None        -> nil
       | Some ((h, _), t) -> 
 	  let acc' = f h acc in
-	  lazy( Cons ((h, acc'), (aux t acc')))
+	  BatLazyList.lcons (fun () -> Cons ((h, acc'), (aux t acc')))
     in aux l init
 end
 
@@ -287,8 +287,8 @@ let source_map p e =
   let rec aux e = match peek e with
     | None        -> nil
     | Some (_, c) -> match apply p e with
-	| Success   (result, rest)    -> lazy (Cons ((result, c), (aux rest)))
-	| Backtrack (result, _, rest) -> lazy (Cons ((result, c), (aux rest)))
+	| Success   (result, rest)    -> BatLazyList.lcons (fun () -> Cons ((result, c), (aux rest)))
+	| Backtrack (result, _, rest) -> BatLazyList.lcons (fun () -> Cons ((result, c), (aux rest)))
 	| Setback _ | Failure _       -> nil (*@TODO: improve error reporting !*)
   in aux e
 	    


### PR DESCRIPTION
This patch hides the 'a BatLazyList.t representation.
It should never have been left exposed.

Then, the 'a BatLazyList.t type is changed to a strict
extension of 'a list, so that the injection from the latter
to the former is Obj.magic. The eager functions (eg.
cons) also no longer create useless indirections.

As a result of hiding the underlying lazy representation,
a new "cons" constructor called lcons is added that
can change a node thunk into a lazy list.

This will be a backwards incompatible change because
of the change to the visibility of the 'a BatLazyList.t type.
