### PR TITLE
Fix mispelled ocamldoc discard command

### DIFF
--- a/src/batInt64.mli
+++ b/src/batInt64.mli
@@ -228,7 +228,7 @@ external format : string -> int64 -> string = "caml_int64_format"
    This function is deprecated; use {!Printf.sprintf} with a [%Lx] format
    instead. *)
 
-(** / **)
+(**/**)
     val modulo : int64 -> int64 -> int64
     val pow : int64 -> int64 -> int64
 

--- a/src/batNativeint.mli
+++ b/src/batNativeint.mli
@@ -256,6 +256,6 @@ external format : string -> nativeint -> string = "caml_nativeint_format"
    one [%d], [%i], [%u], [%x], [%X] or [%o] conversion specification.
    @deprecated use {!Printf.sprintf} with a [%nx] format
    instead. *)
-(** / **)
+(**/**)
 
 


### PR DESCRIPTION
  It's (**/**) not (*\* / **)
