### PR TITLE
Fix Int{64,32}.print so that they print in decimal.

### DIFF
--- a/src/batInt.mli
+++ b/src/batInt.mli
@@ -180,6 +180,7 @@
     (** {7 Printing}*)
 
     val print: 'a BatInnerIO.output -> int -> unit
+      (** prints as decimal string *)
     val xprint: 'a BatInnerIO.output -> int -> unit
       (** prints as hex string *)
 (*    val bprint: 'a BatInnerIO.output -> t -> unit

--- a/src/batInt32.ml
+++ b/src/batInt32.ml
@@ -116,5 +116,6 @@ external format : string -> int32 -> string = "caml_int32_format"
 type bounded = t
 let min_num, max_num = min_int, max_int
 
-let print out t = BatInnerIO.Printf.fprintf out "%lx" t
+let print out t = BatInnerIO.nwrite out (to_string t)
+let xprint out t = BatInnerIO.Printf.fprintf out "%lx" t
 let t_printer paren out t = print out t

--- a/src/batInt32.mli
+++ b/src/batInt32.mli
@@ -265,5 +265,8 @@
 
     (** {7 Printing}*)
     val print: 'a BatInnerIO.output -> t -> unit
+      (** prints as decimal string *)
+    val xprint: 'a BatInnerIO.output -> t -> unit
+      (** prints as hex string *)
     val t_printer : t BatValue_printer.t
 

--- a/src/batInt64.ml
+++ b/src/batInt64.ml
@@ -61,6 +61,7 @@ external float_of_bits : int64 -> float = "caml_int64_float_of_bits"
 external format : string -> int64 -> string = "caml_int64_format"
 
   
-let print out t = BatInnerIO.Printf.fprintf out "%Lx" t
+let print out t = BatInnerIO.nwrite out (to_string t)
+let xprint out t = BatInnerIO.Printf.fprintf out "%Lx" t
 let t_printer paren out t = print out t
 

--- a/src/batInt64.mli
+++ b/src/batInt64.mli
@@ -249,6 +249,9 @@ external format : string -> int64 -> string = "caml_int64_format"
 
     (** {7 Printing}*)
     val print: 'a BatInnerIO.output -> t -> unit
+      (** prints as decimal string *)
+    val xprint: 'a BatInnerIO.output -> t -> unit
+      (** prints as hex string *)
     val t_printer : t BatValue_printer.t
 
 


### PR DESCRIPTION
  While we are at it, add xprint (like in Int module) to print in hexadecimal.
