### PR TITLE
[batString.mli] Removed errant (**/**) directive.

### DIFF
--- a/src/batString.mli
+++ b/src/batString.mli
@@ -542,7 +542,6 @@ val t_printer : t BatValue_printer.t
 
 val unquoted_printer : t BatValue_printer.t
 
-(**/**)
 
 
 (** Exceptionless counterparts for error-raising operations *)


### PR DESCRIPTION
Modules Exceptionless and Cap were not showing up in the generated documentation of String due to a misplaced (**/**). This commit fixes that.
