### PR TITLE
BatRandom.enum_xyz determinism and independence issues

### DIFF
--- a/src/batRandom.ml
+++ b/src/batRandom.ml
@@ -93,16 +93,50 @@ struct
 
 end
 
-let random_enum next = State.random_enum ( State.make_self_init () ) next
+let random_enum clone next =
+  let count () = raise BatEnum.Infinite_enum in
+  let clone () = clone (Random.get_state ()) in
+    BatEnum.make ~next ~count ~clone
 
-let enum_bits () = random_enum State.bits
-let enum_int bound = random_enum (fun s -> State.int s bound)
-let enum_int32 bound = random_enum (fun s -> State.int32 s bound)
-let enum_int64 bound = random_enum (fun s -> State.int64 s bound)
-let enum_float bound = random_enum (fun s -> State.float s bound)
-let enum_nativeint bound = random_enum (fun s -> State.nativeint s bound)
-let enum_bool () = random_enum State.bool
-let enum_char () = random_enum State.char
+let enum_bits () =
+  let next = bits in
+  let clone state = State.enum_bits state () in
+    random_enum clone next
+
+let enum_int bound =
+  let next () = int bound in
+  let clone state = State.enum_int state bound in
+    random_enum clone next
+
+let enum_int32 bound =
+  let next () = int32 bound in
+  let clone state = State.enum_int32 state bound in
+    random_enum clone next
+
+let enum_int64 bound =
+  let next () = int64 bound in
+  let clone state = State.enum_int64 state bound in
+    random_enum clone next
+
+let enum_float bound =
+  let next () = float bound in
+  let clone state = State.enum_float state bound in
+    random_enum clone next
+
+let enum_nativeint bound =
+  let next () = nativeint bound in
+  let clone state = State.enum_nativeint state bound in
+    random_enum clone next
+
+let enum_bool () =
+  let next = bool in
+  let clone state = State.enum_bool state () in
+    random_enum clone next
+
+let enum_char () =
+  let next = char in
+  let clone state = State.enum_char state () in
+    random_enum clone next
 
 let choice e = BatEnum.drop (int (BatEnum.count e)) e; BatEnum.get_exn e
 

--- a/src/batRandom.mli
+++ b/src/batRandom.mli
@@ -89,8 +89,10 @@ val full_range_int : unit -> int
 
 (** {6 Enumerations of random values.}
 
-    These enumerations may be cloned without loss of performance,
-    to obtain reproducible enumerations of pseudo-random numbers.
+    The clone implementations for these enumerations and the enumerations of
+    [BatRandom.State] do not guarantee that the clone and the original will emit
+    the same elements. The enumerations of this module therefore generally
+    shouldn't be cloned.
  *)
 
 val enum_bits  : unit    -> int BatEnum.t


### PR DESCRIPTION
I've written a message to the mailing list on this subject (see https://lists.forge.ocamlcore.org/pipermail/batteries-discuss/2012-February/000172.html) and here is the implementation I am proposing. See also the commit message (included below).

---

This commit replaces the implementation of random enumerations in
BatRandom such that this comment in BatRandom.State becomes true:

>  These functions are the same as the basic functions, except that they
>  use (and update) the given PRNG state instead of the default one.

Currently the enumerations in BatRandom outside of BatRandom.State
construct their own PRNG state behind the back of the user. This is
problematic since the enumerations become unreproducible and since
different enumerations by accident may be constructed from identical or
near-identical states.

Because the state can now be modified from outside of the enumeration,
implementing a correct clone operation is no longer trivial. The same
not-really-correct implementation of BatRandom.State is used, and a
comment has been added warning people not to clone the enumerations.
(IMO a correct clone operation would be to raise an Infinite_enum
exception or to rely on BatEnum's default implementation of clone, but
this is beyond the scope of this commit.)
