### PR TITLE
Fix a typo in ocamlinit that prevents it from loading correctly.

### DIFF
--- a/ocamlinit
+++ b/ocamlinit
@@ -24,7 +24,6 @@
  * ocamlinit file that initializes findlib, just add the last
  * phrase to your ocamlinit.
  *)
- *)
 
 (* Pretend to be in non-interactive mode to hide topfind
 initialization message *)


### PR DESCRIPTION
There was an extra `*)` that made the parser choke.
