### PR TITLE
`List.filter` equivalent for options

### DIFF
--- a/src/batOption.ml
+++ b/src/batOption.ml
@@ -57,6 +57,17 @@ let apply = function
   apply (Some succ) 3 = 4
 *)
 
+
+let filter f = function 
+  | Some x when f x -> Some x
+  | _ -> None
+(*$T filter
+  filter (fun _ -> true) None = None
+  filter (fun _ -> true) (Some 3) = Some 3
+  filter (fun _ -> false) (Some 3) = None
+*)
+
+
 let default v = function
 	| None -> v
 	| Some v -> v

--- a/src/batOption.mli
+++ b/src/batOption.mli
@@ -59,6 +59,10 @@ let interesting_positions dataset =
 val apply : ('a -> 'a) option -> 'a -> 'a
 (** [apply None x] returns [x] and [apply (Some f) x] returns [f x] *)
 
+val filter : ('a -> bool) -> 'a option -> 'a option
+(** [filter f None] returns [None], [apply f (Some x)] returns [Some x] 
+    if [f x] is true, and [None] otherwise. *)
+
 val default : 'a -> 'a option -> 'a
 (** [default x (Some v)] returns [v] and [default x None] returns [x]. *)
 


### PR DESCRIPTION
`filter f (Some x)` returns `Some x` if `f x` is true and `None` otherwise. `filter f None` is always `None`. 

I have found this function useful on several occasions, so I thought I would contribute it to Batteries. What do you think ?

I have not filled in the `@since` doc in this pull request.  
