### PR TITLE
Clean up lots of warnings, includes some API changes and additions

### DIFF
--- a/src/batArray.mli
+++ b/src/batArray.mli
@@ -318,6 +318,7 @@ end
 module Labels : sig
   val init :  int -> f:(int -> 'a) -> 'a array
   val create: int -> init:'a -> 'a array
+  val make: int -> init:'a -> 'a array
   val make_matrix :   dimx:int -> dimy:int -> 'a -> 'a array array
   val create_matrix : dimx:int -> dimy:int -> 'a -> 'a array array
   val sub :  'a array -> pos:int -> len:int -> 'a array

--- a/src/batBase64.ml
+++ b/src/batBase64.ml
@@ -20,7 +20,6 @@
 
 exception Invalid_char
 exception Invalid_table
-exception Invalid_padding
 
 external unsafe_char_of_int : int -> char = "%identity"
 

--- a/src/batBitSet.ml
+++ b/src/batBitSet.ml
@@ -27,7 +27,7 @@ let print_array =
   let print_bchar c = 
     let rc = ref c in
     Buffer.clear buf;
-    for i = 1 to 8 do
+    for _i = 1 to 8 do
       Buffer.add_char buf
         (if !rc land 1 == 1 then '1' else '0');
       rc := !rc lsr 1
@@ -255,7 +255,7 @@ let enum t =
   let rec make n cnt =
     let cur = ref n in
     let cnt = ref cnt in
-    let rec next () =
+    let next () =
       match next_set_bit t !cur with
         Some elem ->
           decr cnt;

--- a/src/batBool.ml
+++ b/src/batBool.ml
@@ -19,9 +19,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *)
 
-
-open BatNumber
-
 module BaseBool = struct
   type t = bool
   external not : bool -> bool = "%boolnot"
@@ -121,7 +118,6 @@ external not : bool -> bool = "%boolnot"
 external ( && ) : bool -> bool -> bool = "%sequand"
 external ( || ) : bool -> bool -> bool = "%sequor"
 
-type bounded = t
 let min_num, max_num = false, true
 
 let print out t = BatInnerIO.nwrite out (to_string t)

--- a/src/batBuffer.ml
+++ b/src/batBuffer.ml
@@ -21,7 +21,6 @@
  *)
 
 
-open BatString
 include Buffer
 
   (** The underlying buffer type. *)
@@ -32,7 +31,6 @@ type buffer =
      initial_buffer : string (** For resetting to the original size **)}
 
 external buffer_of_t : t -> buffer = "%identity"
-external t_of_buffer : buffer -> t = "%identity"
 
 let print out t =
   BatString.print out (contents t)

--- a/src/batDynArray.ml
+++ b/src/batDynArray.ml
@@ -252,7 +252,7 @@ let delete_last d =
   iset d.arr (d.len - 1) dummy_for_gc;
   changelen d (d.len - 1)
 
-let rec blit src srcidx dst dstidx len =
+let blit src srcidx dst dstidx len =
   if len < 0 then invalid_arg len "blit" "len";
   if srcidx < 0 || srcidx + len > src.len then invalid_arg srcidx "blit" "source index";
   if dstidx < 0 || dstidx > dst.len then invalid_arg dstidx "blit" "dest index";

--- a/src/batEnum.ml
+++ b/src/batEnum.ml
@@ -265,7 +265,7 @@ let take n e =
   let r = ref [] in
     begin
       try
-	for i = 1 to n do
+	for _i = 1 to n do
 	  r := e.next () :: !r
 	done
       with No_more_elements -> ()
@@ -419,7 +419,7 @@ let for_all f t =
   with No_more_elements -> true
 
 (* test paired elements, ignore any extra elements from one enum *)
-let for_all2 f t1 t2 =
+let _for_all2 f t1 t2 =
   try
     let rec aux () = f (t1.next()) (t2.next()) && aux () in
     aux ()
@@ -701,7 +701,7 @@ let range ?until x =
 
 
 let drop n e =
-  for i = 1 to n do
+  for _i = 1 to n do
     junk e
   done
 
@@ -891,7 +891,7 @@ let clump clump_size add get e = (* convert a uchar enum into a ustring enum *)
       | Some x ->
 	  add x;
 	  (try
-	     for i = 2 to clump_size do
+	     for _i = 2 to clump_size do
 	       add (e.next ())
 	     done
 	   with No_more_elements -> ());
@@ -1196,7 +1196,7 @@ module Incubator = struct
     else if y > x then Lt
     else Eq
 
-  let eq_elements eq_elt a1 a2 = for_all2 eq_elt a1 a2
+  let eq_elements eq_elt a1 a2 = _for_all2 eq_elt a1 a2
 
   let rec ord_elements ord_elt t u =
     match (get t, get u) with

--- a/src/batFingerTree.ml
+++ b/src/batFingerTree.ml
@@ -185,10 +185,10 @@ struct
   let dummy_printer f _ =
     Format.pp_print_string f "_"
 
-  let pp_debug ?(pp_measure = dummy_printer) pp_a f t =
+  let _pp_debug ?(pp_measure = dummy_printer) pp_a f t =
     pp_debug_tree pp_measure pp_a f t
 
-  let pp_list pp_a f = function
+  let _pp_list pp_a f = function
     | [] -> Format.fprintf f "[]"
     | h :: t ->
       Format.fprintf f "[%a" pp_a h;
@@ -416,7 +416,7 @@ struct
     | [a; b; c] -> three ~monoid ~measure a b c
     | [a; b; c; d] -> four ~monoid ~measure a b c d
     | _ -> assert false (*BISECT-VISIT*)
-  let to_digit_list_node ~monoid = function
+  let _to_digit_list_node ~monoid = function
     | [a] -> one_node a
     | [a; b] -> two_node ~monoid a b
     | [a; b; c] -> three_node ~monoid a b c

--- a/src/batFloat.ml
+++ b/src/batFloat.ml
@@ -145,16 +145,12 @@ external modulo : float -> float -> float = "caml_fmod_float" "fmod" "float"
 external pow : float -> float -> float = "caml_power_float" "pow" "float"
 external of_int : int -> float = "%floatofint"
 external to_int : float -> int = "%intoffloat"
-external of_float : float -> float = "%identity"
-external to_float : float -> float = "%identity"
 external ( + ) : t -> t -> t = "%addfloat"
 external ( - ) : t -> t -> t = "%subfloat"
 external ( * ) : t -> t -> t = "%mulfloat"
 external ( / ) : t -> t -> t = "%divfloat"
 external ( ** ) : t -> t -> t = "caml_power_float" "pow" "float"
 
-
-type bounded = t
 let min_num, max_num = neg_infinity, infinity
 
 type fpkind = Pervasives.fpclass =
@@ -289,7 +285,6 @@ module Safe_float = struct
   let frexp x = let (f, _) as result = frexp x in if_safe f; result (*BISECT-VISIT*)
   let ldexp = safe2 ldexp
 
-  type bounded = t
   let min_num, max_num = neg_infinity, infinity
 
   type fpkind = Pervasives.fpclass =

--- a/src/batGlobal.ml
+++ b/src/batGlobal.ml
@@ -44,8 +44,5 @@ let undef (r, _) =
 let isdef (r, _) =
   !r <> None
 
-let opt (r, _) =
-  !r
-
 let get (r,_) = !r
 (*BISECT-IGNORE-END*)

--- a/src/batHashtbl.ml
+++ b/src/batHashtbl.ml
@@ -38,7 +38,6 @@
     let replace  = Hashtbl.replace
     let iter     = Hashtbl.iter
     let fold     = Hashtbl.fold
-    let length   = Hashtbl.length
     let hash     = Hashtbl.hash
     external hash_param : int -> int -> 'a -> int = "caml_hash_univ_param" "noalloc"
 
@@ -54,7 +53,7 @@
     external h_conv : ('a, 'b) t -> ('a, 'b) h_t = "%identity"
     external h_make : ('a, 'b) h_t -> ('a, 'b) t = "%identity"
 
-    let resize hashfun tbl =
+    let _resize hashfun tbl =
       let odata = tbl.data in
       let osize = Array.length odata in
       let nsize = min (2 * osize + 1) Sys.max_array_length in
@@ -511,11 +510,11 @@
 	let add e ~key ~data     = add e key data
 	let replace e ~key ~data = replace e key data
 	let iter  ~f e           = iter (label f) e
+	let fold  ~f e ~init     = fold (label f) e init
 	let map   ~f e           = map (label f) e
 	let filter     ~f e      = filter f e
 	let filteri    ~f e      = filteri (label f) e
 	let filter_map ~f e      = filter_map (label f) e
-	let fold  ~f e ~init     = fold (label f) e init
       end
 
       module Exceptionless =

--- a/src/batInt.ml
+++ b/src/batInt.ml
@@ -94,10 +94,6 @@ module BaseInt = struct
   external of_int : int -> int = "%identity"
   external to_int : int -> int = "%identity"
 
-
-  let of_string x =
-    try int_of_string x
-    with Failure "int_of_string" -> raise (Invalid_argument "int_of_string")
   let to_string = string_of_int
 
   let enum = enum

--- a/src/batInt.mli
+++ b/src/batInt.mli
@@ -136,7 +136,7 @@ val of_string : string -> int
     The string is read in decimal (by default) or in hexadecimal,
     octal or binary if the string begins with [0x], [0o] or [0b]
     respectively.
-    Raise [Invalid_argument] if the given string is not
+    Raise [Failure] if the given string is not
     a valid representation of an integer, or if the integer represented
     exceeds the range of integers representable in type [int]. *)
 
@@ -342,7 +342,7 @@ module Safe_int : sig
       The string is read in decimal (by default) or in hexadecimal,
       octal or binary if the string begins with [0x], [0o] or [0b]
       respectively.
-      Raise [Invalid_argument] if the given string is not
+      Raise [Failure] if the given string is not
       a valid representation of an integer, or if the integer represented
       exceeds the range of integers representable in type [int]. *)
 

--- a/src/batInt32.ml
+++ b/src/batInt32.ml
@@ -115,10 +115,6 @@ external bits_of_float : float -> int32 = "caml_int32_bits_of_float"
 external float_of_bits : int32 -> float = "caml_int32_float_of_bits"
 external format : string -> int32 -> string = "caml_int32_format"
 
-
-
-
-type bounded = t
 let min_num, max_num = min_int, max_int
 
 let print out t = BatInnerIO.nwrite out (to_string t)

--- a/src/batList.ml
+++ b/src/batList.ml
@@ -106,7 +106,7 @@ let append l1 l2 =
     loop r t;
     inj r
 
-let rec flatten l =
+let flatten l =
   let rec inner dst = function
     | [] -> dst
     | h :: t ->
@@ -241,7 +241,7 @@ let interleave ?first ?last (sep:'a) (l:'a list) =
   (interleave ~first:(-1) ~last:(-2) 0 []) [-1;-2]
 *)
 
-let rec unique ?(eq = ( = )) l =
+let unique ?(eq = ( = )) l =
   let rec loop dst = function
     | [] -> ()
     | h :: t ->
@@ -451,7 +451,7 @@ let find_all p l =
   findnext dummy l;
   dummy.tl
 
-let rec findi p l =
+let findi p l =
   let rec loop n = function
     | [] -> raise Not_found
     | h :: t ->
@@ -459,28 +459,28 @@ let rec findi p l =
   in
   loop 0 l
 
-let rec index_of e l =
+let index_of e l =
   let rec loop n = function
     | []              -> None
     | h::_ when h = e -> Some n
     | _::t            -> loop ( n + 1 ) t
   in loop 0 l
 
-let rec index_ofq e l =
+let index_ofq e l =
   let rec loop n = function
     | []               -> None
     | h::_ when h == e -> Some n
     | _::t             -> loop ( n + 1 ) t
   in loop 0 l
 
-let rec rindex_of e l =
+let rindex_of e l =
   let rec loop n acc = function
     | []              -> acc
     | h::t when h = e -> loop ( n + 1) ( Some n ) t
     | _::t            -> loop ( n + 1 ) acc       t
   in loop 0 None l
 
-let rec rindex_ofq e l =
+let rindex_ofq e l =
   let rec loop n acc = function
     | []               -> acc
     | h::t when h == e -> loop ( n + 1) ( Some n ) t
@@ -542,7 +542,7 @@ let combine l1 l2 =
   loop dummy l1 l2;
   dummy.tl
 
-let rec init size f =
+let init size f =
   if size = 0 then []
   else if size < 0 then invalid_arg "BatList.init"
   else
@@ -635,7 +635,7 @@ let remove l x =
   loop dummy l;
   dummy.tl
 
-let rec remove_if f lst =
+let remove_if f lst =
   let rec loop dst = function
     | [] -> ()
     | x :: l ->
@@ -650,7 +650,7 @@ let rec remove_if f lst =
   loop dummy lst;
   dummy.tl
 
-let rec remove_all l x =
+let remove_all l x =
   let rec loop dst = function
     | [] -> ()
     | h :: t ->
@@ -865,10 +865,7 @@ end
 
 
 module Labels = struct
-
-  type 'a t         = 'a list
   let init i ~f     = init i f
-  let make n  x     = make n x
   let iteri ~f l    = iteri f l
   let map ~f l      = map f l
   let mapi ~f l     = mapi f l

--- a/src/batList.mli
+++ b/src/batList.mli
@@ -733,6 +733,7 @@ module Labels : sig
   val drop_while : f:('a -> bool) -> 'a list -> 'a list
   val stable_sort : ?cmp:('a -> 'a -> int) -> 'a list -> 'a list
   val fast_sort : ?cmp:('a -> 'a -> int) -> 'a list -> 'a list
+  val sort : ?cmp:('a -> 'a -> int) -> 'a list -> 'a list
   val merge : ?cmp:('a -> 'a -> int) -> 'a list -> 'a list -> 'a list
   module LExceptionless : sig
     val find : f:('a -> bool) -> 'a list -> 'a option

--- a/src/batMap.ml
+++ b/src/batMap.ml
@@ -280,15 +280,15 @@ module Concrete = struct
     | Empty -> t
     | Node (l, k, v, r, _) -> rev_cons_iter r (C (k, v, l, t))
 
-  let rec enum_next l () = match !l with
+  let enum_next l () = match !l with
       E -> raise BatEnum.No_more_elements
     | C (k, v, m, t) -> l := cons_iter m t; (k, v)
 
-  let rec enum_backwards_next l () = match !l with
+  let enum_backwards_next l () = match !l with
       E -> raise BatEnum.No_more_elements
     | C (k, v, m, t) -> l := rev_cons_iter m t; (k, v)
 
-  let rec enum_count l () =
+  let enum_count l () =
     let rec aux n = function
       | E -> n
       | C (_, _, m, t) -> aux (n + 1 + cardinal m) t
@@ -331,10 +331,6 @@ module Concrete = struct
     foldi (fun k a acc -> match f k a with
       | None   -> acc
       | Some v -> add k v cmp acc) t empty
-
-  let choose = function
-    | Empty -> invalid_arg "PMap.choose: empty tree"
-    | Node (_l,k,v,_r,_h) -> (k,v)
 
   let for_all f map =
     let rec loop = function
@@ -447,7 +443,7 @@ module Concrete = struct
     | Some d -> join t1 v d t2
     | None -> concat t1 t2
 
-  let rec merge f cmp12 s1 s2 =
+  let merge f cmp12 s1 s2 =
     let rec loop s1 s2 =
       match (s1, s2) with
         | (Empty, Empty) -> Empty
@@ -462,7 +458,7 @@ module Concrete = struct
           assert false in
     loop s1 s2
 
-  let rec merge_diverse f cmp1 s1 cmp2 s2 =
+  let merge_diverse f cmp1 s1 cmp2 s2 =
     (* This implementation does not presuppose that the comparison
        function of s1 and s2 are the same. It is necessary in the PMap
        case, were we can't enforce that the same comparison function is
@@ -550,7 +546,7 @@ module Concrete = struct
      the fast homogeneous implementation instead. This is the
      [heuristic_merge] function.
   *)
-  let rec ordered cmp s =
+  let ordered cmp s =
     try
       ignore
         (foldi (fun k _ last_k ->
@@ -752,8 +748,6 @@ struct
   external t_of_impl: 'a implementation -> 'a t = "%identity"
   external impl_of_t: 'a t -> 'a implementation = "%identity"
 
-  type 'a iter = E | C of key * 'a * 'a implementation * 'a iter
-
   let cardinal t = Concrete.cardinal (impl_of_t t)
   let enum t = Concrete.enum (impl_of_t t)
   let backwards t = Concrete.backwards (impl_of_t t)
@@ -938,8 +932,6 @@ let exists = Concrete.exists
 let partition f m = Concrete.partition f Pervasives.compare m
 let cardinal = Concrete.cardinal
 
-let split k m = Concrete.split k Pervasives.compare m
-
 let add_carry x d m = Concrete.add_carry x d Pervasives.compare m
 let modify x f m = Concrete.modify x f Pervasives.compare m
 
@@ -1074,8 +1066,6 @@ module PMap = struct (*$< PMap *)
   let filter f t = { t with map = Concrete.filter f t.map t.cmp }
   let filter_map f t = { t with map = Concrete.filter_map f t.map t.cmp }
 
-  let choose t = Concrete.choose t.map
-
   let max_binding t = Concrete.max_binding t.map
   let min_binding t = Concrete.min_binding t.map
 
@@ -1093,10 +1083,6 @@ module PMap = struct (*$< PMap *)
   let cardinal m = Concrete.cardinal m.map
 
   let choose m = Concrete.choose m.map
-
-  let split k m =
-    let (l, v, r) = Concrete.split k m.cmp m.map in
-    { m with map = l }, v, { m with map = r }
 
   let add_carry x d m =
     let map', carry = Concrete.add_carry x d m.cmp m.map in

--- a/src/batNativeint.ml
+++ b/src/batNativeint.ml
@@ -73,8 +73,6 @@ external to_int64 : nativeint -> int64 = "%int64_of_nativeint"
 external of_string : string -> nativeint = "caml_nativeint_of_string"
 external format : string -> nativeint -> string = "caml_nativeint_format"
 
-
-type bounded = t
 let min_num, max_num = min_int, max_int
 
 let print out t = BatPrintf.fprintf out "%nx" t

--- a/src/batOption.ml
+++ b/src/batOption.ml
@@ -19,8 +19,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *)
 
-exception No_value
-
 type 'a t = 'a option
 
 let may f = function

--- a/src/batPervasives.ml
+++ b/src/batPervasives.ml
@@ -246,9 +246,6 @@ let args () =
 let exe =
   Array.get Sys.argv 0
 
-let argv = Sys.argv
-
-
   (** {6 I/O}*)
   let print_guess oc v = BatIO.nwrite oc (dump v)
   let prerr_guess v = prerr_endline (dump v)
@@ -380,14 +377,14 @@ let argv = Sys.argv
             match flags.pf_justify with
               | `right ->
                   k (fun oc ->
-                       for i = len + 1 to n do
+                       for _i = len + 1 to n do
                          BatIO.write oc flags.pf_padding_char
                        done;
                        BatIO.nwrite oc x)
               | `left ->
                   k (fun oc ->
                        BatIO.nwrite oc x;
-                       for i = len + 1 to n do
+                       for _i = len + 1 to n do
                          BatIO.write oc flags.pf_padding_char
                        done)
 
@@ -403,14 +400,14 @@ let argv = Sys.argv
             match flags.pf_justify with
               | `right ->
                   k (fun oc ->
-                       for i = len + 1 to n do
+                       for _i = len + 1 to n do
                          BatIO.write oc flags.pf_padding_char
                        done;
                        BatString.Cap.print oc x)
               | `left ->
                   k (fun oc ->
                        BatString.Cap.print oc x;
-                       for i = len + 1 to n do
+                       for _i = len + 1 to n do
                          BatIO.write oc flags.pf_padding_char
                        done)
 

--- a/src/batPervasives.mli
+++ b/src/batPervasives.mli
@@ -521,6 +521,12 @@ val ignore_exceptions : ('a -> 'b) -> 'a -> unit
 (** [ignore_exceptions f x] invokes [f] on [x], ignoring both the returned value
     and the exceptions that may be raised. *)
 
+val verify : bool -> exn -> unit
+(** [verify condition ex] will raise [ex] if [condition] is false, otherwise it
+    does nothing.
+    
+    @since 2.0 *)
+
 val verify_arg : bool -> string -> unit
 (** [verify_arg condition message] will raise [Invalid_argument message] if
     [condition] is false, otherwise it does nothing.

--- a/src/batSet.ml
+++ b/src/batSet.ml
@@ -29,7 +29,6 @@ module Concrete = struct
 
   let empty = Empty
 
-  let is_empty = function Empty -> true | _ -> false
   (* Sets are represented by balanced binary trees (the heights of the
      children differ by at most 2 *)
   let height = function
@@ -204,15 +203,15 @@ module Concrete = struct
       Empty -> t
     | Node (l, e, r, _) -> rev_cons_iter r (C (e, l, t))
 
-  let rec enum_next l () = match !l with
+  let enum_next l () = match !l with
       E -> raise BatEnum.No_more_elements
     | C (e, s, t) -> l := cons_iter s t; e
 
-  let rec enum_backwards_next l () = match !l with
+  let enum_backwards_next l () = match !l with
       E -> raise BatEnum.No_more_elements
     | C (e, s, t) -> l := rev_cons_iter s t; e
 
-  let rec enum_count l () =
+  let enum_count l () =
     let rec aux n = function
         E -> n
       | C (e, s, t) -> aux (n + 1 + cardinal s) t
@@ -427,8 +426,6 @@ struct
   external impl_of_t : t -> implementation = "%identity"
   external t_of_impl : implementation -> t = "%identity"
 
-  type iter = E | C of elt * implementation * iter
-
   let cardinal t = Concrete.cardinal (impl_of_t t)
   let enum t = Concrete.enum (impl_of_t t)
   let of_enum e = t_of_impl (Concrete.of_enum Ord.compare e)
@@ -445,7 +442,7 @@ struct
 
   let exists f t = Concrete.exists f (impl_of_t t)
   let for_all f t = Concrete.for_all f (impl_of_t t)
-  let paritition f t =
+  let partition f t =
     let l, r = Concrete.partition Ord.compare f (impl_of_t t) in
     (t_of_impl l, t_of_impl r)
 
@@ -536,7 +533,6 @@ module PSet = struct
   let fold f s acc = Concrete.fold f s.set acc
   let map f s =
     { cmp = Pervasives.compare; set = Concrete.map Pervasives.compare f s.set }
-  let filter f s = { s with set = Concrete.filter s.cmp f s.set }
   let filter_map f s =
     { cmp = compare; set = Concrete.filter_map compare f s.set }
   let exists f s = Concrete.exists f s.set
@@ -602,8 +598,6 @@ let map f s = Concrete.map Pervasives.compare f s
 (*$T map
   map (fun _x -> 1) (of_list [1;2;3]) |> cardinal = 1
 *)
-
-let filter f s = Concrete.filter Pervasives.compare f s
 
 let filter_map f s = Concrete.filter_map Pervasives.compare f s
 

--- a/src/batString.ml
+++ b/src/batString.ml
@@ -662,7 +662,7 @@ let in_place_mirror s =
 
 let repeat s n =
   let buf = Buffer.create ( n * (String.length s) ) in
-  for i = 1 to n do Buffer.add_string buf s done;
+  for _i = 1 to n do Buffer.add_string buf s done;
   Buffer.contents buf
 (*$T repeat
    repeat "fo" 4 = "fofofofo"

--- a/src/syntax/pa_comprehension/pa_comprehension.ml
+++ b/src/syntax/pa_comprehension/pa_comprehension.ml
@@ -37,7 +37,7 @@ module Make (Syntax : Sig.Camlp4Syntax) = struct
      and insert "[?" and "?]" instead.
 
      Thanks to Jérémie Dimino for the idea. *)
-  value rec delim_filter older_filter stream =
+  value delim_filter older_filter stream =
     let rec filter = parser
     [ [: `(KEYWORD "[", loc); rest :] ->
         match rest with parser


### PR DESCRIPTION
Most of the warnings were unused 'rec' and unused counters in for loops.  There are many more warnings to clean up but most of the others I've seen involve some combination of deleting and exposing functions currently hidden by their module's mli.

Misc fixes that came along with this batch of warnings cleanup:

BatInt.of_string raises Failure like stdlib's int_of_string.  This was documented incorrectly.

The labeled form of List.sort was not exposed.

BatPervasives.verify was not exposed.

BatSet.partition was misspelled so the stdlib implementation was being used.
