### PR TITLE
Fixed two bugs in BatMap

### DIFF
--- a/src/batMap.ml
+++ b/src/batMap.ml
@@ -551,28 +551,31 @@ module Concrete = struct
      [heuristic_merge] function.
   *)
   let rec ordered cmp s =
-    try
-      ignore
-        (foldi (fun k _ last_k ->
-          if cmp last_k k >= 0 then raise Exit
-          else k)
-           (remove_min_binding s)
-           (fst (min_binding s)));
-      true
-    with Exit -> false
+    if s = Empty then true else
+      try
+        ignore
+          (foldi (fun k _ last_k ->
+            if cmp last_k k >= 0 then raise Exit
+            else k)
+             (remove_min_binding s)
+             (fst (min_binding s)));
+        true
+      with Exit -> false
 
+  (* Maps are considered compatible by their comparison function when either:
+     - cmp1 and cmp2 are the *same* function (physical equality)
+     - cmp1 is a correct ordering on m2 (see comment in [ordered]) *)
   let compatible_cmp cmp1 m1 cmp2 m2 =
     cmp1 == cmp2 || ordered cmp1 m2
 
-  let heuristic_merge f cmp1 m1 cmp2 m2 =
-    (* as merge_diverse is much slower than merge, we first try to
-       see if we could possibly use merge; this is the case when either:
-       - cmp1 and cmp2 are the *same* function (physical equality)
-       - cmp1 is a correct ordering on m2 (see comment in [ordered])
+  (* We first try to see if the comparison functions are compatible.
+     If they are, then we use the [merge] function instead of a much
+     slower [merge_diverse].
 
-       In the "same comparisons" case, we return a map ordered with
-       the given comparison. In the other case, we arbitrarily use the
-       comparison function of [m1]. *)
+     In the "same comparisons" case, we return a map ordered with
+     the given comparison. In the other case, we arbitrarily use the
+     comparison function of [m1]. *)
+  let heuristic_merge f cmp1 m1 cmp2 m2 =
     if compatible_cmp cmp1 m1 cmp2 m2
     then merge f cmp1 m1 m2
     else merge_diverse f cmp1 m1 cmp2 m2


### PR DESCRIPTION
I've switched two of my projects to the latest Batteries (in order to get rid of the Camomile dependency, which makes it difficult to distribute binaries on Windows) and these are the bugs which I had to fix in order for my testsuites to pass.

The bug involving physical comparison of externals is quite tricky. Perhaps it should be fixed in a less hacky fashion. Consider it thoroughly.
