### PR TITLE
Fix: qtest wasn't building on WODI

### DIFF
--- a/qtest/_tags
+++ b/qtest/_tags
@@ -1,3 +1,3 @@
-true: thread, debug
+true: threads, debug
 <all_tests.{ml,byte,native}>: pkg_oUnit
 <runner.{ml,byte,native}>: pkg_oUnit


### PR DESCRIPTION
#### Problem

```
''ocamlfind ocamlopt -g threads.cmxa -thread -linkpkg -package bigarray,num,str qtest/misclex.cmx qtest/core.cmx qtest/qparse.cmx qtest/qtest.cmx -o qtest/qtest.native
File "_none_", line 1:
Error: Files C:/wodi32/opt/wodi32/lib/ocaml/std-lib\threads\threads.cmxa
       and C:/wodi32/opt/wodi32/lib/ocaml/std-lib/threads\threads.cmxa
       both define a module named Thread
Exit code 2 while executing this command:
  ''ocamlfind ocamlopt -g threads.cmxa -thread -linkpkg -package bigarray,num,str qtest/misclex.cmx qtest/core.cmx qtest/qparse.cmx qtest/qtest.cmx -o qtest/qtest.native
Makefile:160: recipe for target `_build/qtest/qtest.native' failed
make: *** [_build/qtest/qtest.native] Error 2
```
#### Cause

Wrong tag, according to directions in myocamlbuild.ml:

``` ocaml
      (* DON'T USE TAG 'thread', USE 'threads'
     for compatibility with ocamlbuild *)
      flag ["ocaml"; "compile"; "threads"] & A"-thread";
      flag ["ocaml"; "link"; "threads"] & A"-thread";
      flag ["ocaml"; "doc"; "threads"] & S[A"-I"; A "+threads"];
```
