### PR TITLE
fix: ocamldoc was failing to build doc for BatStats.

### DIFF
--- a/src/batteries.mllib
+++ b/src/batteries.mllib
@@ -69,7 +69,6 @@ BatRef
 BatResult
 BatReturn
 BatSeq
-BatStats
 BatSubstring
 BatTuple
 BatUref


### PR DESCRIPTION
This file (batStats.ml*) stayed on Eric's workdir apparently ;-)
