### PR TITLE
fix: ocamldoc of 3.12.1 can't parse '- :'

### DIFF
--- a/src/batString.mli
+++ b/src/batString.mli
@@ -48,9 +48,9 @@
       # let f () = "foo";;
       val f : unit -> string = <fun>
       # (f ()).[0] <- 'b';;
-      - : unit = ()
+      -: unit = ()
       # f ();;
-      - : string = "boo"
+      -: string = "boo"
   ]}
 
   Likewise, many functions from the standard library can return string


### PR DESCRIPTION
This bug was introduced by merging stdlib's string.mli comments
  (from 4.00) into batString.mli.
  I kept 4.00 comments because they are better than 3.12 but as a work
  around changed '- :' into '-:'
