### PR TITLE
Change BatArray.backwards to match

### DIFF
--- a/src/batArray.ml
+++ b/src/batArray.ml
@@ -286,7 +286,7 @@ let enum xs =
       ~count:(fun () ->
 		n - !start)
       ~clone:(fun () ->
-		make (ref !start) xs)
+		make (BatRef.copy start) xs)
   in
   make (ref 0) xs
 (*$Q enum
@@ -316,8 +316,7 @@ let backwards xs =
       ~count:(fun () ->
 		!start)
       ~clone:(fun () ->
-		let xs' = Array.sub xs 0 !start in
-		make (BatRef.copy start) xs')
+		make (BatRef.copy start) xs)
   in
   make (ref (length xs)) xs
 (*$Q backwards


### PR DESCRIPTION
This will make it faster and enable value sharing.
Without sharing a change to the original array would be visible in the
original backwards enum, but not in its clone.
This certainly is not the expected behaviour.

See commit 8944b0d30b5d062e2f01f5bd9e73e5a9718c5a51
