### PR TITLE
Fix BatText.find, rfind, split, rsplit, and nsplit.

### DIFF
--- a/src/batText.ml
+++ b/src/batText.ml
@@ -694,18 +694,30 @@ let find_from rop ofs sub_rop =
 
 let find rop sub = find_from rop 0 sub
 
-let rfind_from r1 suf r2 =
-  let matchlen = length r2 in
-  let r2_string = to_ustring r2 in
-  let check_at pos = r2_string = (to_ustring (sub r1 pos matchlen)) in
+let rfind_from rop suf sub_rop =
+  if suf + 1 < 0 || suf + 1 > length rop then raise Out_of_bounds;
+  let matchlen = length sub_rop in
+  let sub_rop = to_ustring sub_rop in
+  let check_at pos = sub_rop = (to_ustring (sub rop pos matchlen)) in
   (* TODO: inefficient *)
   Return.with_label (fun label ->
     for i = suf - matchlen + 1 downto 0 do
       if check_at i then Return.return label i
     done;
     raise Not_found)
+(*$T rfind_from
+  rfind_from (of_string "foobarbaz") 5 (of_string "ba") = 3
+  rfind_from (of_string "foobarbaz") 7 (of_string "ba") = 6
+  rfind_from (of_string "foobarbaz") 6 (of_string "ba") = 3
+  rfind_from (of_string "foobarbaz") 7 (of_string "") = 8
+  Result.(catch (rfind_from (of_string "") 3) empty |> is_exn Out_of_bounds)
+  Result.(catch (rfind_from (of_string "") (-1)) (of_string "a") |> is_exn Not_found)
+  Result.(catch (rfind_from (of_string "foobarbaz") 2) (of_string "ba") |> is_exn Not_found)
+  Result.(catch (rfind_from (of_string "foo") 3) (of_string "foo") |> is_exn Out_of_bounds)
+  Result.(catch (rfind_from (of_string "foo") (-2)) (of_string "foo") |> is_exn Out_of_bounds)
+*)
 
-let rfind r1 r2 = rfind_from r1 (length r1 - 1) r2
+let rfind rop sub = rfind_from rop (length rop - 1) sub
 
 let exists r_str r_sub = try ignore(find r_str r_sub); true with Not_found -> false
 

--- a/src/batText.mli
+++ b/src/batText.mli
@@ -301,7 +301,11 @@ val rfind : t -> t -> int
 
 val rfind_from : t -> int -> t -> int
   (** [rfind_from s ofs x] behaves as [rfind s x] but starts searching
-      at offset [ofs]. [rfind s x] is equivalent to [rfind_from s (length s - 1) x].*)
+      at offset [ofs]. [rfind s x] is equivalent to [rfind_from s (length s - 1) x].
+
+      @raise Out_of_bounds if [ofs] is not a valid_position in [s].
+      @raise Not_found if [x] is not a subrope of [s].
+  *)
 
 
 val starts_with : t -> t -> bool


### PR DESCRIPTION
Fixed the BatText functions, which are IMHO immature and strange(?), and added some tests
