### PR TITLE
BatText: remove deprecated Invalid_rope exception

### DIFF
--- a/src/batText.ml
+++ b/src/batText.ml
@@ -49,8 +49,6 @@ let splice s1 off len s2 =
   String.blit s1 (off+len) s (off+len2) (len1 - (off+len)); (* s1 after off+len *)
   s
 
-exception Invalid_rope
-
 type t =
     Empty                             (**An empty rope*)
   | Concat of t * int * t * int * int (**[Concat l ls r rs h] is the concatenation of

--- a/src/batText.mli
+++ b/src/batText.mli
@@ -70,10 +70,6 @@ type t
 exception Out_of_bounds
 (** Raised when an operation violates the bounds of the rope. *)
 
-exception Invalid_rope
-(** An exception thrown when some operation required a rope and
-    received an unacceptable rope.*)
-
 val max_length : int
 (** Maximum length of the rope (number of UTF-8 characters). *)
 


### PR DESCRIPTION
The Invalid_rope exception is not used (nor raised) anywhere in the code: it has been replaced by Not_found and Out_of_bounds over time.
