### PR TITLE
String.rev

### DIFF
--- a/src/batString.ml
+++ b/src/batString.ml
@@ -647,18 +647,20 @@ let nreplace ~str ~sub ~by =
 *)
 
 
-let in_place_mirror s =
+let rev_in_place s =
   let len = String.length s in
   if len > 0 then for k = 0 to (len - 1)/2 do
       let old = s.[k] and mirror = len - 1 - k in
       s.[k] <- s.[mirror]; s.[mirror] <- old;
     done
-(*$= in_place_mirror as f & ~printer:identity
+(*$= rev_in_place as f & ~printer:identity
   (let s="" in f s; s)          ""
   (let s="1" in f s; s)         "1"
   (let s="12" in f s; s)        "21"
   (let s="Example!" in f s; s)  "!elpmaxE"
 *)
+
+let in_place_mirror = rev_in_place
 
 let repeat s n =
   let buf = Buffer.create ( n * (String.length s) ) in

--- a/src/batString.mli
+++ b/src/batString.mli
@@ -602,10 +602,13 @@ val rev : string -> string
 
 (** {6 In-Place Transformations}*)
 
-val in_place_mirror : string -> unit
-(** [in_place_mirror s] mutates the string [s], so that its new value is
+val rev_in_place : string -> unit
+(** [rev_in_place s] mutates the string [s], so that its new value is
     the mirror of its old one: for instance if s contained ["Example!"], after
     the mutation it will contain ["!elpmaxE"]. *)
+
+val in_place_mirror : string -> unit
+(** @deprecated Use {!String.rev_in_place} instead *)
 
 (** {6 Splitting around}*)
 


### PR DESCRIPTION
For the life of me I could not find this function in the source and now I'm pretty certain that it's missing.

This might be a good time to discuss this naming convention in batteries. What's the deal with the `rev_in_place` vs `mirror_in_place` stuff? I much prefer `rev_in_place` but of course we can't remove `mirror_in_place`. Nevertheless would it be good to have both in BatString for consistency?
