### PR TITLE
Make Option.print output configurable for Some/None

### DIFF
--- a/src/batOption.ml
+++ b/src/batOption.ml
@@ -163,9 +163,9 @@ let of_enum = BatEnum.get
    let e = BatList.enum [1; 2; 3] in of_enum e = Some 1 && BatList.of_enum e = [2; 3]
 *)
 
-let print print_a out = function
-  | None   -> BatInnerIO.nwrite out "None"
-  | Some x -> BatPrintf.fprintf out "Some %a" print_a x
+let print ?(some="Some ") ?(none="None") print_a out = function
+  | None   -> BatInnerIO.nwrite out none
+  | Some x -> BatPrintf.fprintf out "%s%a" some print_a x
 
 let maybe_printer a_printer paren out = function
   | None -> ()

--- a/src/batOption.mli
+++ b/src/batOption.mli
@@ -148,7 +148,9 @@ end
 
 (** {7 Printing}*)
 
-val print : ('a BatInnerIO.output -> 'b -> unit) -> 'a BatInnerIO.output -> 'b t -> unit
+val print : ?some:string -> ?none:string ->
+      ('a BatInnerIO.output -> 'b -> unit) -> 'a BatInnerIO.output -> 'b t -> unit
+(** Print the contents of an option *)
 
 (** Operations on options, with labels.*)
 module Labels : sig


### PR DESCRIPTION
Like List.print allow the user to change "[", "]" and the semicolon,
OCaml syntax should not be enforced on option type.
