### PR TITLE
Support compilation in 4.01.0+dev and 4.02.0+dev.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,8 @@ reinstall:
 #	Pre-Processing of Source Code
 ###############################################################################
 
-prefilter: src/batUnix.mli src/batPervasives.mli src/batInnerPervasives.ml src/batHashtbl.ml
+prefilter: src/batMarshal.mli src/batUnix.mli src/batPervasives.mli \
+	   src/batInnerPervasives.ml src/batHashtbl.ml
 
 # Ocaml 4.00 can benefit strongly from some pre-processing to expose
 # slightly different interfaces
@@ -124,10 +125,10 @@ prefilter: src/batUnix.mli src/batPervasives.mli src/batInnerPervasives.ml src/b
 # Look for lines starting with ##Vx##, and delete just the tag or the
 # whole line depending whether the x matches the ocaml major version
 .mliv.mli:
-	sed -e 's/^##V$(OCAML_MAJOR_VERSION)##//' -e '/^##V.##/d' $< > $@
+	perl build/prefilter.pl < $^ > $@
 
 .mlv.ml:
-	sed -e 's/^##V$(OCAML_MAJOR_VERSION)##//' -e '/^##V.##/d' $< > $@
+	perl build/prefilter.pl < $^ > $@
 
 ###############################################################################
 #	BUILDING AND RUNNING UNIT TESTS

--- a/build/prefilter.pl
+++ b/build/prefilter.pl
@@ -1,0 +1,36 @@
+#!/bin/env perl
+
+use strict ;
+
+my $major = -1;
+my $minor = -1 ;
+my $ocaml_version = `ocamlfind ocamlc -version` ;
+if ($ocaml_version =~ /^([0-9]+)\.([0-9]+)\./) {
+    $major = $1 ;
+    $minor = $2 ;
+} else {
+    exit 255 ;
+}
+
+foreach my $line (<STDIN>) {
+    if ($line =~ /^##V([^#]+)##/) {
+        my $ver = $1 ;
+        $line =~ s/^##V[^#]+##// ;
+        chomp $line ;
+        my $pass = 0 ;
+        if ($ver =~ /^[0-9]+$/) {
+            $pass = $ver <= $major ;
+        } elsif ($ver =~ /^([0-9]+)\.([0-9]+)$/) {
+            my $ver_maj = $1 ;
+            my $ver_min = $2 ;
+            $pass = ($ver_maj <= $major) && ($ver_min <= $minor) ;
+        }
+        if ($pass) {
+            printf "%s\n", $line ;
+        } else {
+            printf "(* %s *)(* SUPPRESS: %d.%d < %s *)\n", $line, $major, $minor, $ver ;
+        }
+    } else {
+        print $line ;
+    }
+}

--- a/src/batMarshal.mliv
+++ b/src/batMarshal.mliv
@@ -59,6 +59,7 @@
 type extern_flags = Marshal.extern_flags =
     No_sharing                          (** Don't preserve sharing *)
   | Closures                            (** Send function closures *)
+##V4.1##  | Compat_32                           (** Ensure 32-bit compatibility *)
 (** The flags to the [Marshal.to_*] functions below. *)
 
 

--- a/src/batUChar.ml
+++ b/src/batUChar.ml
@@ -50,7 +50,7 @@ let of_char = Char.code
 
 (* valid range: U+0000..U+D7FF and U+E000..U+10FFFF *)
 let chr n =
-  if (n >= 0 && n <= 0xd7ff) or (n >= 0xe000 && n <= 0x10ffff)
+  if (n >= 0 && n <= 0xd7ff) || (n >= 0xe000 && n <= 0x10ffff)
   then n
   else raise Out_of_range
 

--- a/src/batUTF8.ml
+++ b/src/batUTF8.ml
@@ -197,7 +197,7 @@ let validate s =
           main (i + 3)
       else if n <= 0xf4 then
         let n = trail 3 (i + 1) (n - 0xf0) in
-        if n < 0x10000 or n > 0x10FFFF then raise Malformed_code else
+        if n < 0x10000 || n > 0x10FFFF then raise Malformed_code else
           main (i + 4)
       else raise Malformed_code in
   main 0


### PR DESCRIPTION
This patch makes it compilable in 4.01 and later. It also replaces the `or` operator with `||` in a few files, as the former is considered deprecated syntax.

The only real issue is that the `Marshal` module has changed its signature in 4.01 and later. The prefilter mechanism had to be changed -- we now need to prefilter on _both_ major and minor versions. Instead of a horribly complex sed secript, I've written a simple Perl script `build/prefilter.pl` that does the pre-filtering. (Rewriting this in OCaml is left as an exercise.)
