### PR TITLE
Fix BatMutex.DebugMutex.id is always 0.

### DIFF
--- a/src/batMutex.ml
+++ b/src/batMutex.ml
@@ -32,15 +32,16 @@ struct
       let counter = ref 0
       and mutex   = Mutex.create ()
       in
-      Mutex.lock mutex;
-      let result = !counter in
-      incr counter;
-      Mutex.unlock mutex;
-      result
+      fun () ->
+        Mutex.lock mutex;
+        let result = !counter in
+        incr counter;
+        Mutex.unlock mutex;
+        result
 
     let create () =
       { mutex = Mutex.create () ;
-        id    = unique }
+        id    = unique () }
 
     let lock t =
       Printf.eprintf "[Mutex] Attempting to lock mutex %d\n" t.id;


### PR DESCRIPTION
Perhaps DebugMutex.unique intends to be closure, but it is constant now.

``` ocaml
open Batteries
module Mutex =  BatMutex.DebugMutex

let _ =
  let m = Mutex.create () in
  let m2 = Mutex.create () in
  Mutex.lock m;
  Mutex.lock m2;
  Mutex.unlock m2;
  Mutex.unlock m;
  ()
```
