### PR TITLE
added BatDeque.eq function to compare Deques by content

### DIFF
--- a/src/batDeque.mli
+++ b/src/batDeque.mli
@@ -57,6 +57,11 @@ val rear : 'a dq -> ('a dq * 'a) option
 
 (** {6 Basic operations} *)
 
+val eq : ?eq:('a -> 'a -> bool) -> 'a dq -> 'a dq -> bool
+  (** [eq dq1 dq2] is true if [dq1] and [dq2] have the same sequence
+      of elements. A custom function can be optionally provided with
+      the [eq] parameter (default is {!Pervasives.(=)}). *)
+
 val rev : 'a dq -> 'a dq
 (** [rev dq] reverses [dq]. O(1) *)
 


### PR DESCRIPTION
[This page](https://github.com/ocaml-batteries-team/batteries-included/wiki/%22Junior-tasks%22-for-batteries#deque) refers to an equality operator for Deques. Here is a patch that should do it (along with one unit test and one qtest).
