### PR TITLE
BatMonomorph: module for shadowing polymorphic operators

### DIFF
--- a/src/batMonomorph.ml
+++ b/src/batMonomorph.ml
@@ -1,0 +1,29 @@
+(*
+ * BatMonomorph - Useful module for shadowing polymorphic operators of Pervasives.
+ * Copyright (C) 2013 Jacques-Pascal Deplaix
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version,
+ * with the special exception on linking described in file LICENSE.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *)
+
+let (=) () () = ()
+let (<>) () () = ()
+let (<) () () = ()
+let (>) () () = ()
+let (<=) () () = ()
+let (>=) () () = ()
+let compare () () = ()
+let min () () = ()
+let max () () = ()

--- a/src/batMonomorph.mli
+++ b/src/batMonomorph.mli
@@ -1,0 +1,29 @@
+(*
+ * BatMonomorph - Useful module for shadowing polymorphic operators of Pervasives.
+ * Copyright (C) 2013 Jacques-Pascal Deplaix
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version,
+ * with the special exception on linking described in file LICENSE.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *)
+
+val (=) : unit -> unit -> unit
+val (<>) : unit -> unit -> unit
+val (<) : unit -> unit -> unit
+val (>) : unit -> unit -> unit
+val (<=) : unit -> unit -> unit
+val (>=) : unit -> unit -> unit
+val compare : unit -> unit -> unit
+val min : unit -> unit -> unit
+val max : unit -> unit -> unit

--- a/src/batteries.ml
+++ b/src/batteries.ml
@@ -142,6 +142,7 @@ module UChar = BatUChar
 module UTF8 = BatUTF8
 module Text = BatText
 module Concurrent = BatConcurrent
+module Monomorph = BatMonomorph
 
 (* Batteries Specific *)
 module Interfaces = BatInterfaces


### PR DESCRIPTION
I don't know if this can be included in batteries or only as little standalone library.
I don't know either if the name is good. Formerly I've called it: `Safe`, but `Monomorph` is maybe more explicit.
