### PR TITLE
small patch for #109 , with cleanup of BatIO.input enabled by default

### DIFF
--- a/src/batIO.mli
+++ b/src/batIO.mli
@@ -736,7 +736,7 @@ val input_channel : ?autoclose:bool -> ?cleanup:bool -> in_channel -> input
 
     @param cleanup If true, the channel
     will be automatically closed when the {!type: input} is closed.
-    Otherwise, you will need to close the channel manually.
+    Otherwise, you will need to close the channel manually. Default is [true].
 *)
 
 val output_channel : ?cleanup:bool -> out_channel -> unit output

--- a/src/batInnerIO.ml
+++ b/src/batInnerIO.ml
@@ -362,7 +362,7 @@ let placeholder_in =
     in_close = noop;
     in_id    = (-1);
     in_upstream= weak_create 0 }
-let input_channel ?(autoclose=true) ?(cleanup=false) ch =
+let input_channel ?(autoclose=true) ?(cleanup=true) ch =
   let me = ref placeholder_in (*placeholder*)
   in let result =
     create_in


### PR DESCRIPTION
couldn't comment on the issue (too old!? github bugs), so here's a patch just in case