### PR TITLE
Enum.concat_map alias, as asked in #485

### DIFF
--- a/src/batEnum.ml
+++ b/src/batEnum.ml
@@ -1251,6 +1251,8 @@ let rec of_object o =
 
 let flatten = concat
 
+let concat_map f e = concat (map f e)
+
 module Exceptionless = struct
   let find f e =
     try  Some (find f e)

--- a/src/batEnum.mli
+++ b/src/batEnum.mli
@@ -383,6 +383,10 @@ val concat : 'a t t -> 'a t
 val flatten : 'a t t -> 'a t
 (** Synonym of {!concat}*)
 
+val concat_map : ('a -> 'b t) -> 'a t -> 'b t
+(** Synonym of {!Monad.bind}, with flipped arguments.
+    [concat_map f e] is the same as [concat (map f e)]. *)
+
 (** {6 Constructors}
 
     In this section the word {i shall} denotes a semantic


### PR DESCRIPTION
dito. An attempt to optimize concat_map (and Monad.bind?) may follow.
