### PR TITLE
try to fix coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ prefilter: $(PREPROCESSED_FILES)
 
 DONTTEST=src/batteriesHelp.ml
 TESTABLE ?= $(filter-out $(DONTTEST), $(wildcard src/*.ml))
-TESTDEPS = $(TESTABLE)
+TESTDEPS = prefilter $(TESTABLE)
 
 ### Test suite: "offline" unit tests
 ##############################################
@@ -236,6 +236,6 @@ upload-docs:
 ###############################################################################
 
 coverage/index.html: $(TESTDEPS) $(QTESTDIR)/all_tests.ml
-	$(OCAMLBUILD) coverage/index.html
+	$(OCAMLBUILD) -use-ocamlfind coverage/index.html
 
 coverage: coverage/index.html

--- a/qtest/_tags
+++ b/qtest/_tags
@@ -1,2 +1,3 @@
 true: threads, debug
+<all_tests.*>: package(oUnit), package(QTest2Lib)
 


### PR DESCRIPTION
the target `make coverage` would fail with compilation errors. Now it is compiled against `oUnit` and `QTest2Lib`, and also depends on the `prefilter` targets so that it finds `batInnerPervasives`. Can someone please test?
