### PR TITLE
Monads everywhere

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ PREPROCESSED_FILES = \
  src/batBuffer.ml \
  src/batBytes.ml src/batBytes.mli \
  src/batDigest.ml \
+ src/batFormat.ml \
  src/batHashtbl.ml \
  src/batInnerPervasives.ml \
  src/batList.ml \

--- a/src/batEnum.ml
+++ b/src/batEnum.ml
@@ -1434,40 +1434,40 @@ end
 
 module WithMonad (Mon : BatInterfaces.Monad) =
 struct
+  type 'a t = 'a mappable
   type 'a m = 'a Mon.m
 
-  let sequence enum =
-    let (>>=) = Mon.bind and return = Mon.return in
-    (* We use a list as an accumulator for the result sequence
-       computed under the monad. A previous version of this code used
-       a Queue instead, which was problematic for backtracking
-       monads. Due to the destructive nature of Enums, the current
-       version will still be problematic but at least the result will
-       be consistent. *)
-    let of_acc acc =
-      (* we don't use List functions to avoid creating a cyclic
-         dependency *)
-      let li = ref (List.rev acc) in
-      from (fun () ->
-        match !li with
-        | [] -> raise No_more_elements
-        | hd::tl ->
-          li := tl;
-          hd)
-    in
-    let rec loop acc = match get enum with
-      | None -> return (of_acc acc)
-      | Some elem -> elem >>= (fun x -> loop (x :: acc))
-    in
-    loop []
+  let (>>=) = Mon.bind
 
   let fold_monad f init enum =
-    let (>>=) = Mon.bind and return = Mon.return in
     let rec fold m = match get enum with
       | None -> m
       | Some x -> m >>= fun acc -> fold (f acc x)
     in
-    fold (return init)
+    fold (Mon.return init)
+
+  (* Comment for old sequence function:
+     "We use a list as an accumulator for the result enum
+     computed under the monad. A previous version of this code used
+     a Queue instead, which was problematic for backtracking
+     monads. Due to the destructive nature of Enums, the current
+     version will still be problematic but at least the result will
+     be consistent." *)
+
+  let map_m f enum =
+    let of_acc acc = MicroList.enum (List.rev acc)
+    in
+    let rec loop acc = match get enum with
+      | None -> Mon.return (of_acc acc)
+      | Some elem ->
+          f elem >>= fun x ->
+          loop (x :: acc)
+    in
+    loop []
+
+  let sequence e = map_m (fun x -> x) e
+
+  let fold_m = fold_monad
 end
 
 module Monad =

--- a/src/batEnum.mli
+++ b/src/batEnum.mli
@@ -722,16 +722,13 @@ val ( @// ) : ('a -> 'b option) -> 'a t -> 'b t
     This module will let you use sequence and fold_monad functions over enumerations.
 *)
 module WithMonad : functor (Mon : BatInterfaces.Monad) -> sig
-  type 'a m = 'a Mon.m
-  (** Type of the monadic elements. *)
+  include BatInterfaces.Traversable with type 'a t = 'a t and type 'a m = 'a Mon.m
 
-  val sequence : 'a m t -> 'a t m
-(** [sequence e] evaluates each monadic elements (of type ['a m]) contained in the enumeration [e] to get a monadic enumeration of ['a] elements,
-    of type ['a BatEnum.t m]. *)
-
-val fold_monad : ('a -> 'b -> 'a m) -> 'a -> 'b t -> 'a m
-  (** [fold_monad f init e] does a folding of the enumeration [e] applying step by step the function [f] that gives back results in the [Mon] monad,
-      with the [init] initial element. The result is a value in the [Mon] monad. *)
+  val fold_monad : ('a -> 'b -> 'a m) -> 'a -> 'b t -> 'a m
+  (** [fold_monad f init e] does a folding of the enumeration [e] applying step
+      by step the function [f] that gives back results in the [Mon] monad,
+      with the [init] initial element. The result is a value in the [Mon] monad.
+      Synonym to {!foldM} (see {!BatInterfaces.Traversable}) *)
 end
 
 (** The BatEnum Monad

--- a/src/batEnum.mli
+++ b/src/batEnum.mli
@@ -725,10 +725,9 @@ module WithMonad : functor (Mon : BatInterfaces.Monad) -> sig
   include BatInterfaces.Traversable with type 'a t = 'a t and type 'a m = 'a Mon.m
 
   val fold_monad : ('a -> 'b -> 'a m) -> 'a -> 'b t -> 'a m
-  (** [fold_monad f init e] does a folding of the enumeration [e] applying step
-      by step the function [f] that gives back results in the [Mon] monad,
-      with the [init] initial element. The result is a value in the [Mon] monad.
-      Synonym to {!foldM} (see {!BatInterfaces.Traversable}) *)
+  (** [fold_monad] is a synonym for the [fold_m] function of the
+      {!BatInterfaces.Traversable} interface, kept for backward
+      compatibility. *)
 end
 
 (** The BatEnum Monad

--- a/src/batFormat.mli
+++ b/src/batFormat.mli
@@ -576,11 +576,26 @@ val pp_set_formatter_tag_functions :
 val pp_get_formatter_tag_functions :
   formatter -> unit -> formatter_tag_functions
 ;;
-(** These functions are the basic ones: usual functions
-    operating on the standard formatter are defined via partial
-    evaluation of these primitives. For instance,
-    [print_string] is equal to [pp_print_string std_formatter]. *)
 
+val pp_print_list:
+  ?pp_sep:(formatter -> unit -> unit) ->
+  (formatter -> 'a -> unit) -> (formatter -> 'a list -> unit)
+(** [pp_print_list ?pp_sep pp_v ppf l] prints the list [l]. [pp_v] is
+    used on the elements of [l] and each element is separated by
+    a call to [pp_sep] (defaults to {!pp_print_cut}). Does nothing on
+    empty lists.
+
+    @since 4.02.0
+*)
+
+val pp_print_text : formatter -> string -> unit
+(** [pp_print_text ppf s] prints [s] with spaces and newlines
+    respectively printed with {!pp_print_space} and
+    {!pp_force_newline}.
+
+    @since 4.02.0
+*)
+  
 (** {6 [printf] like functions for pretty-printing.} *)
 
 val fprintf : formatter -> ('a, formatter, unit) format -> 'a;;

--- a/src/batFormat.mli
+++ b/src/batFormat.mli
@@ -576,6 +576,10 @@ val pp_set_formatter_tag_functions :
 val pp_get_formatter_tag_functions :
   formatter -> unit -> formatter_tag_functions
 ;;
+(** These functions are the basic ones: usual functions
+    operating on the standard formatter are defined via partial
+    evaluation of these primitives. For instance,
+    [print_string] is equal to [pp_print_string std_formatter]. *)
 
 val pp_print_list:
   ?pp_sep:(formatter -> unit -> unit) ->

--- a/src/batFormat.mlv
+++ b/src/batFormat.mlv
@@ -80,6 +80,40 @@ let pp_set_formatter_out_channel = pp_set_formatter_output
 let std_formatter = formatter_of_output BatIO.stdout
 let err_formatter = formatter_of_output BatIO.stderr
 
+(* Backward compatibility *)
+
+##V<4.02##(* To format a list *)
+##V<4.02##let rec pp_print_list ?(pp_sep = pp_print_cut) pp_v ppf = function
+##V<4.02##  | [] -> ()
+##V<4.02##  | [v] -> pp_v ppf v
+##V<4.02##  | v :: vs ->
+##V<4.02##    pp_v ppf v;
+##V<4.02##    pp_sep ppf ();
+##V<4.02##    pp_print_list ~pp_sep pp_v ppf vs
+##V<4.02##
+##V<4.02##(* To format free-flowing text *)
+##V<4.02##let pp_print_text ppf s =
+##V<4.02##  let len = String.length s in
+##V<4.02##  let left = ref 0 in
+##V<4.02##  let right = ref 0 in
+##V<4.02##  let flush () =
+##V<4.02##    pp_print_string ppf (String.sub s !left (!right - !left));
+##V<4.02##    incr right; left := !right;
+##V<4.02##  in
+##V<4.02##  while (!right <> len) do
+##V<4.02##    match s.[!right] with
+##V<4.02##      | '\n' ->
+##V<4.02##        flush ();
+##V<4.02##        pp_force_newline ppf ()
+##V<4.02##      | ' ' ->
+##V<4.02##        flush (); pp_print_space ppf ()
+##V<4.02##      (* there is no specific support for '\t'
+##V<4.02##         as it is unclear what a right semantics would be *)
+##V<4.02##      | _ -> incr right
+##V<4.02##  done;
+##V<4.02##  if !left <> len then flush ()
+
+
 (**{6 Initialization}*)
 
 let () =

--- a/src/batIMap.ml
+++ b/src/batIMap.ml
@@ -84,8 +84,8 @@ module Core = struct
         | None   -> raise Exit
       else
         let (n1, n2, v) = root m in
-        if n < n1 then aux (left_branch m) else
-        if n > n2 then aux (right_branch m) else
+        if n < n1 then make_tree (aux (left_branch m)) (n1, n2, v) (right_branch m) else
+        if n > n2 then make_tree (left_branch m) (n1, n2, v) (aux (right_branch m))  else
           match f (Some v) with
           | None    ->
             concat (left_branch m) (right_branch m)

--- a/src/batInterfaces.ml
+++ b/src/batInterfaces.ml
@@ -34,3 +34,13 @@ module type Monad = sig
   val bind : 'a m -> ('a -> 'b m) -> 'b m
   val return: 'a -> 'a m
 end
+
+module type Traversable = sig
+  type 'a t
+
+  type 'a m
+
+  val map_m : ('a -> 'b m) -> 'a t -> 'b t m
+  val fold_m : ('a -> 'b -> 'a m) -> 'a -> 'b t -> 'a m
+  val sequence : 'a m t -> 'a t m
+end

--- a/src/batInterfaces.mli
+++ b/src/batInterfaces.mli
@@ -85,3 +85,27 @@ module type Monad = sig
   val return: 'a -> 'a m
 
 end
+
+(** Traversable structures allow one to traverse a structure, with a monadic
+    function *)
+module type Traversable = sig
+  type 'a t
+  (** Traversable *)
+
+  type 'a m
+  (** Monad *)
+
+  val map_m : ('a -> 'b m) -> 'a t -> 'b t m
+  (** Map each element to a value by a monadic action, and combine results
+      together in the monad. *)
+
+  val fold_m : ('a -> 'b -> 'a m) -> 'a -> 'b t -> 'a m
+  (** Fold on elements of the traversable structure, applying a monadic
+      action to obtain the next accumulator from the current accumulator
+      and element. *)
+
+  val sequence : 'a m t -> 'a t m
+  (** Basic building block for other functions. [sequence x] is similar
+      to [map_m identity x]. *)
+
+end

--- a/src/batLazyList.mli
+++ b/src/batLazyList.mli
@@ -393,6 +393,16 @@ val split_at : int -> 'a t -> 'a t * 'a t
 val split_nth : int -> 'a t -> 'a t * 'a t
 (** Obsolete. As [split_at]. *)
 
+(** {6 Monad} *)
+
+val concat_map : ('a -> 'b t) -> 'a t -> 'b t
+(** [concat_map f l] is the same as [map f l |> concat] *)
+
+module Monad : BatInterfaces.Monad with type 'a m = 'a t
+
+module Traverse(M : BatInterfaces.Monad) :
+  BatInterfaces.Traversable with type 'a t = 'a t and type 'a m = 'a M.m
+
 (**{6 Dropping elements}*)
 
 val unique : ?cmp:('a -> 'a -> int) -> 'a t -> 'a t

--- a/src/batList.mli
+++ b/src/batList.mli
@@ -641,6 +641,10 @@ val interleave : ?first:'a -> ?last:'a -> 'a -> 'a list -> 'a list
     [first; a0; sep; a1; sep; a2; sep; ...; sep; an; last] *)
 
 
+(** {6 Monadic interface} *)
+
+module Monad : BatInterfaces.Monad with type 'a m = 'a list
+
 (** {6 BatEnum functions}
 
     Abstraction layer.*)

--- a/src/batList.mli
+++ b/src/batList.mli
@@ -645,6 +645,9 @@ val interleave : ?first:'a -> ?last:'a -> 'a -> 'a list -> 'a list
 
 module Monad : BatInterfaces.Monad with type 'a m = 'a list
 
+module Traverse(M : BatInterfaces.Monad) :
+  BatInterfaces.Traversable with type 'a m = 'a M.m and type 'a t = 'a list
+
 (** {6 BatEnum functions}
 
     Abstraction layer.*)

--- a/src/batList.mlv
+++ b/src/batList.mlv
@@ -416,25 +416,57 @@ module Traverse(M : BatInterfaces.Monad) = struct
 
   let (>>=) = M.bind
 
-  let rec sequence l = match l with
-    | [] -> M.return []
+  let sequence l =
+    let rec loop acc = function
+    | [] -> M.return (List.rev acc)
     | xs::l' ->
       xs >>= fun x ->
-      sequence l' >>= fun l' ->
-      M.return (x :: l')
+      loop (x :: acc) l'
+    in loop [] l
 
-  let rec map_m f l = match l with
-    | [] -> M.return []
+  (*$T
+     let module TL = Traverse(Monad) in TL.sequence [[1; 2]; [3; 4]] = [[1; 3]; [1; 4]; [2; 3]; [2; 4]]
+     let module TL = Traverse(Monad) in TL.sequence [[1; 2]; []; [3; 4]] = []
+     let module TL = Traverse(Monad) in TL.sequence [] = [[]]
+   *)
+
+  let map_m f l =
+    let rec loop acc = function
+    | [] -> M.return (List.rev acc)
     | x::l' ->
-      map_m f l' >>= fun l' ->
       f x >>= fun x ->
-      M.return (x::l')
+      loop (x :: acc) l'
+    in loop [] l
+
+  (*$T
+     let module TL = Traverse(Monad) in TL.map_m (fun x -> [x; x+1]) [3] = [[3]; [4]]
+     let module TL = Traverse(Monad) in TL.map_m (fun x -> [x; x+1]) [1; 3] = [[1; 3]; [1; 4]; [2; 3]; [2; 4]]
+     let module TL = Traverse(Monad) in TL.map_m (fun x -> []) [1; 3] = []
+     let module TL = Traverse(Monad) in TL.map_m (fun x -> [1]) [] = [[]]
+   *)
+
+  (* There is no easy way to make map_m (or sequence, fold_m etc.) tail-recursive,
+     because most monadic binds call their function argument in non-tail position.
+     For example, the following test would fail with a stack overflow:
+
+       let long = init 1_000_000 (fun x -> x) in
+       let module TL = Traverse(Monad) in
+       TL.map_m (fun x -> [x]) long = [long]
+   *)
 
   let rec fold_m f acc l = match l with
     | [] -> M.return acc
     | x::l' ->
       f acc x >>= fun acc' ->
       fold_m f acc' l'
+
+  (*$T
+     let module TL = Traverse(Monad) in TL.fold_m (fun xs x -> [x::xs; x+1::xs]) [] [3] = [[3]; [4]]
+     let module TL = Traverse(Monad) in TL.fold_m (fun xs x -> [x::xs; x+1::xs]) [] [1; 3] = [[3; 1]; [4; 1]; [3; 2]; [4; 2]]
+     let module TL = Traverse(Monad) in TL.fold_m (fun xs x -> []) [1;2] [3;4] = []
+     let module TL = Traverse(Monad) in TL.fold_m (fun xs x -> [x::xs; x+1::xs]) [] [] = [[]]
+   *)
+
 end
 
 (*$= interleave & ~printer:(IO.to_string (List.print Int.print))

--- a/src/batList.mlv
+++ b/src/batList.mlv
@@ -361,23 +361,19 @@ let takewhile = take_while
 let dropwhile = drop_while
 
 let interleave ?first ?last (sep:'a) (l:'a list) =
-  let rec aux acc = function
-    | []   -> acc
-    | h::t -> aux (h::sep::acc) t
+  let may_prepend maybe_x lst = match maybe_x with
+    | None -> lst
+    | Some x -> x :: lst
   in
-  match (l,first, last) with
-  | ([],   None,   None)       -> []
-  | ([],   None,   Some x)     -> [x]
-  | ([],   Some x, None)       -> [x]
-  | ([],   Some x, Some y)     -> [x;y]
-  | ([h],  None,   None)       -> [h]
-  | ([h],  None,   Some x)     -> [h;x]
-  | ([h],  Some x, None)       -> [x;h]
-  | ([h],  Some x, Some y)     -> [x;h;y]
-  | (h::t, None  , None )      -> rev (aux [h] t)
-  | (h::t, Some x, None )      -> x::(rev (aux [h] t))
-  | (h::t, None,   Some y)     -> rev_append (aux [h] t) [y]
-  | (h::t, Some x, Some y)     -> x::rev_append (aux [h] t) [y]
+  let rec loop acc = function
+    | [] -> acc
+    | x :: xs ->
+      match acc with
+      | [] -> loop [x] xs
+      | _ -> loop (x :: sep :: acc) xs
+  in
+  let res = loop [] l in
+  may_prepend first (rev (may_prepend last res))
 
 (*$= interleave & ~printer:(IO.to_string (List.print Int.print))
   (interleave 0 [1;2;3]) [1;0;2;0;3]

--- a/src/batList.mlv
+++ b/src/batList.mlv
@@ -409,6 +409,34 @@ module Monad = struct
   *)
 end
 
+module Traverse(M : BatInterfaces.Monad) = struct
+  type 'a t = 'a list
+
+  type 'a m = 'a M.m
+
+  let (>>=) = M.bind
+
+  let rec sequence l = match l with
+    | [] -> M.return []
+    | xs::l' ->
+      xs >>= fun x ->
+      sequence l' >>= fun l' ->
+      M.return (x :: l')
+
+  let rec map_m f l = match l with
+    | [] -> M.return []
+    | x::l' ->
+      map_m f l' >>= fun l' ->
+      f x >>= fun x ->
+      M.return (x::l')
+
+  let rec fold_m f acc l = match l with
+    | [] -> M.return acc
+    | x::l' ->
+      f acc x >>= fun acc' ->
+      fold_m f acc' l'
+end
+
 (*$= interleave & ~printer:(IO.to_string (List.print Int.print))
   (interleave 0 [1;2;3]) [1;0;2;0;3]
   (interleave 0 [1]) [1]

--- a/src/batList.mlv
+++ b/src/batList.mlv
@@ -375,6 +375,40 @@ let interleave ?first ?last (sep:'a) (l:'a list) =
   let res = loop [] l in
   may_prepend first (rev (may_prepend last res))
 
+module Monad = struct
+  type 'a m = 'a list
+
+  let return x = [x]
+
+  let bind l f =
+    let rec loop l f acc = match l with
+      | [] -> ()
+      | x::l' ->
+          let xs = f x in
+          let acc = _append xs acc in
+          loop l' f acc
+    and _append l acc = match l with
+      | [] -> acc
+      | x::l' -> _append l' (Acc.accum acc x)
+    in
+    let acc = Acc.dummy() in
+    loop l f acc;
+    acc.tl
+
+  (*$T
+    (Monad.bind [] (fun x -> [x; x*2])) = []
+    (Monad.bind [1;2;3] (fun x -> [x; x*2])) = [1;2;2;4;3;6]
+    (Monad.bind [] (fun _ -> [])) = []
+    (Monad.bind [1;2;3] (function 2 -> [] | x -> [x; x*2])) = [1;2;3;6]
+   *)
+
+  (*$Q
+    (Q.list_of_size (fun () -> 5) (Q.list Q.small_int)) \
+      (fun l -> Monad.bind l identity = flatten l)
+    (Q.list Q.small_int) (fun l -> l = Monad.bind l Monad.return)
+  *)
+end
+
 (*$= interleave & ~printer:(IO.to_string (List.print Int.print))
   (interleave 0 [1;2;3]) [1;0;2;0;3]
   (interleave 0 [1]) [1]

--- a/src/batOption.ml
+++ b/src/batOption.ml
@@ -211,6 +211,8 @@ end
 module Infix =
 struct
   let ( |? ) x def = default def x
+
+  let (>>=) = Monad.bind
 end
 
 include Infix

--- a/src/batOption.mli
+++ b/src/batOption.mli
@@ -172,4 +172,7 @@ module Infix : sig
   val ( |? ) : 'a option -> 'a -> 'a
     (** Like {!default}, with the arguments reversed.
         [None |? 10] returns [10], while [Some "foo" |? "bar"] returns ["foo"]. *)
+
+  val ( >>= ): 'a option -> ('a -> 'b option) -> 'b option
+  (** as [Monad.bind] *)
 end

--- a/src/batSeq.ml
+++ b/src/batSeq.ml
@@ -136,6 +136,16 @@ let of_list l =
   in
   aux l
 
+let to_list seq =
+  let rec loop acc seq = match seq () with
+      | Nil -> List.rev acc
+      | Cons (x, seq) -> loop (x :: acc) seq
+  in loop [] seq
+
+(*$Q to_list
+  (Q.list Q.small_int) (fun li -> li |> of_list |> to_list = li)
+ *)
+
 let rec iter f s = match s () with
   | Nil -> ()
   | Cons(e, s) -> f e; iter f s

--- a/src/batSeq.ml
+++ b/src/batSeq.ml
@@ -352,6 +352,13 @@ module Monad = struct
   let bind x f = concat_map f x
 end
 
+(*$T
+    (Monad.bind nil (fun x -> of_list [x; x*2])) |> to_list = []
+    (Monad.bind (of_list [1;2;3]) (fun x -> of_list [x; x*2])) |> to_list = [1;2;2;4;3;6]
+    (Monad.bind nil (fun _ -> nil)) |> to_list = []
+    (Monad.bind (of_list [1;2;3]) (function 2 -> nil | x -> of_list [x; x*2])) |> to_list = [1;2;3;6]
+   *)
+
 module Traverse(M : BatInterfaces.Monad) = struct
   type 'a t = 'a mappable
   type 'a m = 'a M.m
@@ -365,13 +372,33 @@ module Traverse(M : BatInterfaces.Monad) = struct
       map_m f e' >>= fun e' ->
       M.return (cons x e')
 
+  (*$T
+     let module TL = Traverse(List.Monad) in TL.map_m (fun x -> [x; x+1]) (of_list [3]) |> List.map to_list = [[3]; [4]]
+     let module TL = Traverse(List.Monad) in TL.map_m (fun x -> [x; x+1]) (of_list [1; 3]) |> List.map to_list = [[1; 3]; [1; 4]; [2; 3]; [2; 4]]
+     let module TL = Traverse(List.Monad) in TL.map_m (fun x -> []) (of_list [1; 3]) |> List.map to_list = []
+     let module TL = Traverse(List.Monad) in TL.map_m (fun x -> [1]) nil |> List.map to_list = [[]]
+   *)
+
   let sequence m = map_m (fun x -> x) m
+
+  (*$T
+     let module TL = Traverse(List.Monad) in TL.sequence (of_list [[1; 2]; [3; 4]]) |> List.map to_list = [[1; 3]; [1; 4]; [2; 3]; [2; 4]]
+     let module TL = Traverse(List.Monad) in TL.sequence (of_list [[1; 2]; []; [3; 4]]) |> List.map to_list = []
+     let module TL = Traverse(List.Monad) in TL.sequence (of_list []) |> List.map to_list = [[]]
+   *)
 
   let rec fold_m f acc e = match e () with
     | Nil -> M.return acc
     | Cons (x, e') ->
       f acc x >>= fun acc ->
       fold_m f acc e'
+
+  (*$T
+     let module TL = Traverse(List.Monad) in TL.fold_m (fun xs x -> [x::xs; x+1::xs]) [] (of_list [3]) = [[3]; [4]]
+     let module TL = Traverse(List.Monad) in TL.fold_m (fun xs x -> [x::xs; x+1::xs]) [] (of_list [1; 3]) = [[3; 1]; [4; 1]; [3; 2]; [4; 2]]
+     let module TL = Traverse(List.Monad) in TL.fold_m (fun xs x -> []) [1;2] (of_list [3;4]) = []
+     let module TL = Traverse(List.Monad) in TL.fold_m (fun xs x -> [x::xs; x+1::xs]) [] nil = [[]]
+   *)
 end
 
 

--- a/src/batSeq.mli
+++ b/src/batSeq.mli
@@ -121,6 +121,10 @@ val of_list : 'a list -> 'a t
 (** Convenience function to build a seq from a list.
     @since 2.2.0 *)
 
+val to_list : 'a t -> 'a list
+(** Convenience function to build a list from a sequence.
+    @since NEXT_RELEASE *)
+
 (** {6 Iterators} *)
 
 val iter : ('a -> unit) -> 'a t -> unit

--- a/src/batSeq.mli
+++ b/src/batSeq.mli
@@ -91,6 +91,16 @@ val concat : 'a t t -> 'a t
 val flatten : 'a t t -> 'a t
 (** Same as {!concat}. *)
 
+(** {6 Monad} *)
+
+val concat_map : ('a -> 'b t) -> 'a t -> 'b t
+(** [concat_map f s] is the same as [map f s |> concat] *)
+
+module Monad : BatInterfaces.Monad with type 'a m = 'a t
+
+module Traverse(M : BatInterfaces.Monad) :
+  BatInterfaces.Traversable with type 'a m = 'a M.m and type 'a t = 'a t
+
 (** {6 Constructors} *)
 
 val nil : 'a t

--- a/src/batSet.ml
+++ b/src/batSet.ml
@@ -662,6 +662,16 @@ module Make2(O1 : OrderedType)(O2 : OrderedType) = struct
     Product.t_of_impl p
 end
 
+(*$T
+  let module S1 = Make(Int) in \
+  let module S2 = Make(String) in \
+  let module P = Make2(Int)(String) in \
+  P.cartesian_product \
+    (List.fold_right S1.add [1;2;3] S1.empty) \
+    (List.fold_right S2.add ["a";"b"] S2.empty) \
+    |> P.Product.to_list = [1, "a"; 1, "b"; 2, "a"; 2, "b"; 3, "a"; 3, "b"]
+*)
+
 module PSet = struct (*$< PSet *)
 
   type 'a t = {

--- a/src/batSet.ml
+++ b/src/batSet.ml
@@ -646,6 +646,22 @@ struct
   end
 end
 
+module Make2(O1 : OrderedType)(O2 : OrderedType) = struct
+  module Set1 = Make(O1)
+  module Set2 = Make(O2)
+  module Product = Make(
+  struct
+    type t = O1.t * O2.t
+    let compare (x1,y1)(x2,y2) =
+      let c = O1.compare x1 x2 in
+        if c = 0 then O2.compare y1 y2 else c
+  end)
+
+  let cartesian_product set1 set2 =
+    let p = Concrete.cartesian_product (Set1.impl_of_t set1) (Set2.impl_of_t set2) in
+    Product.t_of_impl p
+end
+
 module PSet = struct (*$< PSet *)
 
   type 'a t = {

--- a/src/batSet.mli
+++ b/src/batSet.mli
@@ -324,11 +324,9 @@ module Make (Ord : OrderedType) : S with type elt = Ord.t
 
 
 module Make2(O1 : OrderedType) (O2 : OrderedType) : sig
-  module Set1 : S with type elt= O1.t
-  module Set2 : S with type elt= O2.t
   module Product : S with type elt = O1.t * O2.t
 
-  val cartesian_product : Set1.t -> Set2.t -> Product.t
+  val cartesian_product : Make(O1).t -> Make(O2).t -> Product.t
   (** cartesian product of the two sets *)
 end
 

--- a/src/batSet.mli
+++ b/src/batSet.mli
@@ -322,6 +322,16 @@ module Make (Ord : OrderedType) : S with type elt = Ord.t
     @documents Set.Make
 *)
 
+
+module Make2(O1 : OrderedType) (O2 : OrderedType) : sig
+  module Set1 : S with type elt= O1.t
+  module Set2 : S with type elt= O2.t
+  module Product : S with type elt = O1.t * O2.t
+
+  val cartesian_product : Set1.t -> Set2.t -> Product.t
+  (** cartesian product of the two sets *)
+end
+
 (** {6 Polymorphic sets}
 
     The definitions below describe the polymorphic set interface.


### PR DESCRIPTION
Ok, now this is a bigger PR than usual. I started it after I looked at #10, for monads like `'a Lwt.t`. It adds monad instances to `batSeq`, `batList` and `batLazyList`, adds a `BatInterfaces.Traversable` module signature that looks like

``` ocaml
module type Traversable = sig
  type 'a t  (* container *)

  type 'a m (* monad *)

  val mapM : ('a -> 'b m) -> 'a t -> 'b t m

  val foldM : ('a -> 'b -> 'a m) -> 'a -> 'b t -> 'a m

  val sequence : 'a m t -> 'a t m
end
```

and functors `Traversable` that take a `BatInterfaces.Monad` and return a traversable for this monad and container, to aforementioned modules as well as `BatEnum`. For `BatEnum`, a similar `WithMonad` functor was already present so I modified it, but didn't rename it to preserve backward compatibility.
