### PR TITLE
Set.Make2 for functorial cartesian product

### DIFF
--- a/src/batSet.ml
+++ b/src/batSet.ml
@@ -637,6 +637,16 @@ module Make2(O1 : OrderedType)(O2 : OrderedType) = struct
     Product.t_of_impl p
 end
 
+(*$T
+  let module S1 = Make(Int) in \
+  let module S2 = Make(String) in \
+  let module P = Make2(Int)(String) in \
+  P.cartesian_product \
+    (List.fold_right S1.add [1;2;3] S1.empty) \
+    (List.fold_right S2.add ["a";"b"] S2.empty) \
+    |> P.Product.to_list = [1, "a"; 1, "b"; 2, "a"; 2, "b"; 3, "a"; 3, "b"]
+*)
+
 module PSet = struct (*$< PSet *)
 
   type 'a t = {

--- a/src/batSet.ml
+++ b/src/batSet.ml
@@ -621,6 +621,22 @@ struct
   end
 end
 
+module Make2(O1 : OrderedType)(O2 : OrderedType) = struct
+  module Set1 = Make(O1)
+  module Set2 = Make(O2)
+  module Product = Make(
+  struct
+    type t = O1.t * O2.t
+    let compare (x1,y1)(x2,y2) =
+      let c = O1.compare x1 x2 in
+        if c = 0 then O2.compare y1 y2 else c
+  end)
+
+  let cartesian_product set1 set2 =
+    let p = Concrete.cartesian_product (Set1.impl_of_t set1) (Set2.impl_of_t set2) in
+    Product.t_of_impl p
+end
+
 module PSet = struct (*$< PSet *)
 
   type 'a t = {

--- a/src/batSet.mli
+++ b/src/batSet.mli
@@ -302,11 +302,9 @@ module Make (Ord : OrderedType) : S with type elt = Ord.t
 
 
 module Make2(O1 : OrderedType) (O2 : OrderedType) : sig
-  module Set1 : S with type elt= O1.t
-  module Set2 : S with type elt= O2.t
   module Product : S with type elt = O1.t * O2.t
 
-  val cartesian_product : Set1.t -> Set2.t -> Product.t
+  val cartesian_product : Make(O1).t -> Make(O2).t -> Product.t
   (** cartesian product of the two sets *)
 end
 

--- a/src/batSet.mli
+++ b/src/batSet.mli
@@ -300,6 +300,16 @@ module Make (Ord : OrderedType) : S with type elt = Ord.t
     @documents Set.Make
 *)
 
+
+module Make2(O1 : OrderedType) (O2 : OrderedType) : sig
+  module Set1 : S with type elt= O1.t
+  module Set2 : S with type elt= O2.t
+  module Product : S with type elt = O1.t * O2.t
+
+  val cartesian_product : Set1.t -> Set2.t -> Product.t
+  (** cartesian product of the two sets *)
+end
+
 (** {6 Polymorphic sets}
 
     The definitions below describe the polymorphic set interface.


### PR DESCRIPTION
See #441. I had to build all three sets (domains and product) because otherwise the abstraction barrier would become unbreakable (product on abstract set implementation is better solved using `Enum`, I believe).