### PR TITLE
[RFC] a completely encapsulated interface for unsafe batList accumulators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ export DOCROOT
 BROWSER_COMMAND ?= x-www-browser
 export BROWSER_COMMAND
 
-OCAMLBUILD ?= ocamlbuild
+OCAMLBUILD ?= ocamlbuild -use-ocamlfind
 OCAMLBUILDFLAGS ?= -no-links
 
 ifeq ($(uname_S),Darwin)
@@ -193,9 +193,9 @@ test-native: prefilter _build/testsuite/main.native _build/$(QTESTDIR)/all_tests
 full-test: $(TEST_TARGET)
 
 test-compat: prefilter src/batteries_compattest.ml
-	ocamlbuild src/batteries_compattest.byte -no-links
+	ocamlbuild -use-ocamlfind src/batteries_compattest.byte -no-links
 
-test: test-byte test-compat
+test: test-native test-compat
 
 ###############################################################################
 #	BENCHMARK SUITE

--- a/src/batEnum.ml
+++ b/src/batEnum.ml
@@ -516,7 +516,7 @@ let find f t =
 
 (*$T
   find ((=) 5) (1 -- 10) = 5
-  try find ((=) 11) (1 -- 10) = 5; false with Not_found -> true
+  try ignore (find ((=) 11) (1 -- 10) = 5); false with Not_found -> true
 *)
 
 let find_map f t =

--- a/src/batList.ml
+++ b/src/batList.ml
@@ -78,15 +78,15 @@ end = struct
     let dummy = { hd = Obj.magic (); tl = [] } in
     f dummy (fun consumer -> consumer dummy.tl)
 
-  let result f =
-    cont (fun dst return ->
-      let res = f dst in
-      return (fun li -> li, res))
-
   let run f =
-    cont (fun dst return ->
-      f dst;
-      return (fun li -> li))
+    let dummy = { hd = Obj.magic (); tl = [] } in
+    f dummy;
+    dummy.tl
+
+  let result f =
+    let dummy = { hd = Obj.magic (); tl = [] } in
+    let res = f dummy in
+    dummy.tl, res
 
   let accum acc x =
     let cell = { hd = x; tl = [] } in


### PR DESCRIPTION
> encapsulate unsafe list-accumulators in an abstract module
> 
> This patch is still incomplete, in particular it lacks tests for most
> of the functions changed, but it demonstrates the possibility to
> capture all the accumulator usage under a common abstraction. I think
> the code is provably safe (equivalent to another imperative implementation
> with (type 'a mut_list = 'a list ref) and no Obj.magic at all).
> 
> The only function that gave me trouble is 'transpose', as it creates
> an unbounded number of intermediate accumulators. The resulting
> implementation, using continuation-passing to not break
> tail-recursivity, is admittedly much less readable than the previous
> one. Is it a fair cost to pay for safety by encapsulation?

This patch is not proposed for inclusion (it fails the testing requirement) but for discussion in relation to #527.
