### PR TITLE
correct the following compilation warnings:

### DIFF
--- a/qtest/_tags
+++ b/qtest/_tags
@@ -1,3 +1,3 @@
 true: threads, debug
-<all_tests.*>: package(oUnit), package(QTest2Lib)
+<all_tests.*>: oUnit, QTest2Lib
 


### PR DESCRIPTION
Warning: tag "package" does not expect a parameter, but is used with parameter "oUnit"
Warning: tag "package" does not expect a parameter, but is used with parameter "QTest2Lib"

PS: we have 11 _tags file in the batteries tree, amazing...
