### PR TITLE
Add test case for BatPervasives.dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ You will need the following libraries:
 
 * [OCaml][] >= 3.12.1
 * [Findlib][] >= 1.2.5
+* [qtest][] >= 2.0.1
 * GNU make
 * [OUnit][] to build and run the tests (optional)
 * [ocaml-benchmark][] to build and run the performance tests (optional)

--- a/src/batPervasives.mliv
+++ b/src/batPervasives.mliv
@@ -64,9 +64,21 @@ val input_all : Pervasives.in_channel -> string
 val dump : 'a -> string
 (** Attempt to convert a value to a string.
 
-    Since types are lost at compile time, the representation might not
-    match your type. For example, None will be printed 0 since they
-    share the same runtime representation.
+    Works well for a lot of cases such as non-empty lists, algebraic
+    datatype, and records.
+
+    However, since types are lost at compile-time, the representation
+    might not match your type. (0, 1) will be printed as expected, but
+    (1, 0) and [1] have the same representation and will get printed
+    in the same way. The result of [dump] is unspecified and may
+    change in future versions, so you should only use it for debugging
+    and never have program behavior depend on the output.
+
+    Here is a list of some of the surprising corner cases of the
+    current implementation:
+
+      - (3, 0) is printed [3], (0.5, 0) is printed [0.5], etc.
+      - None, false and [] are printed 0
 
     [dump] may fail for ill-formed values, such as obtained from
     a faulty C binding or crazy uses of [Obj.set_tag].

--- a/testsuite/test_pervasives.ml
+++ b/testsuite/test_pervasives.ml
@@ -52,6 +52,10 @@ let test_dump () =
 
   test "(1, (2., 3.), [\"foo\"])" {a = 1; b = (2., 3.); c = "foo", None};
 
+  (* tuples *)
+  test "(1, 2)" (1,2);
+  test "[0]" (0,0);
+
   (* lazy *)
   (* lazy immediate values are not lazyfied!
      test "0" (lazy 0); *)


### PR DESCRIPTION
`BatPervasives.dump` currently produces unexpected output when given (0,0). It will print "[0]" rather than "(0, 0)" as I would've expected.

I will have a look and see if I can fix it, but for now I've opened the pull request to make other people aware of the bug. If you have any concerns or ideas how to fix it let me know.

Cheers,
Mads
