### PR TITLE
batList.{modify_at,modify_opt_at}: modify values at a given list position

### DIFF
--- a/src/batList.ml
+++ b/src/batList.ml
@@ -1050,16 +1050,35 @@ let modify_def dfl a f l =
   (modify_def 0 5 succ [ 1,0 ; 8,2 ]) [ 1,0 ; 8,2 ; 5,1 ]
 *)
 
-let modify_at n f l =
+let modify_opt_at n f l =
   if n < 0 then invalid_arg at_negative_index_msg;
   let rec loop acc n = function
     | [] -> invalid_arg at_after_end_msg
     | h :: t ->
-      if n = 0
-      then rev_append acc (f h :: t)
-      else loop (h :: acc) (n - 1) t
+      if n <> 0 then loop (h :: acc) (n - 1) t
+      else match f h with
+        | None -> rev_append acc t
+        | Some v -> rev_append acc (v :: t)
   in
   loop [] n l
+
+(*$T modify_opt_at
+  modify_opt_at 2 (fun n -> Some (n*n)) [1;2;3;4;5] = [1;2;9;4;5]
+  modify_opt_at 2 (fun _ -> None) [1;2;3;4;5] = [1;2;4;5]
+  try ignore (modify_opt_at 0 (fun _ -> None) []); false \
+  with Invalid_argument _ -> true
+  try ignore (modify_opt_at 2 (fun _ -> None) []); false \
+  with Invalid_argument _ -> true
+  try ignore (modify_opt_at (-1) (fun _ -> None) [1;2;3]); false \
+  with Invalid_argument _ -> true
+  try ignore (modify_opt_at 5 (fun _ -> None) [1;2;3]); false \
+  with Invalid_argument _ -> true
+  try ignore (modify_opt_at 3 (fun _ -> None) [1;2;3]); false \
+  with Invalid_argument _ -> true
+*)
+
+let modify_at n f l =
+  modify_opt_at n (fun x -> Some (f x)) l
 
 (*$T modify_at
   modify_at 2 ((+) 1) [1;2;3;4] = [1;2;4;4]

--- a/src/batList.mli
+++ b/src/batList.mli
@@ -519,6 +519,14 @@ val modify_at : int -> ('a -> 'a) -> 'a list -> 'a list
     @raise Invalid_argument if the index is outside of [l] bounds
     @since NEXT_RELEASE *)
 
+val modify_opt_at : int -> ('a -> 'a option) -> 'a list -> 'a list
+(** [modify_at_opt n f l] returns the same list as [l] but with
+    nth-value [a] removed if [f a] is [None], and replaced by [v] if
+    it is [Some v].
+
+    @raise Invalid_argument if the index is outside of [l] bounds
+    @since NEXT_RELEASE *)
+
 val split_at : int -> 'a list -> 'a list * 'a list
 (** [split_at n l] returns two lists [l1] and [l2], [l1] containing the
     first [n] elements of [l] and [l2] the others. @raise Invalid_argument if


### PR DESCRIPTION
on #ocaml early this morning:

> 02:23 < morolin> Is there a good way to write a function that takes a list and an integer (n) as an input, and returns a list with the nth element modifed in some way? 
> 02:24 < morolin> I'd rather avoid using fold_left, since in most cases, I will be modifying elements from the beginning of the list
> 02:24 < morolin> Looking at the "List" module, I see "nth" which will let me get the nth element, but nothing that'll let me replace it.
> 02:25 < morolin> I.e., I would like to have a function whose type is: 'a list -> int -> ('a -> 'a) -> 'a list

"Of course, it is in Batteries". Almost.

To be honest I'm extremely confident in `modify_at`, but slightly less
about `modify_opt_at`. On one hand, it is an obvious generalization,
on the other the difference with respect to `modify_opt` (we only
support returning an option, not taking an option as input, as
extending a list at arbitrary indices makes no sense) makes it
slightly less satisfying.

Do you have warm feelings about `modify_opt_at`, or should we
(over-)cautiously leave it out?

Note that the failure mode is to raise `Invalid_argument`, like all
the `*_at` functions, instead of `Not_found` as all the `modify_*`
functions. I think it is the better choice, but users might assume the
other way. My reasoning is as follows: accessing-by-index
a fixed-length data-structure is much less flexible than
accessing-by-key an associative data-structure and notably, users are
supposed to have already checked the index before calling the
function, so the error is not supposed to get caught -- so it's ok if
it's one of those lousy string-taking exceptions.
