### PR TITLE
Balanced binary trees: enumeration starting from an arbitrary key

### DIFF
--- a/src/batMap.mli
+++ b/src/batMap.mli
@@ -250,11 +250,19 @@ sig
       to the ordering [Ord.compare], where [Ord] is the argument given to
       {!Map.Make}. *)
 
+  val enum_from : key -> 'a t -> (key * 'a) BatEnum.t
+  (** [enum_from k t] return an enumeration as [enum], but starting from
+      the first key equal or greater than [k] *)
+
   val backwards  : 'a t -> (key * 'a) BatEnum.t
   (** Return an enumeration of (key, value) pairs of a map.
       The returned enumeration is sorted in decreasing order with respect
-      to the ordering [Ord.compare], where [Ord] is the argument given to
+      to the ordering {!Ord.compare}, where [Ord] is the argument given to
       {!Map.Make}. *)
+
+  val backwards_from : key -> 'a t -> (key * 'a) BatEnum.t
+  (** [backwards_from k t] return an enumeration as [backward], but
+      starting from the last key smaller or equal to [k] *)
 
   val of_enum: (key * 'a) BatEnum.t -> 'a t
   (** Create a map from a (key, value) enumeration. *)
@@ -464,8 +472,16 @@ val max_binding : ('key, 'a) t -> ('key * 'a)
 val enum : ('a, 'b) t -> ('a * 'b) BatEnum.t
 (** creates an enumeration for this map, enumerating key,value pairs with the keys in increasing order. *)
 
+val enum_from : 'a -> ('a, 'b) t -> ('a * 'b) BatEnum.t
+(** [enum_from k t] return an enumeration as [enum], but starting from
+    the first key equal or greater than [k] *)
+
 val backwards  : ('a,'b) t -> ('a * 'b) BatEnum.t
 (** creates an enumeration for this map, enumerating key,value pairs with the keys in decreasing order. *)
+
+val backwards_from : 'a -> ('a, 'b) t -> ('a * 'b) BatEnum.t
+(** [enum_from k t] return an enumeration as [enum], but starting from
+    the first key equal or greater than [k] *)
 
 val keys : ('a,'b) t -> 'a BatEnum.t
 (** Return an enumeration of all the keys of a map.*)

--- a/src/batSet.mli
+++ b/src/batSet.mli
@@ -231,6 +231,14 @@ sig
       to the ordering [Ord.compare], where [Ord] is the argument
       given to {!Set.Make}. *)
 
+  val enum_from : elt -> t -> elt BatEnum.t
+  (** [enum_from e t] enumerates the elements of the set above or
+      equal to [e], in increasing order *)
+
+  val backwards_from : elt -> t -> elt BatEnum.t
+  (** [backwards_from e t] enumerates the elements of the set below or equal to [e], in
+      decreasing order *)
+
   val of_enum: elt BatEnum.t -> t
 
   val of_list: elt list -> t
@@ -510,7 +518,11 @@ val cartesian_product : 'a t -> 'b t -> ('a * 'b) t
 val enum: 'a t -> 'a BatEnum.t
 (** Return an enumeration of all elements of the given set.
     The returned enumeration is sorted in increasing order with respect
-    to the ordering of this set.*)
+    to [Pervasives.compare].*)
+
+val enum_from : 'a -> 'a t -> 'a BatEnum.t
+(** [enum_from e t] enumerates the elements of the set above or equal to [e], in
+    increasing order with respect to [Pervasives.compare] *)
 
 val of_enum: 'a BatEnum.t -> 'a t
 
@@ -519,6 +531,10 @@ val backwards: 'a t -> 'a BatEnum.t
     returned enumeration is sorted in decreasing order with respect to
     the ordering [Pervasives.compare]. *)
 
+val backwards_from : 'a -> 'a t -> 'a BatEnum.t
+(** [backwards_from e t] enumerates the elements of the set below or
+    equal to [e], in decreasing order with respect to
+    [Pervasives.compare] *)
 
 val of_list: 'a list -> 'a t
 (** builds a set from the given list, using the default comparison
@@ -738,6 +754,19 @@ module PSet : sig
   (** Return an enumeration of all elements of the given set.
       The returned enumeration is sorted in increasing order with respect
       to the ordering of this set.*)
+
+  val enum_from : 'a -> 'a t -> 'a BatEnum.t
+  (** [enum_from e t] enumerates the elements of the set [t] above or equal to [e], in
+      increasing order with respect to the ordering of [t]*)
+
+  val backwards: 'a t -> 'a BatEnum.t
+  (** Return an enumeration of all elements of the given set.
+      The returned enumeration is sorted in decreasing order with respect
+      to the ordering of this set.*)
+
+  val backwards_from : 'a -> 'a t -> 'a BatEnum.t
+  (** [enum_from e t] enumerates the elements of the set [t] below or equal to [e], in
+      decreasing order with respect to the ordering of [t]*)
 
   val of_enum: 'a BatEnum.t -> 'a t
 

--- a/src/batSplay.ml
+++ b/src/batSplay.ml
@@ -380,6 +380,31 @@ struct
     | Node (l, (k, v), r) ->
       rev_cons_enum r (More (k, v, l, e))
 
+  (* see batMap.ml:iter_from for comments *)
+  let iter_from x map =
+    let rec loop m e = match m with
+      | Empty -> e
+      | Node (l, (k, v), r) ->
+        let c = Ord.compare x k in
+        if c > 0 then loop r e
+        else
+          let e = More (k, v, r, e) in
+          if c = 0 then e
+          else loop l e
+    in loop map End
+
+  let rev_iter_from x map =
+    let rec loop m e = match m with
+      | Empty -> e
+      | Node (l, (k, v), r) ->
+        let c = Ord.compare x k in
+        if c < 0 then loop l e
+        else
+          let e = More (k, v, l, e) in
+          if c = 0 then e
+          else loop l e
+    in loop map End
+
   let compare cmp (Map tr1) (Map tr2) =
     let rec aux e1 e2 = match (e1, e2) with
       | (End, End) -> 0
@@ -418,6 +443,9 @@ struct
 
   let enum (Map tr) = enum_bst cons_enum (cons_enum tr End)
   let backwards (Map tr) = enum_bst rev_cons_enum (rev_cons_enum tr End)
+
+  let enum_from k (Map tr) = enum_bst cons_enum (iter_from k tr)
+  let backwards_from k (Map tr) = enum_bst rev_cons_enum (rev_iter_from k tr)
 
   let keys m = Enum.map fst (enum m)
   let values m = Enum.map snd (enum m)

--- a/testsuite/test_map.ml
+++ b/testsuite/test_map.ml
@@ -111,6 +111,8 @@ module TestMap
     val bindings : 'a m -> (key * 'a) list
     val enum : 'a m -> (key * 'a) BatEnum.t
     val backwards : 'a m -> (key * 'a) BatEnum.t
+    val enum_from : key -> 'a m -> (key * 'a) BatEnum.t
+    val backwards_from : key -> 'a m -> (key * 'a) BatEnum.t
     val of_enum : (key * 'a) BatEnum.t -> 'a m
     val bindings : 'a m -> (key * 'a) list
 
@@ -433,6 +435,23 @@ module TestMap
         M.bindings %> BatList.enum, "enum bindings";
       ]
 
+  let test_froms () =
+    (* test enum_from, backwards_from *)
+    let test_from f name comp compname elem t =
+      eq ~msg:(Printf.sprintf "of_enum (%s %d t) = filter (_ %s %d) t"
+                 name elem compname elem)
+        BatInt.compare BatInt.print
+        (M.of_enum (f elem t)) (M.filter (fun k _v -> comp k elem) t) in
+    List.iter (fun (f,name,comp,compname) ->
+      List.iter (fun elem ->
+        test_from f name comp compname elem
+          (il [(0,1); (1,2); (3,4); (4,5)])
+      ) [(-1);0;1;2;3;4;5]
+    ) [
+      M.enum_from, "enum_from", (>=), ">=";
+      M.backwards_from, "backwards_from", (<=), "<="
+    ]
+
   let reindex (f : M.key -> 'a -> 'b) : 'a -> 'b =
     let count = ref (-1) in
     fun x -> incr count; f !count x
@@ -576,6 +595,7 @@ module TestMap
     "test_for_all_exists" >:: test_for_all_exists;
     "test_print" >:: test_print;
     "test_enums" >:: test_enums;
+    "test_froms" >:: test_froms;
     "test_iterators" >:: test_iterators;
     "test_pop" >:: test_pop;
     "test_extract" >:: test_extract;


### PR DESCRIPTION
``` ocaml
val enum_from : key -> 'a t -> (key * 'a) BatEnum.t
(** [enum_from k t] return an enumeration as [enum], but starting from
    the first key equal or greater than [k] *)


val backwards_from : key -> 'a t -> (key * 'a) BatEnum.t
(** [backwards_from k t] return an enumeration as [backward], but
     starting from the last key smaller or equal to [k] *)
```

Of course the performance of this are only as good than our enumeration library, but the code does not depend on it (Map and Set already had manually-derived control-inversed iterators that make these kind of things convenient) so it will be trivial to change to, say, `Sequence` if we want to in the future.
