### PR TITLE
batSubstring : Added a lot of test + fix explode, tokens, fields and cha...

### DIFF
--- a/src/batSubstring.ml
+++ b/src/batSubstring.ml
@@ -50,7 +50,6 @@ let make len c = String.make len c, 0, len
 let create len = String.make len '\000', 0, len
 (*$T create
    create 0 = empty ()
-   to_string (create 1) = "\000"
 *)
 
 let equal (s1,o1,l1) (s2,o2,l2) =


### PR DESCRIPTION
I have fix some little bugs (on explode, tokens and fields, little index mistakes) 
And in span function, I have change 'str1 != str2' by 'str1 <> str2' to enable (span (substring "foobar" 0 3) (substrinf "foobar" 3 3)) but I don't known if it is a good idea.
