### PR TITLE
add BatSubstring.sub analagous to String.sub

### DIFF
--- a/src/batSubstring.ml
+++ b/src/batSubstring.ml
@@ -189,6 +189,12 @@ let slice (str,off,len) off2 len2_opt =
    is_empty (slice (substring "foobar" 0 3) 3 None) = true
 *)
 
+let sub s pos len = slice s pos (Some (len - pos))
+(*T sub
+  to_string (sub (of_string "testing") 1 4) = (String.sub "testing" 1 4)
+  to_string (sub (substring "foobar" 1 4) 0 2) = "oo"
+*)
+
 let concat ssl =
   let len = List.fold_left (fun acc (_,_,l) ->acc+l) 0 ssl in
   let item = String.create len in

--- a/src/batSubstring.mli
+++ b/src/batSubstring.mli
@@ -109,6 +109,13 @@ val slice : t -> int -> int option -> t
     where [sus] = [(s, i, n)].  @raise Invalid_argument if [i' < 0]
     or [n' < 0] or [i'+n' >= n].
 *)
+
+val sub : t -> int -> int -> t
+(** [sub sus i' n'] returns the substring [(s, i+i', i+i'+n')],
+    where [sus] = [(s, i, n)].  @raise Invalid_argument if [i' < 0]
+    or [n' < 0] or [i+i'+n' >= n].
+*)
+
 val concat : t list -> string
 (** [concat suss] returns a string consisting of the concatenation of
     the substrings.  Equivalent to [String.concat (List.map to_string


### PR DESCRIPTION
makes it easier to replace `String` uses with `BatSubstring`
