### PR TITLE
[ bug ] modify_opt randomly drops parts of the map

### DIFF
--- a/src/batIMap.ml
+++ b/src/batIMap.ml
@@ -84,8 +84,8 @@ module Core = struct
         | None   -> raise Exit
       else
         let (n1, n2, v) = root m in
-        if n < n1 then aux (left_branch m) else
-        if n > n2 then aux (right_branch m) else
+        if n < n1 then make_tree (aux (left_branch m)) (n1, n2, v) (right_branch m) else
+        if n > n2 then make_tree (left_branch m) (n1, n2, v) (aux (right_branch m))  else
           match f (Some v) with
           | None    ->
             concat (left_branch m) (right_branch m)


### PR DESCRIPTION
  * This is a naïve fix: I'm not sure whether one could use
    [create] rather than [make_tree] in order to avoid the
    rebalancing operation.