### PR TITLE
Fix HTML in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,12 @@
 <html>
   <head>
-    <title> Batteries Included </title>
+    <title>OCaml Batteries Included </title>
   </head>
   <body>
-    <h1> Batteries Included </h1>
-    <p> Our main home page is: <a href="http://batteries.forge.ocamlcore.org/">
-    <p> The source code is available at <a href="http://www.github.com/ocaml-batteries-team/batteries-included/">http://www.github.com/ocaml-batteries-team/batteries-included/</a>.</p>
-    <p> The current (v2) API documentation is available at <a href="http://ocaml-batteries-team.github.com/batteries-included/hdoc2/">http://ocaml-batteries-team.github.com/batteries-included/hdoc2/</a>.</p>
-    <p> The previous (v1) API documentation is available at <a href="http://ocaml-batteries-team.github.com/batteries-included/hdoc/">http://ocaml-batteries-team.github.com/batteries-included/hdoc/</a>.</p>
-
+    <h1>OCaml Batteries Included </h1>
+    <p><a href="http://batteries.forge.ocamlcore.org/">Our main home page</a>. </p>
+    <p>The source code is available at <a href="http://www.github.com/ocaml-batteries-team/batteries-included/">http://www.github.com/ocaml-batteries-team/batteries-included/</a>.</p>
+    <p>The current (v2) API documentation is available at <a href="http://ocaml-batteries-team.github.com/batteries-included/hdoc2/">http://ocaml-batteries-team.github.com/batteries-included/hdoc2/</a>.</p>
+    <p>The previous (v1) API documentation is available at <a href="http://ocaml-batteries-team.github.com/batteries-included/hdoc/">http://ocaml-batteries-team.github.com/batteries-included/hdoc/</a>.</p>
   </body>
 </html>


### PR DESCRIPTION
This page is the second Google hit for "OCaml Batteries Included":

https://www.google.com/search?hl=en&source=hp&q=%22ocaml%20batteries%20included%22

This fixes the HTML on this page.
