### PR TITLE
BatUTF8.enum, based on BatString.enum / BatList.enum

### DIFF
--- a/src/batUTF8.ml
+++ b/src/batUTF8.ml
@@ -252,6 +252,17 @@ let enum s =
           c
         end
     )
+(*$T enum
+   "" |> of_latin1 |> enum |> BatList.of_enum = []
+   "foo" |> of_latin1 |> enum |> BatList.of_enum = List.map BatUChar.of_char ['f'; 'o'; 'o']
+   let e = of_latin1 "abcdef" |> enum in \
+   for _i = 0 to 2 do BatEnum.junk e done; \
+   let e2 = BatEnum.clone e in \
+   let to_string en = BatList.of_enum en |> List.map BatUChar.char_of |> BatString.implode in \
+   to_string e = "def" && to_string e2 = "def"
+   init 3 (fun i -> BatUChar.of_int (1211+i)) |> enum |> BatList.of_enum = List.map BatUChar.of_int [1211;1212;1213]
+*)
+(* The last test checks that we can make a round-trip of non-ASCII strings like "һҼҽ" *)
 
 
 let escaped = String.escaped

--- a/src/batUTF8.ml
+++ b/src/batUTF8.ml
@@ -239,6 +239,21 @@ let fold f a s =
       loop a' (next s i) in
   loop a 0
 
+let enum s =
+  let sl = String.length s in
+  let i = (ref (first s)) in
+  BatEnum.from (fun () ->
+      if !i = sl then
+        raise BatEnum.No_more_elements
+      else
+        begin
+          let c = look s !i in
+          i := next s !i;
+          c
+        end
+    )
+
+
 let escaped = String.escaped
 
 module ByteIndex : sig

--- a/src/batUTF8.mli
+++ b/src/batUTF8.mli
@@ -178,6 +178,8 @@ val iteri : (BatUChar.t -> int -> unit) -> t -> unit
 
 val fold : ('a -> BatUChar.t -> 'a) -> 'a -> t -> 'a
 
+val enum : t -> BatUChar.t BatEnum.t
+
 val map : (BatUChar.t -> BatUChar.t) -> t -> t
 
 val filter_map : (BatUChar.t -> BatUChar.t option) -> t -> t


### PR DESCRIPTION
Is there a reason for not having this in here? 

I'm new to OCaml, so I probably made some errors here, but it seems useful anyway to have a BatUTF8.enum