### PR TITLE
Fix description of LazyList.range

### DIFF
--- a/src/batLazyList.mli
+++ b/src/batLazyList.mli
@@ -134,7 +134,7 @@ val make : int -> 'a -> 'a t
 val range : int -> int -> int t
 (**Compute lazily a range of integers a .. b as a lazy list.
 
-   The range is empty if a <= b.*)
+   The range is empty if b <= a.*)
 
 
 (**


### PR DESCRIPTION
The previous description was incorrect. b <= a matches the implementation.
