### PR TITLE
Optimize hashtbl modify_{def, opt} functions

### DIFF
--- a/src/batHashtbl.mlv
+++ b/src/batHashtbl.mlv
@@ -188,7 +188,11 @@ let modify_opt key f h =
   let hc = h_conv h in
 
   let rec loop = function
-    | Empty -> raise Hashtbl_key_not_found
+    | Empty ->
+      (* Inserting an element might require a resize of the hash table.
+         We rely on Hashtbl.add function to grow the hashtbl if needed
+         instead of duplicating logic from the OCaml standard library. *)
+      raise Hashtbl_key_not_found
     | Cons(k,v,next) ->
       if k = key then
         match f (Some v) with
@@ -206,7 +210,10 @@ let modify_opt key f h =
   | Hashtbl_key_not_found ->
     begin match f None with
       | None -> ()
-      | Some v -> add h key v
+      | Some v ->
+        (* Add the element to make sure the hashtbl is grown correctly if
+           needed. *)
+        add h key v
     end
 
 (*$T modify_opt
@@ -611,16 +618,20 @@ struct
     let hc = h_conv (to_hash h) in
 
     let rec loop = function
-    | Empty -> raise Hashtbl_key_not_found
-    | Cons(k,v,next) ->
-      if H.equal k key then
-        match f (Some v) with
-        | Some v -> Cons(key,v,next)
-        | None ->
-          hc.size <- pred hc.size;
-          next
-      else
-        Cons(k,v,loop next)
+      | Empty ->
+        (* Inserting a element might require a resize of the hashtbl.
+           We rely on Hashtbl.add function to grow the hashtbl if needed
+           instead of duplicating logic from the OCaml standard library. *)
+        raise Hashtbl_key_not_found
+      | Cons(k,v,next) ->
+        if H.equal k key then
+          match f (Some v) with
+            | Some v -> Cons(key,v,next)
+            | None ->
+              hc.size <- pred hc.size;
+              next
+        else
+          Cons(k,v,loop next)
     in
     try
       let pos = (H.hash key) mod (Array.length hc.data) in
@@ -629,7 +640,10 @@ struct
     | Hashtbl_key_not_found ->
       begin match f None with
         | None -> ()
-        | Some v -> add h key v
+        | Some v ->
+          (* Add the element to make sure the hashtbl is grown correctly if
+             needed. *)
+          add h key v
       end
 
   let modify key f h =

--- a/src/batHashtbl.mlv
+++ b/src/batHashtbl.mlv
@@ -225,7 +225,7 @@ let modify key f h =
     | Empty -> raise Not_found
     | Cons(k,v,next) ->
       if k = key then (
-        Cons(k,f v,next)
+        Cons(key,f v,next)
       ) else
         Cons(k,v,loop next)
   in
@@ -638,7 +638,7 @@ struct
       | Empty -> raise Not_found
       | Cons(k,v,next) ->
         if H.equal k key then (
-          Cons(k,f v,next)
+          Cons(key,f v,next)
         ) else
           Cons(k,v,loop next)
     in

--- a/src/batHashtbl.mlv
+++ b/src/batHashtbl.mlv
@@ -188,10 +188,10 @@ let modify_opt key f h =
   let hc = h_conv h in
 
   let rec loop = function
+    (* Inserting an element might require a resize of the hash table.
+       We rely on Hashtbl.add function to grow the hashtbl if needed
+       instead of duplicating logic from the OCaml standard library. *)
     | Empty ->
-      (* Inserting an element might require a resize of the hash table.
-         We rely on Hashtbl.add function to grow the hashtbl if needed
-         instead of duplicating logic from the OCaml standard library. *)
       raise Hashtbl_key_not_found
     | Cons(k,v,next) ->
       if k = key then
@@ -618,10 +618,10 @@ struct
     let hc = h_conv (to_hash h) in
 
     let rec loop = function
+      (* Inserting an element might require a resize of the hash table.
+         We rely on Hashtbl.add function to grow the hashtbl if needed
+         instead of duplicating logic from the OCaml standard library. *)
       | Empty ->
-        (* Inserting a element might require a resize of the hashtbl.
-           We rely on Hashtbl.add function to grow the hashtbl if needed
-           instead of duplicating logic from the OCaml standard library. *)
         raise Hashtbl_key_not_found
       | Cons(k,v,next) ->
         if H.equal k key then

--- a/src/batHashtbl.mlv
+++ b/src/batHashtbl.mlv
@@ -183,16 +183,31 @@ let length h = (h_conv h).size
 
 let is_empty h = length h = 0
 
+exception Hashtbl_key_not_found
 let modify_opt key f h =
-  match find_option h key with
-  | Some _ as v ->
-     (match f v with
-      | Some v' -> replace h key v'
-      | None -> remove h key)
-  | None ->
-     (match f None with
+  let hc = h_conv h in
+
+  let rec loop = function
+    | Empty -> raise Hashtbl_key_not_found
+    | Cons(k,v,next) ->
+      if k = key then
+        match f (Some v) with
+          | Some v -> Cons(key,v,next)
+          | None ->
+            hc.size <- pred hc.size;
+            next
+      else
+        Cons(k,v,loop next)
+  in
+  try
+    let pos = (hash key) mod (Array.length hc.data) in
+    Array.unsafe_set hc.data pos (loop (Array.unsafe_get hc.data pos))
+  with
+  | Hashtbl_key_not_found ->
+    begin match f None with
+      | None -> ()
       | Some v -> add h key v
-      | None -> ())
+    end
 
 (*$T modify_opt
   let h = create 3 in \
@@ -228,9 +243,11 @@ let modify key f h =
 *)
 
 let modify_def v0 key f h =
-  match find_option h key with
-  | None -> add h key (f v0)
-  | Some v -> replace h key (f v)
+  let f' = function
+    | None -> Some (f v0)
+    | Some v -> Some (f v)
+  in
+  modify_opt key f' h
 
 (*$T modify_def
   let h = create 3 in \
@@ -591,15 +608,29 @@ struct
     result
 
   let modify_opt key f h =
-    match find_option h key with
-    | Some _ as v ->
-       (match f v with
-        | Some v' -> replace h key v'
-        | None -> remove h key)
-    | None ->
-       (match f None with
+    let hc = h_conv (to_hash h) in
+
+    let rec loop = function
+    | Empty -> raise Hashtbl_key_not_found
+    | Cons(k,v,next) ->
+      if H.equal k key then
+        match f (Some v) with
+        | Some v -> Cons(key,v,next)
+        | None ->
+          hc.size <- pred hc.size;
+          next
+      else
+        Cons(k,v,loop next)
+    in
+    try
+      let pos = (H.hash key) mod (Array.length hc.data) in
+      Array.unsafe_set hc.data pos (loop (Array.unsafe_get hc.data pos))
+    with
+    | Hashtbl_key_not_found ->
+      begin match f None with
+        | None -> ()
         | Some v -> add h key v
-        | None -> ())
+      end
 
   let modify key f h =
     let hc = h_conv (to_hash h) in
@@ -615,9 +646,11 @@ struct
     Array.unsafe_set hc.data pos (loop (Array.unsafe_get hc.data pos))
 
   let modify_def v0 key f h =
-    match find_option h key with
-    | None -> add h key (f v0)
-    | Some v -> replace h key (f v)
+    let f' = function
+      | None -> Some (f v0)
+      | Some v -> Some (f v)
+    in
+    modify_opt key f' h
 
   module Labels =
   struct


### PR DESCRIPTION
This pull request optimizes the Hashtbl.modify functions to eliminate an extra lookup in the case the key is already in the hash table.

Hashtbl.modify_opt still does an extra lookup when adding the key to the hash table in order to make sure the hash table is grown if needed (by call to Hashtbl.add).

The pull request also contains a change to Hashtbl.modify, to use the new key instead of the old key to follow the semantics of Hashtbl.replace.
This change might put more pressure on memory as the new key will to be copied to the major heap if not already there (if the hashtbl is on the major heap). OTOH, the change follows the semantics of Hahtbl.replace and makes it easier to control which keys are referenced or not (Consider the case if the key is referenced from the value itself, e.g. Hashtbl.modify k (k, v) h. or if a custom equal function is used).







