### PR TITLE
added an interleave utility function to the BatEnum module

### DIFF
--- a/src/batEnum.ml
+++ b/src/batEnum.ml
@@ -1253,6 +1253,49 @@ let merge test a b =
     if *)
 
 
+let interleave enums =
+  let enums_len = Array.length enums in
+  if not (enums_len > 0) then empty () else begin
+    let available = Array.make enums_len true
+    and next_idx = Array.init enums_len ((+) 1) in
+    next_idx.((Array.length next_idx) - 1) <- 0 ;
+    let rec next_elem idx =
+      match get enums.(idx) with
+       | Some x -> x , next_idx.(idx)
+       | None -> begin
+           available.(idx) <- false ;
+           let rec loop k =
+             let l = next_idx.(k) in
+             if l = idx then raise No_more_elements else
+             if available.(l) then (next_idx.(idx) <- l ; next_elem l) else loop l
+           in loop idx
+         end
+    in
+    from_loop 0 next_elem
+  end
+
+(*$T
+  let e1 = List.enum [ 8 ; 2 ; 5 ; 2 ] and e2 = List.enum [ -5 ; -7 ; -6 ; 2 ; 1 ; -9 ; 2 ] in \
+  let e = interleave [| e1 ; e2 |] in \
+  List.of_enum e = [ 8 ; -5 ; 2 ; -7 ; 5 ; -6 ; 2 ; 2 ; 1 ; -9 ; 2 ]
+*)
+
+(*
+  let let e1 = Enum.empty \
+  and e2 = List.enum [ 8 ; 2 ; 5 ; 2 ] \
+  and e3 = List.enum [ -5 ; -7 ; -6 ; 2 ; 1 ; -9 ; 2 ] in \
+  let e = interleave [| e1; e2 ; e3 |] in \
+  List.of_enum e = [ 8 ; -5 ; 2 ; -7 ; 5 ; -6 ; 2 ; 2 ; 1 ; -9 ; 2 ]
+*)
+
+(*
+  let let e1 = Enum.empty \
+  and e2 = Enum.empty \
+  and e3 = Enum.epmyt \
+  let e = interleave [| e1; e2 ; e3 |] in \
+  List.of_enum e = [ ]
+*)
+
 let slazy f =
   let constructor = lazy (f ()) in
   make ~next: (fun () -> (Lazy.force constructor).next ())

--- a/src/batEnum.mli
+++ b/src/batEnum.mli
@@ -580,6 +580,14 @@ val merge : ('a -> 'a -> bool) -> 'a t -> 'a t -> 'a t
     in increasing order, then [merge (<) a b] will also be sorted.
 *)
 
+val interleave : 'a t array -> 'a t
+(** [interleave enums] creates a new enumeration from an array of enumerations.
+    The new enumeration first yields the first elements of the enumerations in
+    the supplied order, then second elements, etc.  Thus, a sequence
+    [ [| [x11 ; x12 ; ...] ; [x21 ; x22, ...] , ... [xN1 ; xN2 ; ...] |] ] becomes
+    [[ x11 ; x12 ; ... ; xN1 ; x21 ; x22 ; ... ; xN2 ; x31 ; ... ]].
+*)
+
 val uniq : 'a t -> 'a t
 (** [uniq e] returns a duplicate of [e] with repeated values
     omitted (similar to unix's [uniq] command).


### PR DESCRIPTION
keeps track of transitions in an array of indexes

never polls the expired enum twice
