### PR TITLE
expose `Format.asprintf` for V>=4.01, fixes #597

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,6 @@ src/batMarshal.mli
 src/batPrintexc.mli
 src/batPrintf.ml
 src/batPrintf.mli
+src/batFormat.mli
 src/batSys.mli
 src/batBigarray.mli

--- a/src/batFormat.mliv
+++ b/src/batFormat.mliv
@@ -688,6 +688,13 @@ val sprintf : ('a, unit, string) format -> 'a;;
     buffer of your own: flushing the formatter and the buffer at the end of
     pretty-printing returns the desired string. *)
 
+##V>=4.01##val asprintf : ('a, formatter, unit, string) format4 -> 'a;;
+##V>=4.01##(** Same as [printf] above, but instead of printing on a formatter, returns a
+##V>=4.01##    string containing the result of formatting the arguments. The type of
+##V>=4.01##    asprintf is general enough to interact nicely with [%a] conversions.
+##V>=4.01##    @since 4.01.0
+##V>=4.01##*)
+
 val ifprintf : formatter -> ('a, formatter, unit) format -> 'a;;
 (** Same as [fprintf] above, but does not print anything.
     Useful to ignore some material when conditionally printing.


### PR DESCRIPTION
Maybe it's better to backport it...