### PR TITLE
synchronize BatText.nsplit to match BatString.nsplit (fixes #561)

### DIFF
--- a/src/batText.mli
+++ b/src/batText.mli
@@ -429,7 +429,13 @@ val nsplit : t -> t -> t list
     which are separated by [sep].
     [nsplit "" _] returns the empty list.
     If the separator is not found, it returns a list of
-    the rope [s]. *)
+    the rope [s].
+    If two occurences of the separator are consecutive (with nothing
+    in between), the empty rope is added in the sequence. For example,
+    [nsplit "a//b/" "/"] is ["a"; ""; "b"; ""].
+
+    @raise Invalid_argument if the separator is empty
+ *)
 
 val compare : t -> t -> int
 (** The comparison function for ropes, with the same specification as


### PR DESCRIPTION
Supersedes #645 .

The BatText.nsplit implementation seems to suffer from a off-by-one
offset error. The present commit changes its implementation to reuse
exactly the more battle-tested implementation of BatString.split.

A consequence of this change are two small changes of behavior, that
corresponds to non-specified aspects of BatText.nsplit and arguably
fix bugs:
- nsplit now raises an (Invalid_argument ...) exception if the separator passed is empty (splitting on it makes no sense)
  (the previous implementation would loop endlessly)
- on two consecutive occurrences of the separate, nsplit now inserts an empty text in the sequence:
  `nsplit "a//b/c" "/" ` is `["a"; ""; "b"; "c"]` rather than `["a"; "b"; "c"]` as previously
  This ensures that for any `sep` and `str`, we have
    `join sep (split str sep)) = str`