### PR TITLE
clean must also remove the qtest-generated file all_tests.ml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,8 @@ all:
 	$(OCAMLBUILD) $(OCAMLBUILDFLAGS) $(TARGETS)
 
 clean:
-	@${RM} src/batteriesConfig.ml src/batUnix.mli batteries.odocl bench.log
+	@${RM} src/batteriesConfig.ml src/batUnix.mli batteries.odocl \
+	  bench.log $(QTESTDIR)/all_tests.ml
 	@${RM} -r man/
 	@$(OCAMLBUILD) $(OCAMLBUILDFLAGS) -clean
 	@echo " Cleaned up working copy" # Note: ocamlbuild eats the first char!


### PR DESCRIPTION
or when you run 'make test' you can get errors which are outdated
for example after you do an opam switch to test with a different compiler