### PR TITLE
Disable deprecation warnings

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,7 +1,6 @@
 <**/*.ml> : annot
 <**/*.ml> and not <libs/**.ml>: warn_-29
-<src/batArray.mlv>: warn_-3
-true: package(bytes)
+true: package(bytes), warn_-3
 "build": include
 "src": include
 "libs": include


### PR DESCRIPTION
Maintaining compatibility with older OCaml versions while avoiding
deprecation warnings is just too painful for a standard-library-like
project like Batteries: beside -safe-string issues (which can be
checked by enabling -safe-string and fixing errors, it is more
robustly than relying on deprecation warnings), all deprecation
warnings we have are because we rebind or extend deprecated functions,
which we need to do to support our user with older OCaml versions or
that haven't converted out of deprecated functions yet.

We could of course turn any use of a deprecated function into
a version-conditional code to avoid the warning on recent OCaml
versions. A previous version of this patch had for example:

    (* silence the deprecation warning *)
    ##V<4##let lazy_from_val = Lazy.lazy_from_val
    ##V>=4##let lazy_from_val = Lazy.from_val

I doubt this provides any actual advantage in terms of code quality,
while that definitely decreases maintainability, so I think it is just
not worth it.