### PR TITLE
Adds make functions in BatTuple

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+## NEXT_RELEASE
+
+- BatTuple: add Tuple{N}.make : 'a1 -> ... -> 'an -> 'a1 * ... * 'an
+  (Thibault Suzanne)
+
 ## v2.4.0
 
 - BatBitSet: use Bytes instead of String

--- a/src/batTuple.ml
+++ b/src/batTuple.ml
@@ -25,6 +25,8 @@ module Tuple2 = struct
 
   type 'a enumerable = 'a * 'a
 
+  let make a b = (a, b)
+
   external first : 'a * 'b -> 'a = "%field0"
   external second : 'a * 'b -> 'b = "%field1"
 
@@ -102,6 +104,8 @@ module Tuple3 = struct
   type ('a,'b,'c) t = 'a * 'b * 'c
 
   type 'a enumerable = 'a * 'a * 'a
+
+  let make a b c = (a, b, c)
 
   let first (a,_,_) = a
   let second (_,b,_) = b
@@ -193,6 +197,8 @@ module Tuple4 = struct
   type ('a,'b,'c,'d) t = 'a * 'b * 'c * 'd
 
   type 'a enumerable = 'a * 'a * 'a * 'a
+
+  let make a b c d = (a, b, c, d)
 
   let first (a,_,_,_) = a
   let second (_,b,_,_) = b
@@ -304,6 +310,8 @@ module Tuple5 = struct
   type ('a,'b,'c,'d,'e) t = 'a * 'b * 'c * 'd * 'e
 
   type 'a enumerable = 'a * 'a * 'a * 'a * 'a
+
+  let make a b c d e = (a, b, c, d, e)
 
   let first (a,_,_,_,_) = a
   let second (_,b,_,_,_) = b

--- a/src/batTuple.mli
+++ b/src/batTuple.mli
@@ -26,6 +26,9 @@
     Modules are provided for tuples with 2, 3, 4, and 5
     elements. Each provides the following categories of functions.
 
+    Creation. Functions [make] take [n] arguments and build
+    a [n]-tuple.
+
     Projection. Functions [first], [second], [third], [fourth], and [fifth]
     extract a single element. Also, multiple elements can be
     extracted. For example, {!Tuple3.get13} returns the first and
@@ -72,6 +75,8 @@
 module Tuple2 : sig
 
   type ('a,'b) t = 'a * 'b
+
+  val make : 'a -> 'b -> 'a * 'b
 
   external first : 'a * 'b -> 'a = "%field0"
   (** Equivalent to {!Pervasives.fst}. *)
@@ -134,6 +139,8 @@ module Tuple3 : sig
 
   type ('a,'b,'c) t = 'a * 'b * 'c
 
+  val make : 'a -> 'b -> 'c -> 'a * 'b * 'c
+
   val first : 'a * 'b * 'c -> 'a
   val second : 'a * 'b * 'c -> 'b
   val third : 'a * 'b * 'c -> 'c
@@ -194,6 +201,8 @@ end
 module Tuple4 : sig
 
   type ('a,'b,'c,'d) t = 'a * 'b * 'c * 'd
+
+  val make : 'a -> 'b -> 'c -> 'd -> 'a * 'b * 'c * 'd
 
   val first : 'a * 'b * 'c * 'd -> 'a
   val second : 'a * 'b * 'c * 'd -> 'b
@@ -264,6 +273,8 @@ end
 module Tuple5 : sig
 
   type ('a,'b,'c,'d,'e) t = 'a * 'b * 'c * 'd * 'e
+
+  val make : 'a -> 'b -> 'c -> 'd -> 'e -> 'a * 'b * 'c * 'd * 'e
 
   val first : 'a * 'b * 'c * 'd * 'e -> 'a
   val second : 'a * 'b * 'c * 'd * 'e -> 'b


### PR DESCRIPTION
TupleN.make takes n arguments and builds a n-tuple.

No big stuff, but they can be useful e.g. as parameters of other functions, especially since `( , )` is no valid syntax.

Maybe `make` is not the better name: I also have in mind `build` and `create`, and have no idea which one (or which other one) is better.