### PR TITLE
Documentation: fix a small typographic error in BatPervasives

### DIFF
--- a/src/batPervasives.mliv
+++ b/src/batPervasives.mliv
@@ -430,7 +430,7 @@ val ( % ) : ('a -> 'b) -> ('c -> 'a) -> 'c -> 'b
 
 val ( %> ) : ('a -> 'b) -> ('b -> 'c) -> 'a -> 'c
 (** Piping function composition. [f %> g] is [fun x -> g (f x)].
-    Whereas [f % g] applies [g] first and [f] second, [f @> g]
+    Whereas [f % g] applies [g] first and [f] second, [f %> g]
     applies [f], then [g].
     Note that it plays well with pipes, so for instance
     [x |> f %> g %> h |> i %> j] yields the expected result...


### PR DESCRIPTION
This PR fixes a small typographic error in the documentation ( `@>` appearing instead of `%>`) for the BatPervasives module.