### PR TITLE
s/QTest2Lib/qcheck/

### DIFF
--- a/qtest/_tags
+++ b/qtest/_tags
@@ -1,3 +1,3 @@
 true: threads, debug
-<all_tests.*>: package(oUnit), package(QTest2Lib)
+<all_tests.*>: package(oUnit), package(qcheck)
 


### PR DESCRIPTION
Not sure why but qcheck library have been renamed some time ago. As a consequence I could not
make test. This patch change findlib requirement name to pull the proper library. I'm curious why this
was not done already ; maybe batteries dev are supposed to use an older version of qcheck? Or
maybe there is a better way to configure this?
