### PR TITLE
Remove dead code and fix documentation.

### DIFF
--- a/src/batInt.ml
+++ b/src/batInt.ml
@@ -95,9 +95,6 @@ module BaseInt = struct
   external to_int : int -> int = "%identity"
 
 
-  let of_string x =
-    try int_of_string x
-    with Failure err -> raise (Invalid_argument err)
   let to_string = string_of_int
 
   let enum = enum

--- a/src/batInt.mli
+++ b/src/batInt.mli
@@ -136,7 +136,7 @@ val of_string : string -> int
     The string is read in decimal (by default) or in hexadecimal,
     octal or binary if the string begins with [0x], [0o] or [0b]
     respectively.
-    @raise Invalid_argument if the given string is not
+    @raise Failure if the given string is not
     a valid representation of an integer, or if the integer represented
     exceeds the range of integers representable in type [int]. *)
 
@@ -354,7 +354,7 @@ module Safe_int : sig
       The string is read in decimal (by default) or in hexadecimal,
       octal or binary if the string begins with [0x], [0o] or [0b]
       respectively.
-      @raise Invalid_argument if the given string is not
+      @raise Failure if the given string is not
       a valid representation of an integer, or if the integer represented
       exceeds the range of integers representable in type [int]. *)
 


### PR DESCRIPTION
The documentation for BatInt.of_string was misleading:
The current implementation throws Failure, not Invalid_argument.

This is because the implementation being referred to was dead code,
which is being removed in this commit.