### PR TITLE
Add List.{map2i,iter2i}

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,7 @@ Changelog
   (Michael Färber, Gabriel Scherer, Thibault Suzanne)
 
 - Add `List.{map2i,iter2i}`
+  #696
   (Thibault Suzanne)
 
 ## v2.5.3

--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,9 @@ Changelog
   #694
   (Michael Färber, Gabriel Scherer, Thibault Suzanne)
 
+- Add `List.{map2i,iter2i}`
+  (Thibault Suzanne)
+
 ## v2.5.3
 
 Batteries 2.5.3 synchronizes library functions with OCaml 4.04+beta2,

--- a/src/batList.mli
+++ b/src/batList.mli
@@ -262,11 +262,23 @@ val iter2 : ('a -> 'b -> unit) -> 'a list -> 'b list -> unit
     @raise Different_list_size if the two lists have
     different lengths. *)
 
+val iter2i : (int -> 'a -> 'b -> unit) -> 'a list -> 'b list -> unit
+(** [List.iter2i f [a0; a1; ...; an] [b0; b1; ...; bn]] calls in turn
+    [f 0 a0 b0; f 1 a1 b1; ...; f n an bn].
+    @raise Different_list_size if the two lists have
+    different lengths. *)
+
 val map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
 (** [List.map2 f [a0; a1; ...; an] [b0; b1; ...; bn]] is
     [[f a0 b0; f a1 b1; ...; f an bn]].
     @raise Different_list_size if the two lists have
     different lengths.  Tail-recursive. *)
+
+val map2i : (int -> 'a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
+(** [List.map2i f [a0; a1; ...; an] [b0; b1; ...; bn]] is
+    [[f 0 a0 b0; f 1 a1 b1; ...; f n an bn]].
+    @raise Different_list_size if the two lists have
+    different lengths. Tail-recursive. *)
 
 val rev_map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
 (** [List.rev_map2 f l1 l2] gives the same result as

--- a/src/batList.mli
+++ b/src/batList.mli
@@ -265,8 +265,8 @@ val iter2 : ('a -> 'b -> unit) -> 'a list -> 'b list -> unit
 val iter2i : (int -> 'a -> 'b -> unit) -> 'a list -> 'b list -> unit
 (** [List.iter2i f [a0; a1; ...; an] [b0; b1; ...; bn]] calls in turn
     [f 0 a0 b0; f 1 a1 b1; ...; f n an bn].
-    @raise Different_list_size if the two lists have
-    different lengths. *)
+    @raise Different_list_size or Invalid_argument if the two lists
+    have different lengths. *)
 
 val map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
 (** [List.map2 f [a0; a1; ...; an] [b0; b1; ...; bn]] is
@@ -277,8 +277,8 @@ val map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
 val map2i : (int -> 'a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
 (** [List.map2i f [a0; a1; ...; an] [b0; b1; ...; bn]] is
     [[f 0 a0 b0; f 1 a1 b1; ...; f n an bn]].
-    @raise Different_list_size if the two lists have
-    different lengths. Tail-recursive. *)
+    @raise Different_list_size or Invalid_argument if the two lists
+    have different lengths. Tail-recursive. *)
 
 val rev_map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
 (** [List.rev_map2 f l1 l2] gives the same result as

--- a/src/batList.mlv
+++ b/src/batList.mlv
@@ -529,6 +529,17 @@ let map2i f l1 l2 =
   loop 0 dummy l1 l2;
   dummy.tl
 
+(*$T map2i
+  map2i (fun i x y -> i, x, y) [] [] = []
+  map2i (fun i x y -> i, x, y) ['a'] ["b"] = [0, 'a', "b"]
+  map2i (fun i x y -> i, x, y) ['a', 'b', 'c'] ["d", "e", "f"] = \
+    [(0, 'a', "d"); (1, 'b', "e"); (2, 'c', "f")]
+  try ignore (map2i (fun i x y -> i, x, y) [] [0]); false \
+    with Invalid_argument _ -> true
+  try ignore (map2i (fun i x y -> i, x, y) [1, 2, 3] ["4"]); false \
+    with Invalid_argument _ -> true
+*)
+
 let rec iter2 f l1 l2 =
   match l1, l2 with
   | [], [] -> ()
@@ -542,6 +553,19 @@ let iter2i f l1 l2 =
     | h1 :: t1, h2 :: t2 -> f i h1 h2; loop (succ i) t1 t2
     | _ -> invalid_arg "iter2: Different_list_size"
   in loop 0 l1 l2
+
+(*$T iter2i
+  try iter2i (fun _ _ _ -> ()) [1] [1;2;3]; false \
+    with Invalid_argument _ -> true
+  try iter2i (fun _ _ _ -> ()) [1] []; false \
+    with Invalid_argument _ -> true
+*)
+
+(*$T iter2i
+  iter2i (fun _ _ _ -> assert false) [] []; true
+  let r = ref 0 in iter2i (fun i x y -> r := r + i * x + y) [1] [2]; !r = 2
+  let r = ref 0 in iter2i (fun i x y -> r := r + i * x + y) [1; 2] [3; 4]; !r = 9
+*)
 
 let rec fold_left2 f accum l1 l2 =
   match l1, l2 with

--- a/src/batList.mlv
+++ b/src/batList.mlv
@@ -517,11 +517,31 @@ let map2 f l1 l2 =
   loop dummy l1 l2;
   dummy.tl
 
+let map2i f l1 l2 =
+  let rec loop i dst src1 src2 =
+    match src1, src2 with
+    | [], [] -> ()
+    | h1 :: t1, h2 :: t2 ->
+      loop (succ i) (Acc.accum dst (f i h1 h2)) t1 t2
+    | _ -> invalid_arg "map2i: Different_list_size"
+  in
+  let dummy = Acc.dummy () in
+  loop 0 dummy l1 l2;
+  dummy.tl
+
 let rec iter2 f l1 l2 =
   match l1, l2 with
   | [], [] -> ()
   | h1 :: t1, h2 :: t2 -> f h1 h2; iter2 f t1 t2
   | _ -> invalid_arg "iter2: Different_list_size"
+
+let iter2i f l1 l2 =
+  let rec loop i l1 l2 =
+    match l1, l2 with
+    | [], [] -> ()
+    | h1 :: t1, h2 :: t2 -> f i h1 h2; loop (succ i) t1 t2
+    | _ -> invalid_arg "iter2: Different_list_size"
+  in loop 0 l1 l2
 
 let rec fold_left2 f accum l1 l2 =
   match l1, l2 with


### PR DESCRIPTION
I could use a `List.map2i` function, so here it is. For the sake of consistency, I also added `iter2i`, but I don't have enough time×motivation tonight to add a `_2i` version of each `_2` function of `List` (partly because it feels like a process which I'm not sure whether it terminates).

I propose to add `map2i` and `iter2i` anyway since they are written, and to wait until someone needs them (or until my shame takes over my laziness) to write the other ones.