### PR TITLE
Fix qtest+mlv

### DIFF
--- a/build/prefilter.ml
+++ b/build/prefilter.ml
@@ -38,8 +38,9 @@ let print_loc = function
      end
 
 let process_line loc line =
-  if Str.string_match filter_cookie_re line 0 then begin
-    mark_loc_stale loc;
+  if not (Str.string_match filter_cookie_re line 0)
+  then print_endline line
+  else begin
     let cmp = match Str.matched_group 1 line with
     | "<" -> (<) | ">" -> (>) | "=" -> (=)
     | "<=" -> (<=) | ">=" -> (>=)
@@ -52,16 +53,15 @@ let process_line loc line =
     let pass = cmp (major*100+minor) (ver_maj*100+ver_min) in
     if pass
     then print_endline (Str.replace_first filter_cookie_re "" line)
-  end else begin
-    print_loc loc;
-    print_endline line;
-   end
+    else mark_loc_stale loc
+  end
 
 let ( |> ) x f = f x
 
 let process in_channel loc =
   try
     while true do
+      print_loc loc;
       input_line in_channel |> process_line loc;
       incr_loc loc;
     done

--- a/src/batBytes.mlv
+++ b/src/batBytes.mlv
@@ -47,13 +47,13 @@ include Bytes
 ##V<4.3##let lowercase_ascii s = map BatChar.lowercase_ascii s
 
 (*$T uppercase_ascii
-  equal ("five" |> of_string |> capitalize_ascii |> to_string) "FIVE"
-  equal ("école" |> of_string |> captialize_ascii |> to_string) "éCOLE"
+  equal ("five" |> of_string |> uppercase_ascii |> to_string) "FIVE"
+  equal ("école" |> of_string |> uppercase_ascii |> to_string) "éCOLE"
  *)
 
 (*$T lowercase_ascii
-  equal ("FIVE" |> of_string |> capitalize_ascii |> to_string) "five"
-  equal ("ÉCOLE" |> of_string |> captialize_ascii |> to_string) "École"
+  equal ("FIVE" |> of_string |> lowercase_ascii |> to_string) "five"
+  equal ("ÉCOLE" |> of_string |> lowercase_ascii |> to_string) "École"
  *)
 
 ##V<4.3##let map_first_char f s =
@@ -67,10 +67,10 @@ include Bytes
 
 (*$T capitalize_ascii
   equal ("five" |> of_string |> capitalize_ascii |> to_string) "Five"
-  equal ("école" |> of_string |> captialize_ascii |> to_string) "école"
+  equal ("école" |> of_string |> capitalize_ascii |> to_string) "école"
  *)
 
 (*$T uncapitalize_ascii
-  equal ("Five" |> of_string |> capitalize_ascii |> to_string) "Five"
-  equal ("école" |> of_string |> captialize_ascii |> to_string) "école"
+  equal ("Five" |> of_string |> uncapitalize_ascii |> to_string) "five"
+  equal ("École" |> of_string |> uncapitalize_ascii |> to_string) "École"
  *)

--- a/src/batDigest.mlv
+++ b/src/batDigest.mlv
@@ -98,7 +98,7 @@ let compare = String.compare
 (*$T
   equal (string "foo") (string "foo")
   equal (string "") (string "")
-  not <| equal (string "foo") (string "bar")
-  not <| equal (string "foo") (string "foo\0")
-  not <| equal (string "foo") (string "")
+  not @@ equal (string "foo") (string "bar")
+  not @@ equal (string "foo") (string "foo\000")
+  not @@ equal (string "foo") (string "")
  *)

--- a/src/batList.mlv
+++ b/src/batList.mlv
@@ -532,11 +532,11 @@ let map2i f l1 l2 =
 (*$T map2i
   map2i (fun i x y -> i, x, y) [] [] = []
   map2i (fun i x y -> i, x, y) ['a'] ["b"] = [0, 'a', "b"]
-  map2i (fun i x y -> i, x, y) ['a', 'b', 'c'] ["d", "e", "f"] = \
+  map2i (fun i x y -> i, x, y) ['a'; 'b'; 'c'] ["d"; "e"; "f"] = \
     [(0, 'a', "d"); (1, 'b', "e"); (2, 'c', "f")]
   try ignore (map2i (fun i x y -> i, x, y) [] [0]); false \
     with Invalid_argument _ -> true
-  try ignore (map2i (fun i x y -> i, x, y) [1, 2, 3] ["4"]); false \
+  try ignore (map2i (fun i x y -> i, x, y) [1; 2; 3] ["4"]); false \
     with Invalid_argument _ -> true
 *)
 
@@ -563,8 +563,8 @@ let iter2i f l1 l2 =
 
 (*$T iter2i
   iter2i (fun _ _ _ -> assert false) [] []; true
-  let r = ref 0 in iter2i (fun i x y -> r := r + i * x + y) [1] [2]; !r = 2
-  let r = ref 0 in iter2i (fun i x y -> r := r + i * x + y) [1; 2] [3; 4]; !r = 9
+  let r = ref 0 in iter2i (fun i x y -> r := !r + i * x + y) [1] [2]; !r = 2
+  let r = ref 0 in iter2i (fun i x y -> r := !r + i * x + y) [1; 2] [3; 4]; !r = 9
 *)
 
 let rec fold_left2 f accum l1 l2 =

--- a/src/batString.mlv
+++ b/src/batString.mlv
@@ -910,13 +910,13 @@ let numeric_compare s1 s2 =
 ##V<4.3##let lowercase_ascii s = map BatChar.lowercase_ascii s
 
 (*$T uppercase_ascii
-  equal ("five" |> of_string |> capitalize_ascii |> to_string) "FIVE"
-  equal ("école" |> of_string |> captialize_ascii |> to_string) "éCOLE"
+  equal ("five" |> uppercase_ascii) "FIVE"
+  equal ("école" |> uppercase_ascii) "éCOLE"
  *)
 
 (*$T lowercase_ascii
-  equal ("FIVE" |> of_string |> capitalize_ascii |> to_string) "five"
-  equal ("ÉCOLE" |> of_string |> captialize_ascii |> to_string) "École"
+  equal ("FIVE" |> lowercase_ascii) "five"
+  equal ("ÉCOLE" |> lowercase_ascii) "École"
  *)
 
 ##V<4.3##let map_first_char f s =
@@ -930,12 +930,12 @@ let numeric_compare s1 s2 =
 
 (*$T capitalize_ascii
   equal ("five" |> capitalize_ascii) "Five"
-  equal ("école" |> captialize_ascii) "école"
+  equal ("école" |> capitalize_ascii) "école"
  *)
 
 (*$T uncapitalize_ascii
-  equal ("Five" |> capitalize_ascii) "Five"
-  equal ("école" |> captialize_ascii) "école"
+  equal ("Five" |> uncapitalize_ascii) "five"
+  equal ("École" |> uncapitalize_ascii) "École"
  *)
 
 module NumString =


### PR DESCRIPTION
As noticed by @UnixJunkie (thanks!) there was a problem at the interaction between qtest and mlv preprocessing. The present PR fixes it, and fixes the couple mistakes that had been inserted in test files as we did not notice it.

Currently a side-effect of the change is that compilation errors in test files are given in `_build/src/batFoo.ml` instead of `src/batFoo.mlv`, but vincent-hugot/iTeML#45 should solve this.