### PR TITLE
Make Set.to_array use Enum instead of Bigarray

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -26,6 +26,11 @@ Changelog
   #714, #716
   (Gabriel Scherer, request by François Bérenger)
 
+- BatSet: make `to_array` allocate the resulting array at first
+  instead of using Dynarray (faster, uses less memory).
+  #724
+  (Thibault Suzanne)
+
 ## v2.5.3
 
 Batteries 2.5.3 synchronizes library functions with OCaml 4.04+beta2,

--- a/src/batSet.ml
+++ b/src/batSet.ml
@@ -119,7 +119,7 @@ module Concrete = struct
       Empty -> invalid_arg "Set.remove_min_elt"
     | Node(Empty, v, r, _) -> r
     | Node(l, v, r, _) -> bal (remove_min_elt l) v r
-    
+
   (* Merge two trees l and r into one.
      All elements of l must precede the elements of r.
      Assume | height l - height r | <= 2. *)
@@ -332,9 +332,13 @@ module Concrete = struct
   let to_list = elements
 
   let to_array s =
-    let acc = BatDynArray.create () in
-    iter (BatDynArray.add acc) s;
-    BatDynArray.to_array acc
+    match s with
+    | Empty -> [||]
+    | Node (_, e, _, _) ->
+      let arr = Array.make (cardinal s) e in
+      let i = ref 0 in
+      iter (fun x -> Array.unsafe_set arr (!i) x; incr i) s;
+      arr
 
   let rec cons_iter s t = match s with
       Empty -> t


### PR DESCRIPTION
This breaks the dependency Set -> Bigarray -> Int. A quick benchmark
also shows that the new function has comparable performances and can avoid
Out_of_memory.

This is required for having `Int.Set` as an instantion of `Set`, see #712.

```console
# Benchmark results (see `conversion`, smaller is better)

$ ./bench.native old 1000
old: creation 0.000853, conversion 0.000130
$ ./bench.native new 1000
new: creation 0.000819, conversion 0.000198

$ ./bench.native old 10000
old: creation 0.008550, conversion 0.001304
$ ./bench.native new 10000
new: creation 0.004781, conversion 0.000600

$ ./bench.native old 1000000
old: creation 0.280667, conversion 0.041365
$ ./bench.native new 1000000
new: creation 0.279677, conversion 0.050910

$ ./bench.native old 10000000
old: creation 2.750616, conversion 0.562951
$ ./bench.native new 10000000
new: creation 2.752049, conversion 0.501288

$ ./bench.native old 100000000
Fatal error: exception Out of memory
$ ./bench.native new 100000000
new: creation 30.198271, conversion 5.130372
```


```ocaml
(* Benchmark code *)
module S = BatSet.Make (BatInt)

let old_to_array s =
  let acc = BatDynArray.create () in
  S.iter (BatDynArray.add acc) s;
  BatDynArray.to_array acc

let to_array = match Sys.argv.(1) with
  | "old" -> old_to_array
  | "new" -> S.to_array
  | _ -> assert false

let nb_elem = int_of_string (Sys.argv.(2))

let t0 = Unix.gettimeofday ()

let set =
  S.of_enum @@ BatEnum.range 0 ~until:nb_elem

let t1 = Unix.gettimeofday ()

let arr = to_array set

let t2 = Unix.gettimeofday ()

let () =
  Printf.printf "%s: creation %f, conversion %f\n"
    Sys.argv.(1)
    (t1 -. t0)
    (t2 -. t1)

let () =
  if Array.length arr <= 50 then begin
    print_endline "debug:";
    BatArray.print BatInt.print BatIO.stdout arr
  end
```