### PR TITLE
Fix a whitespace oddity in Changelog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -114,8 +114,8 @@ then it is only available under OCaml 4.03.0.
 - BatHashtbl: more efficient modify_opt and modify_def
   (Anders Fugmann)
 - BatFormat: add pp_print_list: ?pp_sep:(formatter -> unit -> unit) ->
-	                        (formatter -> 'a -> unit) ->
-	                        (formatter -> 'a list -> unit)
+				(formatter -> 'a -> unit) ->
+				(formatter -> 'a list -> unit)
 	     and pp_print_text: formatter -> string -> unit
   (Christoph Höger)
 - BatEnum: add uniq_by: ('a -> 'a -> bool) -> 'a t -> 'a t


### PR DESCRIPTION
This seems to be a "tabulation instead of spaces" thing. My editor (emacs with automatic whitespace-cleanup on save) always changes these two particular lines when adding a Change. I would personnally find it comfortable not to manually remove them from the commit every time (and keeping the automatic cleanup for my own editions), but I would also understand if we don't want to (half-)arbitrarily make this change.