### PR TITLE
Common Map and Set functor applications

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,11 @@ Changelog
   #705
   (Ifaz Kabir)
 
+- Add {BatSet,BatMap}.{Int,Int32,Int64,Nativeint,Float,Char,String} as
+  common instantions of the respective `Make` functor.
+  #709, #712
+  (Thibault Suzanne, François Bérenger)
+
 - BatString: add `chop : ?l:int -> ?r:int -> string -> string`
   #714, #716
   (Gabriel Scherer, request by François Bérenger)

--- a/src/batMap.ml
+++ b/src/batMap.ml
@@ -985,7 +985,7 @@ let at_rank_exn = Concrete.at_rank_exn
 (*$Q foldi
   (Q.list Q.small_int) (fun xs -> \
   let m = List.fold_left (fun acc x -> add x true acc) empty xs in \
-  foldi (fun x _y acc -> x :: acc) m [] |> List.rev = List.sort_unique Int.compare xs)
+  foldi (fun x _y acc -> x :: acc) m [] |> List.rev = List.sort_unique BatInt.compare xs)
 *)
 
 let enum = Concrete.enum
@@ -994,7 +994,7 @@ let enum = Concrete.enum
   (Q.list Q.small_int) (fun xs -> \
   List.fold_left (fun acc x -> add x true acc) \
     empty xs |> keys |> List.of_enum \
-  = List.sort_unique Int.compare xs)
+  = List.sort_unique BatInt.compare xs)
 *)
 
 let backwards = Concrete.backwards
@@ -1104,7 +1104,7 @@ module PMap = struct (*$< PMap *)
   let get_cmp {cmp} = cmp
 
   (*$T get_cmp
-    get_cmp (create Int.compare) == Int.compare
+    get_cmp (create BatInt.compare) == BatInt.compare
   *)
 
   let empty = { cmp = Pervasives.compare; map = Concrete.empty }
@@ -1171,8 +1171,8 @@ module PMap = struct (*$< PMap *)
 
   (*$Q foldi
     (Q.list Q.small_int) (fun xs -> \
-    let m = List.fold_left (fun acc x -> add x true acc) (create Int.compare) xs in \
-    foldi (fun x _y acc -> x :: acc) m [] |> List.rev = List.sort_unique Int.compare xs)
+    let m = List.fold_left (fun acc x -> add x true acc) (create BatInt.compare) xs in \
+    foldi (fun x _y acc -> x :: acc) m [] |> List.rev = List.sort_unique BatInt.compare xs)
   *)
 
   let at_rank_exn i m =
@@ -1183,8 +1183,8 @@ module PMap = struct (*$< PMap *)
   (*$Q keys
     (Q.list Q.small_int) (fun xs -> \
     List.fold_left (fun acc x -> add x true acc) \
-    (create Int.compare) xs |> keys |> List.of_enum \
-    = List.sort_unique Int.compare xs)
+    (create BatInt.compare) xs |> keys |> List.of_enum \
+    = List.sort_unique BatInt.compare xs)
   *)
 
   let backwards t = Concrete.backwards t.map

--- a/src/batMap.ml
+++ b/src/batMap.ml
@@ -912,6 +912,13 @@ struct
 
 end
 
+module Int = Make (BatInt)
+module Int32 = Make (BatInt32)
+module Int64 = Make (BatInt64)
+module Nativeint = Make (BatNativeint)
+module Float = Make (BatFloat)
+module Char = Make (BatChar)
+module String = Make (BatString)
 
 (**
  * PMap - Polymorphic maps

--- a/src/batMap.ml
+++ b/src/batMap.ml
@@ -1199,10 +1199,10 @@ module PMap = struct (*$< PMap *)
 
   let max_binding t = Concrete.max_binding t.map
   let min_binding t = Concrete.min_binding t.map
-  let pop_min_binding m = 
+  let pop_min_binding m =
     let mini, rest = Concrete.pop_min_binding m.map in
     (mini, { m with map = rest })
-  let pop_max_binding m = 
+  let pop_max_binding m =
     let maxi, rest = Concrete.pop_max_binding m.map in
     (maxi, { m with map = rest })
 

--- a/src/batMap.mli
+++ b/src/batMap.mli
@@ -363,6 +363,15 @@ module Make (Ord : BatInterfaces.OrderedType) : S with type key = Ord.t
     given a totally ordered type.
 *)
 
+(** {6 Common instantiations} **)
+
+module Int : S with type key = int
+module Int32 : S with type key = int32
+module Int64 : S with type key = int64
+module Nativeint : S with type key = nativeint
+module Float : S with type key = float
+module Char : S with type key = char
+module String : S with type key = string
 
 (** {4 Polymorphic maps}
 
@@ -946,4 +955,3 @@ module PMap : sig
   val get_cmp : ('a, 'b) t -> ('a -> 'a -> int)
 
 end (* PMap module *)
-

--- a/src/batSet.ml
+++ b/src/batSet.ml
@@ -738,6 +738,14 @@ struct
   end
 end
 
+module Int = Make (BatInt)
+module Int32 = Make (BatInt32)
+module Int64 = Make (BatInt64)
+module Nativeint = Make (BatNativeint)
+module Float = Make (BatFloat)
+module Char = Make (BatChar)
+module String = Make (BatString)
+
 module Make2(O1 : OrderedType)(O2 : OrderedType) = struct
   module Set1 = Make(O1)
   module Set2 = Make(O2)

--- a/src/batSet.ml
+++ b/src/batSet.ml
@@ -763,9 +763,9 @@ module Make2(O1 : OrderedType)(O2 : OrderedType) = struct
 end
 
 (*$T
-  let module S1 = Make(Int) in \
-  let module S2 = Make(String) in \
-  let module P = Make2(Int)(String) in \
+  let module S1 = Make(BatInt) in \
+  let module S2 = Make(BatString) in \
+  let module P = Make2(BatInt)(BatString) in \
   P.cartesian_product \
     (List.fold_right S1.add [1;2;3] S1.empty) \
     (List.fold_right S2.add ["a";"b"] S2.empty) \
@@ -787,7 +787,7 @@ module PSet = struct (*$< PSet *)
   let get_cmp {cmp} = cmp
 
   (*$T get_cmp
-    get_cmp (create Int.compare) == Int.compare
+    get_cmp (create BatInt.compare) == BatInt.compare
   *)
 
 

--- a/src/batSet.mli
+++ b/src/batSet.mli
@@ -375,7 +375,7 @@ module Make2(O1 : OrderedType) (O2 : OrderedType) : sig
   (** cartesian product of the two sets *)
 end
 
-(** {6 Polymorphic sets}
+(** {4 Polymorphic sets}
 
     The definitions below describe the polymorphic set interface.
 

--- a/src/batSet.mli
+++ b/src/batSet.mli
@@ -375,6 +375,16 @@ module Make2(O1 : OrderedType) (O2 : OrderedType) : sig
   (** cartesian product of the two sets *)
 end
 
+(** {6 Common instantiations} *)
+
+module Int : S with type elt = int
+module Int32 : S with type elt = int32
+module Int64 : S with type elt = int64
+module Nativeint : S with type elt = nativeint
+module Float : S with type elt = float
+module Char : S with type elt = char
+module String : S with type elt = string
+
 (** {4 Polymorphic sets}
 
     The definitions below describe the polymorphic set interface.


### PR DESCRIPTION
This is yet another proposal for #709 and #712. It does add a dependency from `BatSet` and `BatMake` to the argument modules, but I think it's acceptable, as `Int`, `Float` and other number modules can probably be seen as foundation modules anyway (that won't depend on `Set`), and there already is a dependency from `Set` and `Map` to `Char` and `String` (so we don't actually add one here -- which could be seen as a problem).

I'm all ears about other common instantiations to add.