### PR TITLE
Remove some deprecation warnings in Float for doc generation

### DIFF
--- a/src/batFloat.mliv
+++ b/src/batFloat.mliv
@@ -81,8 +81,12 @@ val sub : float -> float -> float
 val mul : float -> float -> float
 val div : float -> float -> float
 
-external modulo : float -> float -> float = "caml_fmod_float" "fmod" "float"
-external pow : float -> float -> float = "caml_power_float" "pow" "float"
+external modulo : float -> float -> float = "caml_fmod_float" "fmod"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
+external pow : float -> float -> float = "caml_power_float" "pow"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
 
 val min_num : float
 val max_num : float
@@ -100,7 +104,9 @@ external ( - ) : t -> t -> t = "%subfloat"
 external ( * ) : t -> t -> t = "%mulfloat"
 external ( / ) : t -> t -> t = "%divfloat"
 
-external ( ** ) : t -> t -> t = "caml_power_float" "pow" "float"
+external ( ** ) : t -> t -> t = "caml_power_float" "pow"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
 
 val min : float -> float -> float
 val max : float -> float -> float
@@ -121,52 +127,84 @@ val operations : t BatNumber.numeric
    {6 Operations specific to floating-point numbers}
 *)
 
-external sqrt : float -> float = "caml_sqrt_float" "sqrt" "float"
+external sqrt : float -> float = "caml_sqrt_float" "sqrt"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
 (** Square root. *)
 
-external exp : float -> float = "caml_exp_float" "exp" "float"
+external exp : float -> float = "caml_exp_float" "exp"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
 (** Exponential. *)
 
-external log : float -> float = "caml_log_float" "log" "float"
+external log : float -> float = "caml_log_float" "log"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
 (** Natural logarithm. *)
 
-external log10 : float -> float = "caml_log10_float" "log10" "float"
+external log10 : float -> float = "caml_log10_float" "log10"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
 (** Base 10 logarithm. *)
 
-external cos : float -> float = "caml_cos_float" "cos" "float"
+external cos : float -> float = "caml_cos_float" "cos"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
 (** See {!atan2}. *)
 
-external sin : float -> float = "caml_sin_float" "sin" "float"
+external sin : float -> float = "caml_sin_float" "sin"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
 (** See {!atan2}. *)
 
-external tan : float -> float = "caml_tan_float" "tan" "float"
+external tan : float -> float = "caml_tan_float" "tan"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
 (** See {!atan2}. *)
 
-external acos : float -> float = "caml_acos_float" "acos" "float"
+external acos : float -> float = "caml_acos_float" "acos"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
 (** See {!atan2}. *)
 
-external asin : float -> float = "caml_asin_float" "asin" "float"
+external asin : float -> float = "caml_asin_float" "asin"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
 (** See {!atan2}. *)
 
-external atan : float -> float = "caml_atan_float" "atan" "float"
+external atan : float -> float = "caml_atan_float" "atan"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
 (** See {!atan2}. *)
 
-external atan2 : float -> float -> float = "caml_atan2_float" "atan2" "float"
+external atan2 : float -> float -> float = "caml_atan2_float" "atan2"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
 (** The usual trigonometric functions. *)
 
-external cosh : float -> float = "caml_cosh_float" "cosh" "float"
+external cosh : float -> float = "caml_cosh_float" "cosh"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
 (** See {!tanh}. *)
 
-external sinh : float -> float = "caml_sinh_float" "sinh" "float"
+external sinh : float -> float = "caml_sinh_float" "sinh"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
 (** See {!tanh}. *)
 
-external tanh : float -> float = "caml_tanh_float" "tanh" "float"
+external tanh : float -> float = "caml_tanh_float" "tanh"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
 (** The usual hyperbolic trigonometric functions. *)
 
-external ceil : float -> float = "caml_ceil_float" "ceil" "float"
+external ceil : float -> float = "caml_ceil_float" "ceil"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
 (** See {!floor}. *)
 
-external floor : float -> float = "caml_floor_float" "floor" "float"
+external floor : float -> float = "caml_floor_float" "floor"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
 (** Round the given float to an integer value.
     [floor f] returns the greatest integer value less than or
     equal to [f].

--- a/src/batFloat.mlv
+++ b/src/batFloat.mlv
@@ -56,21 +56,51 @@ let approx_equal ?(epsilon = 1e-5) f1 f2 = abs_float (f1 -. f2) < epsilon
    not (approx_equal 1.5 1.45)
 *)
 
-external exp : float -> float = "caml_exp_float" "exp" "float"
-external log : float -> float = "caml_log_float" "log" "float"
-external log10 : float -> float = "caml_log10_float" "log10" "float"
-external cos : float -> float = "caml_cos_float" "cos" "float"
-external sin : float -> float = "caml_sin_float" "sin" "float"
-external tan : float -> float = "caml_tan_float" "tan" "float"
-external acos : float -> float = "caml_acos_float" "acos" "float"
-external asin : float -> float = "caml_asin_float" "asin" "float"
-external atan : float -> float = "caml_atan_float" "atan" "float"
-external atan2 : float -> float -> float = "caml_atan2_float" "atan2" "float"
-external cosh : float -> float = "caml_cosh_float" "cosh" "float"
-external sinh : float -> float = "caml_sinh_float" "sinh" "float"
-external tanh : float -> float = "caml_tanh_float" "tanh" "float"
-external ceil : float -> float = "caml_ceil_float" "ceil" "float"
-external floor : float -> float = "caml_floor_float" "floor" "float"
+external exp : float -> float = "caml_exp_float" "exp"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
+external log : float -> float = "caml_log_float" "log"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
+external log10 : float -> float = "caml_log10_float" "log10"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
+external cos : float -> float = "caml_cos_float" "cos"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
+external sin : float -> float = "caml_sin_float" "sin"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
+external tan : float -> float = "caml_tan_float" "tan"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
+external acos : float -> float = "caml_acos_float" "acos"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
+external asin : float -> float = "caml_asin_float" "asin"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
+external atan : float -> float = "caml_atan_float" "atan"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
+external atan2 : float -> float -> float = "caml_atan2_float" "atan2"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
+external cosh : float -> float = "caml_cosh_float" "cosh"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
+external sinh : float -> float = "caml_sinh_float" "sinh"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
+external tanh : float -> float = "caml_tanh_float" "tanh"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
+external ceil : float -> float = "caml_ceil_float" "ceil"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
+external floor : float -> float = "caml_floor_float" "floor"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
 external frexp : float -> float * int = "caml_frexp_float"
 external ldexp : float -> int -> float = "caml_ldexp_float"
 external modf : float -> float * float = "caml_modf_float"
@@ -146,11 +176,17 @@ let max (x:float) y = if x < y then y else x
 (* Fix definitions for performance *)
 external of_float : float -> float = "%identity"
 external to_float : float -> float = "%identity"
-external sqrt : float -> float = "caml_sqrt_float" "sqrt" "float"
+external sqrt : float -> float = "caml_sqrt_float" "sqrt"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
 external neg : float -> float = "%negfloat"
 external abs : float -> float = "%absfloat"
-external modulo : float -> float -> float = "caml_fmod_float" "fmod" "float"
-external pow : float -> float -> float = "caml_power_float" "pow" "float"
+external modulo : float -> float -> float = "caml_fmod_float" "fmod"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
+external pow : float -> float -> float = "caml_power_float" "pow"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
 external of_int : int -> float = "%floatofint"
 external to_int : float -> int = "%intoffloat"
 external of_float : float -> float = "%identity"
@@ -159,7 +195,9 @@ external ( + ) : t -> t -> t = "%addfloat"
 external ( - ) : t -> t -> t = "%subfloat"
 external ( * ) : t -> t -> t = "%mulfloat"
 external ( / ) : t -> t -> t = "%divfloat"
-external ( ** ) : t -> t -> t = "caml_power_float" "pow" "float"
+external ( ** ) : t -> t -> t = "caml_power_float" "pow"
+##V<4.3##  "float"
+##V>=4.3##  [@@unboxed] [@@noalloc]
 
 
 type bounded = t

--- a/src/batString.mliv
+++ b/src/batString.mliv
@@ -1272,9 +1272,15 @@ sig
   (** {6 Undocumented operations} *)
   external unsafe_get : [> `Read] t -> int -> char = "%string_unsafe_get"
   external unsafe_set : [> `Write] t -> int -> char -> unit = "%string_unsafe_set"
+
   external unsafe_blit :
-    [> `Read] t -> int -> [> `Write] t -> int -> int -> unit = "caml_blit_string" "noalloc"
-  external unsafe_fill : [> `Write] t -> int -> int -> char -> unit = "caml_fill_string" "noalloc"
+    [> `Read] t -> int -> [> `Write] t -> int -> int -> unit = "caml_blit_string"
+##V<4.3##    "noalloc"
+##V>=4.3##    [@@noalloc]
+
+  external unsafe_fill : [> `Write] t -> int -> int -> char -> unit = "caml_fill_string"
+##V<4.3##    "noalloc"
+##V>=4.3##    [@@noalloc]
 
   (**/**)
 
@@ -1316,8 +1322,12 @@ end
 external unsafe_get : string -> int -> char = "%string_unsafe_get"
 external unsafe_set : Bytes.t -> int -> char -> unit = "%string_unsafe_set"
 external unsafe_blit :
-  string -> int -> Bytes.t -> int -> int -> unit = "caml_blit_string" "noalloc"
+  string -> int -> Bytes.t -> int -> int -> unit = "caml_blit_string"
+##V<4.3##  "noalloc"
+##V>=4.3##  [@@noalloc]
 external unsafe_fill :
-  Bytes.t -> int -> int -> char -> unit = "caml_fill_string" "noalloc"
+  Bytes.t -> int -> int -> char -> unit = "caml_fill_string"
+##V<4.3##  "noalloc"
+##V>=4.3##  [@@noalloc]
 
   (**/**)


### PR DESCRIPTION
I simply followed warning recommendations, I didn't add any annotation (maybe we should, at least some float functions in the compiler stdlib have more annotations than what we have). 

I don't really know the details of C interface, so it would be nice if someone can confirm that `"noalloc"` can be replaced with `[@@noalloc]` everywhere, and same for `"float"` and `[@@unboxed] [@@noalloc]`.