### PR TITLE
Add List.fold_map

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -44,7 +44,7 @@ Changelog
   #724
   (Thibault Suzanne)
 
-- BatList: add `fold_map`
+- BatList: add `fold_left_map : ('a -> 'b -> 'a * 'c) -> 'a -> 'b list -> 'a * 'c list`
   #734
   (Thibault Suzanne)
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -46,7 +46,7 @@ Changelog
 
 - BatList: add `fold_left_map : ('a -> 'b -> 'a * 'c) -> 'a -> 'b list -> 'a * 'c list`
   #734
-  (Thibault Suzanne, feature request by Oscar Gauthier)
+  (Thibault Suzanne, review by Gabriel Scherer, request by Oscar Gauthier)
 
 ## v2.5.3
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -46,7 +46,7 @@ Changelog
 
 - BatList: add `fold_left_map : ('a -> 'b -> 'a * 'c) -> 'a -> 'b list -> 'a * 'c list`
   #734
-  (Thibault Suzanne)
+  (Thibault Suzanne, feature request by Oscar Gauthier)
 
 ## v2.5.3
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -44,6 +44,10 @@ Changelog
   #724
   (Thibault Suzanne)
 
+- BatList: add `fold_map`
+  #734
+  (Thibault Suzanne)
+
 ## v2.5.3
 
 Batteries 2.5.3 synchronizes library functions with OCaml 4.04+beta2,

--- a/src/batList.mli
+++ b/src/batList.mli
@@ -231,6 +231,15 @@ val reduce : ('a -> 'a -> 'a) -> 'a list -> 'a
 
     @raise Invalid_argument on empty list. *)
 
+val fold_map : ('a -> 'b -> ('a * 'c)) -> 'a -> 'b list -> 'a * 'c list
+(** If [f x] is [(f_fst x, f_snd x)], [fold_map f acc [a0; a1; ...;
+    an]] returns both [f_fst (... (f_fst (f_fst acc a0) a1) ...) an]
+    (like [fold_left]) and [[f_snd a0; ...; f_snd an]] (like
+    [map]). Tail recursive.
+
+    @since NEXT_RELEASE
+*)
+
 val max : 'a list -> 'a
 (** [max l] returns the largest value in [l] as judged by
     [Pervasives.compare] *)

--- a/src/batList.mli
+++ b/src/batList.mli
@@ -236,12 +236,14 @@ val fold_left_map : ('a -> 'b -> 'a * 'c) -> 'a -> 'b list -> 'a * 'c list
 
     More precisely :
 
-    [fold_left_map f acc [] = (acc, [])]
+    {[
+    fold_left_map f acc [] = (acc, [])
 
-    [fold_left_map f acc (x :: xs) =
-    let (acc', y) = f acc x in
-    let (res, ys) = fold_left_map acc' xs in
-    (res, y :: ys)]
+    fold_left_map f acc (x :: xs) =
+      let (acc', y) = f acc x in
+      let (res, ys) = fold_left_map acc' xs in
+      (res, y :: ys)
+    ]}
 
     @since NEXT_RELEASE
 *)

--- a/src/batList.mli
+++ b/src/batList.mli
@@ -234,6 +234,15 @@ val reduce : ('a -> 'a -> 'a) -> 'a list -> 'a
 val fold_left_map : ('a -> 'b -> 'a * 'c) -> 'a -> 'b list -> 'a * 'c list
 (** Combines [fold_left] and [map]. Tail-recursive.
 
+    More precisely :
+
+    [fold_left_map f acc [] = (acc, [])]
+
+    [fold_left_map f acc (x :: xs) =
+    let (acc', y) = f acc x in
+    let (res, ys) = fold_left_map acc' xs in
+    (res, y :: ys)]
+
     @since NEXT_RELEASE
 *)
 

--- a/src/batList.mli
+++ b/src/batList.mli
@@ -231,11 +231,8 @@ val reduce : ('a -> 'a -> 'a) -> 'a list -> 'a
 
     @raise Invalid_argument on empty list. *)
 
-val fold_map : ('a -> 'b -> ('a * 'c)) -> 'a -> 'b list -> 'a * 'c list
-(** If [f x] is [(f_fst x, f_snd x)], [fold_map f acc [a0; a1; ...;
-    an]] returns both [f_fst (... (f_fst (f_fst acc a0) a1) ...) an]
-    (like [fold_left]) and [[f_snd a0; ...; f_snd an]] (like
-    [map]). Tail recursive.
+val fold_left_map : ('a -> 'b -> 'a * 'c) -> 'a -> 'b list -> 'a * 'c list
+(** Combines [fold_left] and [map]. Tail-recursive.
 
     @since NEXT_RELEASE
 *)

--- a/src/batList.mlv
+++ b/src/batList.mlv
@@ -891,6 +891,25 @@ let fold_righti f l init =
   fold_righti (fun i x acc -> (i, x) :: acc) [0.; 1.] [] = [(0, 0.); (1, 1.)]
 *)
 
+let fold_map f acc = function
+  | [] -> acc, []
+  | h :: t ->
+    let rec loop acc dst = function
+      | [] -> acc
+      | h :: t ->
+        let acc', t' = f acc h in
+        loop acc' (Acc.accum dst t') t
+    in
+    let acc', h' = f acc h in
+    let r = Acc.create h' in
+    let res = loop acc' r t in
+    res, inj r
+
+(*$T fold_map
+  fold_map (fun acc x -> assert false) 0 [] = (0, [])
+  fold_map (fun acc x -> acc ^ x, int_of_string x) "0" ["1"; "2"; "3"] = ("0123", [1; 2; 3])
+*)
+
 let first = hd
 
 let rec last = function

--- a/src/batList.mlv
+++ b/src/batList.mlv
@@ -891,7 +891,7 @@ let fold_righti f l init =
   fold_righti (fun i x acc -> (i, x) :: acc) [0.; 1.] [] = [(0, 0.); (1, 1.)]
 *)
 
-let fold_map f acc = function
+let fold_left_map f acc = function
   | [] -> acc, []
   | h :: t ->
     let rec loop acc dst = function
@@ -905,9 +905,9 @@ let fold_map f acc = function
     let res = loop acc' r t in
     res, inj r
 
-(*$T fold_map
-  fold_map (fun acc x -> assert false) 0 [] = (0, [])
-  fold_map (fun acc x -> acc ^ x, int_of_string x) "0" ["1"; "2"; "3"] = ("0123", [1; 2; 3])
+(*$T fold_left_map
+  fold_left_map (fun acc x -> assert false) 0 [] = (0, [])
+  fold_left_map (fun acc x -> acc ^ x, int_of_string x) "0" ["1"; "2"; "3"] = ("0123", [1; 2; 3])
 *)
 
 let first = hd


### PR DESCRIPTION
```
            _y | ah mais même dans Batteries il y a pas de map_reduce
companion_cube | fold_map ?
companion_cube | j'ai même fold_flat_map :-]
            _y | http://ocamloscope.herokuapp.com/ :-(
            _y | pas dans BatList en tout cas
companion_cube | 2bad
companion_cube | dans containers ya ça
```

Let's race Containers.