### PR TITLE
added bin_annot in _tags

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,4 +1,4 @@
-<**/*.ml> : annot
+<**/*.ml> : annot, bin_annot
 <**/*.ml> and not <libs/**.ml>: warn_-29
 true: package(bytes), warn_-3
 "build": include


### PR DESCRIPTION
that allows to create the .cmt files (no .cmti files however, are they important?), however, the .cmt files are still not installed.
Is there any ocamlbuild wizard in here that would know how to install them?