### PR TITLE
Make Set.choose return the fastest available element

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,10 @@ Changelog
 
 ## v2.6.0 (minor release)
 
+- added Bat{Set,Map,Splay}.any and fixed Bat{Map,Splay}.choose
+  #751
+  (Cedric Cellier)
+
 - added BatList.favg and faster BatList.fsum
   #746
   (Gabriel Scherer, Francois Berenger)

--- a/src/batMap.mli
+++ b/src/batMap.mli
@@ -226,16 +226,23 @@ sig
       along with the rest of the map *)
 
   (* The following documentations comments are from stdlib's map.mli:
-       - choose
        - split
        - singleton
        - partition
   *)
   val choose : 'a t -> (key * 'a)
-  (** Return one binding of the given map, or raise [Not_found] if
-      the map is empty. Which binding is chosen is unspecified,
-      but equal bindings will be chosen for equal maps.
+  (** Return one binding of the given map.
+      Which binding is chosen is unspecified, but equal bindings will be
+      chosen for equal maps.
+      @raise Not_found if the map is empty
   *)
+
+  val any : 'a t -> (key * 'a)
+  (** Return one binding of the given map.
+      The difference with choose is that there is no guarantee that equals
+      elements will be picked for equal sets.
+      This merely returns the quickest binding to get (O(1)).
+      @raise Not_found if the map is empty. *)
 
   val split : key -> 'a t -> ('a t * 'a option * 'a t)
   (** [split x m] returns a triple [(l, data, r)], where
@@ -323,6 +330,8 @@ sig
   (** Operations on {!Map} without exceptions.*)
   module Exceptionless : sig
     val find: key -> 'a t -> 'a option
+    val choose: 'a t -> (key * 'a) option
+    val any: 'a t -> (key * 'a) option
   end
 
   (** Infix operators over a {!BatMap} *)
@@ -490,16 +499,21 @@ val filter_map: ('key -> 'a -> 'b option) -> ('key, 'a) t -> ('key, 'b) t
     pairs [keyi],[bi] such as [f keyi ai = Some bi] (when [f] returns
     [None], the corresponding element of [m] is discarded). *)
 
-(* The following documentations comments are from stdlib's map.mli:
-   - choose
-   - split
-*)
 val choose : ('key, 'a) t -> ('key * 'a)
-(** Return one binding of the given map, or raise [Not_found] if
-    the map is empty. Which binding is chosen is unspecified,
-    but equal bindings will be chosen for equal maps.
+(** Return one binding of the given map.
+    Which binding is chosen is unspecified, but equal bindings will be
+    chosen for equal maps.
+    @raise Not_found if the map is empty
 *)
 
+val any : ('key, 'a) t -> ('key * 'a)
+(** Return one binding of the given map.
+    The difference with choose is that there is no guarantee that equals
+    elements will be picked for equal sets.
+    This merely returns the quickest binding to get (O(1)).
+    @raise Not_found if the map is empty. *)
+
+(* The following documentation comment is from stdlib's map.mli: *)
 val split : 'key -> ('key, 'a) t -> (('key, 'a) t * 'a option * ('key, 'a) t)
 (** [split x m] returns a triple [(l, data, r)], where
       [l] is the map with all the bindings of [m] whose key
@@ -620,6 +634,8 @@ val equal : ('b -> 'b -> bool) -> ('a,'b) t -> ('a, 'b) t -> bool
 (** Exceptionless versions of functions *)
 module Exceptionless : sig
   val find: 'a -> ('a,'b) t -> 'b option
+  val choose: ('a, 'b) t -> ('a * 'b) option
+  val any: ('a, 'b) t -> ('a * 'b) option
 end
 
 
@@ -790,15 +806,21 @@ module PMap : sig
       pairs [keyi],[bi] such as [f keyi ai = Some bi] (when [f] returns
       [None], the corresponding element of [m] is discarded). *)
 
-  (* The following documentations comments are from stdlib's map.mli:
-     - choose
-     - split
-  *)
   val choose : ('key, 'a) t -> ('key * 'a)
-  (** Return one binding of the given map, or raise [Not_found] if
-      the map is empty. Which binding is chosen is unspecified,
-      but equal bindings will be chosen for equal maps.  *)
+  (** Return one binding of the given map.
+      Which binding is chosen is unspecified, but equal bindings will be chosen
+      for equal maps.
+      @raise Not_found if the map is empty. *)
 
+  val any : ('key, 'a) t -> ('key * 'a)
+  (** Return one binding of the given map.
+      The difference with choose is that there is no guarantee that equals
+      elements will be picked for equal sets.
+      This merely returns the quickest binding to get (O(1)).
+      @raise Not_found if the map is empty. *)
+
+
+  (* The following documentation comment is from stdlib's map.mli: *)
   val split : 'key -> ('key, 'a) t -> (('key, 'a) t * 'a option * ('key, 'a) t)
   (** [split x m] returns a triple [(l, data, r)], where
       [l] is the map with all the bindings of [m] whose key
@@ -926,6 +948,8 @@ module PMap : sig
   (** Exceptionless versions of functions *)
   module Exceptionless : sig
     val find: 'a -> ('a,'b) t -> 'b option
+    val choose: ('a, 'b) t -> ('a * 'b) option
+    val any: ('a, 'b) t -> ('a * 'b) option
   end
 
 

--- a/src/batSet.ml
+++ b/src/batSet.ml
@@ -183,10 +183,6 @@ module Concrete = struct
       Empty -> ()
     | Node(l, v, r, _) -> iter f l; f v; iter f r
 
-  let get_root = function
-    | Empty -> raise Not_found
-    | Node(l, v, r, _) -> v
-
   let rec fold f s accu =
     match s with
       Empty -> accu
@@ -391,6 +387,16 @@ module Concrete = struct
   let filter_map cmp f e = fold (fun x acc -> match f x with Some v -> add cmp v acc | _ -> acc) e empty
 
   let choose = min_elt (* I'd rather this chose the root, but okay *)
+  (*$= choose
+    42 (empty |> add 42 |> choose)
+    (empty |> add 0 |> add 1 |> choose) (empty |> add 1 |> add 0 |> choose)
+  *)
+
+  let any = get_root
+  (*$T any
+    empty |> add 42 |> any = 42
+    try empty |> any |> ignore ; false with Not_found -> true
+  *)
 
   let rec for_all p = function
       Empty -> true
@@ -558,6 +564,7 @@ sig
   val pop_max: t -> elt * t
   val max_elt: t -> elt
   val choose: t -> elt
+  val any: t -> elt
   val pop: t -> elt * t
   val enum: t -> elt BatEnum.t
   val backwards: t -> elt BatEnum.t
@@ -582,6 +589,7 @@ sig
     val min_elt: t -> elt option
     val max_elt: t -> elt option
     val choose:  t -> elt option
+    val any:     t -> elt option
     val find: elt -> t -> elt option
   end
   (** Operations on {!Set} with labels. *)
@@ -642,6 +650,7 @@ struct
 
   let max_elt t = Concrete.max_elt (impl_of_t t)
   let choose t = Concrete.choose (impl_of_t t)
+  let any t = Concrete.any (impl_of_t t)
   let pop t =
     let e, t = Concrete.pop (impl_of_t t) in
     e, t_of_impl t
@@ -722,6 +731,7 @@ struct
     let min_elt t = try Some (min_elt t) with Not_found -> None
     let max_elt t = try Some (max_elt t) with Not_found -> None
     let choose  t = try Some (choose t)  with Not_found -> None
+    let any     t = try Some (any t)     with Not_found -> None
     let find  e t = try Some (find e t)  with Not_found -> None
   end
 
@@ -812,6 +822,7 @@ module PSet = struct (*$< PSet *)
   let to_list = elements
   let to_array s = Concrete.to_array s.set
   let choose s = Concrete.choose s.set
+  let any s = Concrete.any s.set
   let min_elt s = Concrete.min_elt s.set
   let pop_min s =
     let mini, others = Concrete.pop_min s.set in
@@ -939,6 +950,7 @@ let to_list = elements
 let to_array s = Concrete.to_array s
 
 let choose s = Concrete.choose s
+let any s = Concrete.any s
 
 let min_elt s = Concrete.min_elt s
 

--- a/src/batSet.mli
+++ b/src/batSet.mli
@@ -250,9 +250,17 @@ sig
       given set. *)
 
   val choose: t -> elt
-  (** Return one element of the given set, or raise [Not_found] if
-      the set is empty. Which element is chosen is unspecified,
-      but equal elements will be chosen for equal sets. *)
+  (** Return one element of the given set.
+      Which element is chosen is unspecified, but equal elements will be
+      chosen for equal sets.
+      @raise Not_found if the set is empty. *)
+
+  val any: t -> elt
+  (** Return one element of the given set.
+      The difference with choose is that there is no guarantee that equals
+      elements will be picked for equal sets.
+      This merely returns the quickest element to get (O(1)).
+      @raise Not_found if the set is empty. *)
 
   val pop : t -> elt * t
   (** returns one element of the set and the set without that element.
@@ -319,6 +327,7 @@ sig
     val min_elt: t -> elt option
     val max_elt: t -> elt option
     val choose:  t -> elt option
+    val any:     t -> elt option
     val find: elt -> t -> elt option
   end
 
@@ -613,6 +622,13 @@ val choose : 'a t -> 'a
 (** returns an arbitrary (but deterministic) element of the given set.
     @raise Not_found if given an empty set. *)
 
+val any: 'a t -> 'a
+(** Return one element of the given set.
+    The difference with choose is that there is no guarantee that equals
+    elements will be picked for equal sets.
+    This merely returns the quickest element to get (O(1)).
+    @raise Not_found if the set is empty. *)
+
 val pop : 'a t -> 'a * 'a t
 (** returns one element of the set and the set without that element.
     @raise Not_found if given an empty set *)
@@ -903,6 +919,14 @@ module PSet : sig
   val choose : 'a t -> 'a
   (** returns an arbitrary (but deterministic) element of the given set.
       @raise Not_found if given an empty set. *)
+
+  val any: 'a t -> 'a
+  (** Return one element of the given set.
+      The difference with choose is that there is no guarantee that equals
+      elements will be picked for equal sets.
+      This merely returns the quickest element to get (O(1)).
+      @raise Not_found if the set is empty. *)
+
 
   val pop : 'a t -> 'a * 'a t
   (** returns one element of the set and the set without that element.

--- a/src/batSplay.ml
+++ b/src/batSplay.ml
@@ -222,6 +222,11 @@ end
 
 module Map (Ord : BatInterfaces.OrderedType) =
 struct
+  (*$inject
+    module TestMap = Splay.Map (Int)
+  *)
+  (*$< TestMap *)
+
   type key = Ord.t
 
   type 'a map = (key * 'a) bst
@@ -354,10 +359,6 @@ struct
     in
     visit acc tr
 
-  let choose tr = match sget tr with
-    | Empty -> raise Not_found
-    | Node (_, kv, _) -> kv
-
   let min_binding tr =
     let tr = sget tr in
     let rec bfind = function
@@ -366,6 +367,22 @@ struct
       | Empty -> raise Not_found
     in
     bfind tr
+
+  let choose = min_binding
+  (*$= choose
+    (empty |> add 0 1 |> add 1 1 |> choose) \
+      (empty |> add 1 1 |> add 0 1 |> choose)
+  *)
+  (*$T choose
+    try choose empty ; false with Not_found -> true
+  *)
+
+  let any tr = match sget tr with
+    | Empty -> raise Not_found
+    | Node (_, kv, _) -> kv
+  (*$T any
+    try any empty ; false with Not_found -> true
+  *)
 
   let pop_min_binding tr =
     let mini = ref (choose tr) in
@@ -536,8 +553,9 @@ struct
   end
 
   module Exceptionless = struct
-    let find k m =
-      try Some (find k m) with Not_found -> None
+    let find k m = try Some (find k m) with Not_found -> None
+    let choose m = try Some (choose m) with Not_found -> None
+    let any m = try Some (any m) with Not_found -> None
   end
 
   module Infix = struct
@@ -658,4 +676,5 @@ struct
     match !maybe_v with
     | None -> raise Not_found
     | Some v -> v, sref tr
+  (*$>*)
 end


### PR DESCRIPTION
I've always assumed Set.choose was returning the quickest element available and
that it had complexity O(1). Instead, I just discovered that it's actually
looking for the smallest element, for no good reason that I can see. A comment
from @thelema suggests that he also expected that: "I'd rather this chose the
root, but okay".

Maybe there were some good reasons at the time not to return the root?  In case
those reasons do not apply any more this patch makes it return the root.