### PR TITLE
Fix make test

### DIFF
--- a/opam
+++ b/opam
@@ -20,7 +20,8 @@ remove: [["ocamlfind" "remove" "batteries"]]
 depends: [
   "ocamlfind" {>= "1.5.3"}
   "ocamlbuild" {build}
-  "qtest" {test & >= "2.0.0"}
+  "qtest" {test & >= "2.0.0" & < "2.5"}
+  "bisect" {test}
 ]
 available: [
   ocaml-version >= "3.12.1"

--- a/src/batArray.mlv
+++ b/src/batArray.mlv
@@ -588,7 +588,7 @@ let min_max a =
 (*$T min_max
     min_max [|1|] = (1, 1)
     min_max [|1;-2;10;3|] = (-2, 10)
-    try min_max [||]; false with Invalid_argument _ -> true
+    try ignore (min_max [||]); false with Invalid_argument _ -> true
 *)
 
 let sum = reduce (+)

--- a/src/batSplay.ml
+++ b/src/batSplay.ml
@@ -374,14 +374,14 @@ struct
       (empty |> add 1 1 |> add 0 1 |> choose)
   *)
   (*$T choose
-    try choose empty ; false with Not_found -> true
+    try ignore (choose empty) ; false with Not_found -> true
   *)
 
   let any tr = match sget tr with
     | Empty -> raise Not_found
     | Node (_, kv, _) -> kv
   (*$T any
-    try any empty ; false with Not_found -> true
+    try ignore (any empty) ; false with Not_found -> true
   *)
 
   let pop_min_binding tr =


### PR DESCRIPTION
Ask opam for a qcheck package that's compatible with batteries (This is not
a proper fix for #756, but make tests work in the meantime).
While at it, ask for bisect.
Also clean some harmless warnings in the compilation of some tests ("expression
should have type unit").