### PR TITLE
Fix an implementation/specification mismatch in BatVect.insert

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,10 @@ Changelog
   #763
   (Varun Gandhi, review by Francois Berenger, Gabriel Scherer, Thibault Suzanne)
 
+- fix documentation of BatVect.insert to match (correct) implementation
+  #766, #767
+  (Gabriel Scherer, report by Varun Gandhi)
+
 - Documents exceptions for List.(min, max)
   #770
   (Varun Gandhi)

--- a/src/batVect.ml
+++ b/src/batVect.ml
@@ -318,8 +318,30 @@ let sub v s l = sub s l v
 let insert start rope r =
   concat (concat (sub r 0 start) rope) (sub r start (length r - start))
 
+(*$T insert
+(of_list [0;1;2;3] |> insert 0 (singleton 10) |> to_list) = [10;0;1;2;3]
+(of_list [0;1;2;3] |> insert 1 (singleton 10) |> to_list) = [0;10;1;2;3]
+(of_list [0;1;2;3] |> insert 2 (singleton 10) |> to_list) = [0;1;10;2;3]
+(of_list [0;1;2;3] |> insert 3 (singleton 10) |> to_list) = [0;1;2;10;3]
+(of_list [0;1;2;3] |> insert 4 (singleton 10) |> to_list) = [0;1;2;3;10]
+try of_list [0;1;2;3] |> insert (-1) (singleton 10) |> to_list |> ignore; false; with _ -> true
+try of_list [0;1;2;3] |> insert 5 (singleton 10) |> to_list |> ignore; false; with _ -> true
+(of_list [] |> insert 0 (singleton 1) |> to_list) = [1]
+(of_list [0] |> insert 0 (singleton 1) |> to_list) = [1; 0]
+(of_list [0] |> insert 1 (singleton 1) |> to_list) = [0; 1]
+*)
+
 let remove start len r =
   concat (sub r 0 start) (sub r (start + len) (length r - start - len))
+
+(*$Q remove
+(Q.pair (Q.pair Q.small_int Q.small_int) (Q.small_int)) \
+(fun ((n1, n2), lr) -> \
+  let init len = of_list (BatList.init len (fun i -> i)) in \
+  let n, lu = min n1 n2, max n1 n2 in \
+  let u, r = init lu, init lr in \
+  equal (=) u (u |> insert n r |> remove n (length r)))
+*)
 
 let to_string r =
   let rec strings l = function

--- a/src/batVect.mli
+++ b/src/batVect.mli
@@ -169,9 +169,9 @@ val sub : 'a t -> int -> int -> 'a t
 
 val insert : int -> 'a t -> 'a t -> 'a t
 (** [insert n r u] returns a copy of the [u] vect where [r] has been
-    inserted between the elements with index [n] and [n + 1] in the
-    original vect. The length of the new vect is
-    [length u + length r].
+    inserted between the elements with index [n - 1] and [n] in the
+    original vect; after insertion, the first element of [r] (if any)
+    is at index [n]. The length of the new vect is [length u + length r].
     Operates in amortized [O(log(size r) + log(size u))] time. *)
 
 val remove : int -> int -> 'a t -> 'a t


### PR DESCRIPTION
`BatVect.insert : int -> 'a t -> 'a t` is specified so that `insert n r u` inserts the rope `r` between the elements of index `n` and `n+1` in `u`. Its implementation does something different, it inserts `r` strictly before the element of index `n` in `u`.

The present commit changes the specification to match the implementation.

First, we expect users to have tested their program instead of trusting (or, unfortunately, even reading) the documentation, so it is likely that the uses of `BatVect.insert` with the current implementation is correct for their needs; changing it would break user program.

Second, we argue that the implemented behavior is actually far more
natural:

- the implementation (in terms of `sub` and `concat`) is nicer -- hear the code!

- the ranges of integer values valid for `insert` is  `0  .. (length u - 1)`, as one would expect, instead of  `(-1) .. (length u - 2)` as with the current specification.

- this gives a very natural invariant between `insert` and  `BatVect.remove : (*start*)int -> (*len*)int -> 'a t -> 'a t`:  `u` is equal to `u |> insert n r |> remove n (length r))`.

fixes #766.