### PR TITLE
Less exceptions -- remove internal uses of `BatReturn`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,7 +22,7 @@ Changelog
     raising/catching than the native OCaml backend.
     Internal exceptions (trough the BatReturn label) have been removed
     from the modules BatString and BatSubstring.
-  (Gabriel Scherer, request by Clément Pit-Claudel)
+  (Gabriel Scherer, request and review by Clément Pit-Claudel)
 
 - Documents exceptions for List.(min, max)
   #770

--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,15 @@ Changelog
   #766, #767
   (Gabriel Scherer, report by Varun Gandhi)
 
+- avoid using exceptions for internal control-flow
+  #768
+    This purely internal change should improve performances when using
+    js_of_ocaml, which generates much slower code for local exceptions
+    raising/catching than the native OCaml backend.
+    Internal exceptions (trough the BatReturn label) have been removed
+    from the modules BatString and BatSubstring.
+  (Gabriel Scherer, request by Clément Pit-Claudel)
+
 - Documents exceptions for List.(min, max)
   #770
   (Varun Gandhi)

--- a/src/batString.mlv
+++ b/src/batString.mlv
@@ -46,13 +46,11 @@ let starts_with str p =
   let len = length p in
   if length str < len then false
   else
-    BatReturn.label
-      (fun label ->
-        for i = 0 to len - 1 do
-          if unsafe_get str i <> unsafe_get p i then
-            BatReturn.return label false
-        done;
-        true)
+    let rec loop str p i =
+      if i = len then true
+      else if unsafe_get str i <> unsafe_get p i then false
+      else loop str p (i + 1)
+    in loop str p 0
 (*$T starts_with
   starts_with "foobarbaz" "foob"
   starts_with "foobarbaz" ""

--- a/src/batString.mlv
+++ b/src/batString.mlv
@@ -132,16 +132,15 @@ let rfind_from str pos sub =
   and len = length str in
   if pos + 1 < 0 || pos + 1 > len then raise (Invalid_argument "String.rfind_from");
   if sublen = 0 then pos + 1 else
-    BatReturn.label (fun label ->
-      for i = pos - sublen + 1 downto 0 do
-        let j = ref 0 in
-        while unsafe_get str (i + !j) = unsafe_get sub !j do
-          incr j;
-          if !j = sublen then BatReturn.return label i
-        done;
-      done;
-      raise Not_found
-    )
+    let rec find ~str ~sub i =
+      if i < 0 then raise Not_found
+      else
+        let rec loop ~str ~sub i j =
+          if j = sublen then i
+          else if unsafe_get str (i + j) <> unsafe_get sub j then find ~str ~sub (i - 1)
+          else loop ~str ~sub i (j + 1)
+        in loop ~str ~sub i 0
+    in find ~str ~sub (pos - sublen + 1)
 (*$Q rfind_from
   (Q.triple Q.string Q.char Q.small_int) ~count:1000 (fun (s, c, ofs) -> \
     let v1 = try `res (rfind_from s ofs (String.make 1 c)) with Not_found -> `nf | Invalid_argument _ -> `inv in \

--- a/src/batString.mlv
+++ b/src/batString.mlv
@@ -69,13 +69,11 @@ let ends_with str p =
   let diff = sl - el in
   if diff < 0 then false (*string is too short*)
   else
-    BatReturn.label
-      (fun label ->
-        for i = 0 to el - 1 do
-          if get str (diff + i) <> get p i then
-            BatReturn.return label false
-        done;
-        true)
+    let rec loop str p diff i =
+      if i = el then true
+      else if get str (diff + i) <> get p i then false
+      else loop str p diff (i + 1)
+    in loop str p diff 0
 (*$T ends_with
   ends_with "foobarbaz" "rbaz"
   ends_with "foobarbaz" ""

--- a/src/batString.mlv
+++ b/src/batString.mlv
@@ -90,16 +90,15 @@ let find_from str pos sub =
   let sublen = length sub in
   if pos < 0 || pos > len then raise (Invalid_argument "String.find_from");
   if sublen = 0 then pos else
-    BatReturn.label (fun label ->
-      for i = pos to len - sublen do
-        let j = ref 0 in
-        while unsafe_get str (i + !j) = unsafe_get sub !j do
-          incr j;
-          if !j = sublen then BatReturn.return label i
-        done;
-      done;
-      raise Not_found
-    )
+    let rec find ~str ~sub i =
+      if i > len - sublen then raise Not_found
+      else
+        let rec loop ~str ~sub i j =
+          if j = sublen then i
+          else if unsafe_get str (i + j) <> unsafe_get sub j then find ~str ~sub (i + 1)
+          else loop ~str ~sub i (j + 1)
+        in loop ~str ~sub i 0
+    in find ~str ~sub pos
 (*$Q find_from
   (Q.triple Q.string Q.char Q.small_int) ~count:1000 (fun (s, c, ofs) -> \
     let v1 = try `res (find_from s ofs (String.make 1 c)) with Not_found -> `nf | Invalid_argument _ -> `inv in \

--- a/src/batSubstring.ml
+++ b/src/batSubstring.ml
@@ -54,10 +54,12 @@ let create len = String.make len '\000', 0, len
 
 let equal (s1,o1,l1) (s2,o2,l2) =
   if l1 <> l2 then false
-  else BatReturn.label (fun label ->
-      for i = 0 to l1-1 do
-        if s1.[i+o1] <> s2.[i+o2] then BatReturn.return label false
-      done; true)
+  else
+    let rec loop i =
+      if i = l1 then true
+      else if s1.[i+o1] <> s2.[i+o2] then false
+      else loop (i + 1)
+    in loop 0
 (*$T equal
    equal (of_string "abc") (of_string "abc") = true
    equal (substring "aba" 0 1) (substring "aba" 2 1) = true

--- a/src/batSubstring.ml
+++ b/src/batSubstring.ml
@@ -56,12 +56,13 @@ let equal (s1,o1,l1) (s2,o2,l2) =
   if l1 <> l2 then false
   else BatReturn.label (fun label ->
       for i = 0 to l1-1 do
-        if s1.[i+o1] <> s1.[i+o2] then BatReturn.return label false
+        if s1.[i+o1] <> s2.[i+o2] then BatReturn.return label false
       done; true)
 (*$T equal
    equal (of_string "abc") (of_string "abc") = true
    equal (substring "aba" 0 1) (substring "aba" 2 1) = true
    equal (substring "aba" 1 1) (substring "aba" 2 1) = false
+   equal (substring "abc" 0 2) (substring "cab" 1 2) = true
 *)
 
 (*


### PR DESCRIPTION
@cpitclaudel reports that uses of `BatString` in the F* compiler become performance bottlenecks when used on a webpage through js_of_ocaml. This comes from the use of the BatReturn module that uses first-class exception declaration and raising for internal control flow -- this seems to be compiled to very slow js code.

This PR removes uses of local exception control-flow from the `String` and `Substring` modules. In passing, I found a bug in Substring.equal (when comparing substrings from different strings) that is fixed.

I have been working on removing these local-exceptions from all of Batteries, and have further PRs down the line (BatVect : easy; BatText : more challenging).