### PR TITLE
Less exceptions in `batVect`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,17 +16,17 @@ Changelog
   (Gabriel Scherer, report by Varun Gandhi)
 
 - avoid using exceptions for internal control-flow
-  #768
+  #768, #769
     This purely internal change should improve performances when using
     js_of_ocaml, which generates much slower code for local exceptions
     raising/catching than the native OCaml backend.
     Internal exceptions (trough the BatReturn label) have been removed
-    from the modules BatString and BatSubstring.
+    from the modules BatString, BatSubstring and BatVect.
   (Gabriel Scherer, request and review by Clément Pit-Claudel)
 
 - added `BatVect.find_opt : ('a -> bool) -> 'a t -> 'a option`
   and BatVect.Make.find_opt
-  #TODO
+  #769
   (Gabriel Scherer)
 
 - Documents exceptions for List.(min, max)

--- a/ChangeLog
+++ b/ChangeLog
@@ -24,6 +24,10 @@ Changelog
     from the modules BatString and BatSubstring.
   (Gabriel Scherer, request and review by Clément Pit-Claudel)
 
+- added `BatVect.find_opt : ('a -> bool) -> 'a t -> 'a option`
+  #TODO
+  (Gabriel Scherer)
+
 - Documents exceptions for List.(min, max)
   #770
   (Varun Gandhi)

--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,7 @@ Changelog
   (Gabriel Scherer, request and review by Clément Pit-Claudel)
 
 - added `BatVect.find_opt : ('a -> bool) -> 'a t -> 'a option`
+  and BatVect.Make.find_opt
   #TODO
   (Gabriel Scherer)
 

--- a/src/batVect.ml
+++ b/src/batVect.ml
@@ -553,6 +553,12 @@ let rec find_opt f = function
       | Some _ as result -> result
       | None -> find_opt f r
     end
+(*$T find_opt
+  [0;1;2;3] |> of_list |> find_opt ((=) 2) = Some 2
+  [0;1;2;3] |> of_list |> find_opt ((=) 4) = None
+  [] |> of_list |> find_opt ((=) 2) = None
+  concat (of_list [0; 1]) (of_list ([2; 3])) |> find_opt (fun n -> n > 0) = Some 1
+*)
 
 let find f v =
   match find_opt f v with

--- a/src/batVect.ml
+++ b/src/batVect.ml
@@ -1215,6 +1215,13 @@ struct
         | None -> find_opt f r
       end
 
+  (*$T find_opt
+    find_opt (fun x -> true) empty = None
+    find_opt (fun x -> true) (of_array [|0;1;2|]) = Some 0
+    find_opt (fun x -> x mod 2 <> 0) (of_array [|0;1;2|]) = Some 1
+    find_opt (fun x -> x mod 2 <> 0) (of_array [|0;2|]) = None
+  *)
+
   let find f v = match find_opt f v with
     | None -> raise Not_found
     | Some a -> a

--- a/src/batVect.mli
+++ b/src/batVect.mli
@@ -269,32 +269,39 @@ val exists : ('a -> bool) -> 'a t -> bool
     [ (p a0) || (p a1) || ... || (p an)]. *)
 
 val find : ('a -> bool) -> 'a t -> 'a
-(** [find p a] returns the first element of vect [a]
+(** [find p v] returns the first element of vect [v]
     that satisfies the predicate [p].
     @raise Not_found if there is no value that satisfies [p] in the
-    vect [a]. *)
+    vect [v]. *)
+
+val find_opt : ('a -> bool) -> 'a t -> 'a option
+(** [find_opt p v] returns [Some a], where [a] is the first element
+    of vect [v] that satisfies the predicate [p], or [None]
+    if no such element exists.
+
+    @since NEXT_RELEASE *)
 
 val mem : 'a -> 'a t -> bool
-(** [mem m a] is true if and only if [m] is equal to an element of [a]. *)
+(** [mem a v] is true if and only if [a] is equal to an element of [v]. *)
 
 val memq : 'a -> 'a t -> bool
 (** Same as {!Vect.mem} but uses physical equality instead of
     structural equality to compare vect elements.  *)
 
 val findi : ('a -> bool) -> 'a t -> int
-(** [findi p a] returns the index of the first element of vect [a]
+(** [findi p v] returns the index of the first element of vect [v]
     that satisfies the predicate [p].
     @raise Not_found if there is no value that satisfies [p] in the
-    vect [a].  *)
+    vect [v].  *)
 
 val filter : ('a -> bool) -> 'a t -> 'a t
-(** [filter f v] returns a vect with the elements [x] from [v] such that
-    [f x] returns [true]. Operates in [O(n)] time. *)
+(** [filter f v] returns a vect with the elements [a] from [v] such that
+    [f a] returns [true]. Operates in [O(n)] time. *)
 
 val filter_map : ('a -> 'b option) -> 'a t -> 'b t
-(** [filter_map f e] returns a vect consisting of all elements
-    [x] such that [f y] returns [Some x] , where [y] is an element
-    of [e]. *)
+(** [filter_map f v] returns a vect consisting of all elements
+    [b] such that [f a] returns [Some b] , where [a] is an element
+    of [v]. *)
 
 val find_all : ('a -> bool) -> 'a t -> 'a t
 (** [find_all] is another name for {!Vect.filter}. *)

--- a/src/batVect.mli
+++ b/src/batVect.mli
@@ -628,6 +628,14 @@ val find : ('a -> bool) -> 'a t -> 'a
     @raise Not_found if there is no value that satisfies [p] in the
     vect [a]. *)
 
+val find_opt : ('a -> bool) -> 'a t -> 'a option
+(** [find_opt p a] returns [Some x], where [x] is the first element
+    of vect [a] that satisfies the predicate [p], or [None]
+    if no such element exists.
+
+    @since NEXT_RELEASE
+*)
+
 val mem : 'a -> 'a t -> bool
 (** [mem m a] is true if and only if [m] is equal to an element of [a]. *)
 


### PR DESCRIPTION
This is a follow-up of #768, eliminating local exceptions for control flow from the BatVect module. As a side-effect, I added a `find_opt : ('a -> bool) -> 'a t -> 'a option` function to the existing `find : ('a -> bool) -> 'a t -> 'a` function.