### PR TITLE
Add Changelog for #763 (BatVect.Labels addition)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,7 +6,11 @@ Changelog
 - added BatArray.min_max
   #757
   (Francois Berenger)
-  
+
+- added a Label module to BatVect
+  #763
+  (Varun Gandhi, review by Francois Berenger, Gabriel Scherer, Thibault Suzanne)
+
 - Documents exceptions for List.(min, max)
   #770
   (Varun Gandhi)


### PR DESCRIPTION
Fix #765 , end of #763.

No test are already present in BatVect, I didnt add them for the Labels module. This should be fixed at some point, although @gasche suggests in #762 that we should change our tests system so maybe we should wait for this.