### PR TITLE
Less exceptions battext

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,12 +16,12 @@ Changelog
   (Gabriel Scherer, report by Varun Gandhi)
 
 - avoid using exceptions for internal control-flow
-  #768, #769
+  #768, #769, #773
     This purely internal change should improve performances when using
     js_of_ocaml, which generates much slower code for local exceptions
     raising/catching than the native OCaml backend.
     Internal exceptions (trough the BatReturn label) have been removed
-    from the modules BatString, BatSubstring and BatVect.
+    from the modules BatString, BatSubstring, BatVect and BatText.
   (Gabriel Scherer, request and review by Clément Pit-Claudel)
 
 - added `BatVect.find_opt : ('a -> bool) -> 'a t -> 'a option`
@@ -34,7 +34,7 @@ Changelog
   (Varun Gandhi)
 
 - BatText: bugfixes in `rindex{,_from}` and `rcontains_from`
-  #TODO
+  #773
   (Gabriel Scherer)
 
 ## v2.6.0 (minor release)

--- a/ChangeLog
+++ b/ChangeLog
@@ -33,6 +33,10 @@ Changelog
   #770
   (Varun Gandhi)
 
+- fix return value of BatText.rindex{,_from}
+  #TODO
+  (Gabriel Scherer)
+
 ## v2.6.0 (minor release)
 
 - added Bat{Set,Map,Splay}.any and fixed Bat{Map,Splay}.choose

--- a/ChangeLog
+++ b/ChangeLog
@@ -33,7 +33,7 @@ Changelog
   #770
   (Varun Gandhi)
 
-- fix return value of BatText.rindex{,_from}
+- BatText: bugfixes in `rindex{,_from}` and `rcontains_from`
   #TODO
   (Gabriel Scherer)
 

--- a/src/batText.ml
+++ b/src/batText.ml
@@ -707,6 +707,15 @@ let contains_from r start char =
     let contains_aux c = if c = char then Return.return label true in
     range_iter contains_aux start (length r - start) r;
     false)
+(*$T contains_from
+  try ignore (contains_from empty 4 (BatUChar.of_char 't')); false with Out_of_bounds -> true
+  try ignore (contains_from (of_string "") 4 (BatUChar.of_char 't')); false with Out_of_bounds -> true
+  contains_from (of_string "batteries") 4 (BatUChar.of_char 't') = false
+  contains_from (of_string "batteries") 3 (BatUChar.of_char 't') = true
+  contains_from (of_string "batteries") 2 (BatUChar.of_char 't') = true
+  contains_from (of_string "batteries") 1 (BatUChar.of_char 't') = true
+  contains_from (of_string "batteries") 4 (BatUChar.of_char 'y') = false
+*)
 
 let rcontains_from = contains_from
 

--- a/src/batText.ml
+++ b/src/batText.ml
@@ -717,7 +717,20 @@ let contains_from r start char =
   contains_from (of_string "batteries") 4 (BatUChar.of_char 'y') = false
 *)
 
-let rcontains_from = contains_from
+let rcontains_from r stop char =
+  Return.with_label (fun label ->
+    let contains_aux c = if c = char then Return.return label true in
+    range_iter contains_aux 0 (stop + 1) r;
+    false)
+(*$T rcontains_from
+  try ignore (rcontains_from empty 4 (BatUChar.of_char 't')); false with Out_of_bounds -> true
+  try ignore (rcontains_from (of_string "") 4 (BatUChar.of_char 't')); false with Out_of_bounds -> true
+  rcontains_from (of_string "batteries") 4 (BatUChar.of_char 't') = true
+  rcontains_from (of_string "batteries") 3 (BatUChar.of_char 't') = true
+  rcontains_from (of_string "batteries") 2 (BatUChar.of_char 't') = true
+  rcontains_from (of_string "batteries") 1 (BatUChar.of_char 't') = false
+  rcontains_from (of_string "batteries") 4 (BatUChar.of_char 'y') = false
+*)
 
 let equal r1 r2 = compare r1 r2 = 0
 

--- a/src/batText.ml
+++ b/src/batText.ml
@@ -492,7 +492,7 @@ let rec iteri ?(base=0) f = function
 
 let rec bulk_iteri_backwards ~top f = function
   | Empty -> ()
-  | Leaf (lens,s) -> f (top-lens) s (* gives f the base position, not the top *)
+  | Leaf (lens,s) -> f top s
   | Concat(l,_,r,cr,_) ->
     bulk_iteri_backwards ~top f r;
     bulk_iteri_backwards ~top:(top-cr) f l
@@ -670,12 +670,23 @@ let rindex r char =
         Return.return label (p+i)
       with Not_found -> ()
     in
-    bulk_iteri_backwards ~top:(length r) index_aux r;
+    bulk_iteri_backwards ~top:(length r - 1) index_aux r;
     raise Not_found)
+(*$T rindex
+  rindex (of_string "batteries") (BatUChar.of_char 't') = 3
+  rindex (of_string "batt") (BatUChar.of_char 't') = 3
+  try ignore (rindex (of_string "batteries") (BatUChar.of_char 'y')); false with Not_found -> true
+*)
 
 let rindex_from r start char =
-  let rsub = left r start in
+  let rsub = left r (start + 1) in
   (rindex rsub char)
+(*$T rindex_from
+  let s = "batteries" in rindex_from (of_string s) (String.length s - 1) (BatUChar.of_char 't') = 3
+  let s = "batteries" in rindex_from (of_string s) 2 (BatUChar.of_char 't') = 2
+  try ignore (rindex_from (of_string "batteries") 4 (BatUChar.of_char 'y')); false with Not_found -> true
+  try ignore (rindex_from (of_string "batteries") 20 (BatUChar.of_char 'y')); false with Out_of_bounds -> true
+*)
 
 let contains r char =
   Return.with_label (fun label ->
@@ -684,6 +695,12 @@ let contains r char =
     in
     bulk_iter contains_aux r;
     false)
+(*$T contains
+  contains empty (BatUChar.of_char 't') = false
+  contains (of_string "") (BatUChar.of_char 't') = false
+  contains (of_string "batteries") (BatUChar.of_char 't') = true
+  contains (of_string "batteries") (BatUChar.of_char 'y') = false
+*)
 
 let contains_from r start char =
   Return.with_label (fun label ->

--- a/src/batText.mli
+++ b/src/batText.mli
@@ -283,13 +283,13 @@ val contains_from : t -> int -> BatUChar.t -> bool
 (** [contains_from s start c] tests if character [c] appears in
     the subrope of [s] starting from [start] to the end of [s].
 
-    @raise Invalid_argument if [start] is not a valid index of [s]. *)
+    @raise Out_of_bounds if [start] is not a valid index of [s]. *)
 
 val rcontains_from : t -> int -> BatUChar.t -> bool
 (** [rcontains_from s stop c] tests if character [c]
     appears in the subrope of [s] starting from the beginning
     of [s] to index [stop].
-    @raise Invalid_argument if [stop] is not a valid index of [s]. *)
+    @raise Out_of_bounds if [stop] is not a valid index of [s]. *)
 
 val find : t -> t -> int
 (** [find s x] returns the starting index of the first occurrence of

--- a/src/batText.mli
+++ b/src/batText.mli
@@ -288,7 +288,7 @@ val contains_from : t -> int -> BatUChar.t -> bool
 val rcontains_from : t -> int -> BatUChar.t -> bool
 (** [rcontains_from s stop c] tests if character [c]
     appears in the subrope of [s] starting from the beginning
-    of [s] to index [stop].
+    of [s] to index [stop] (included).
     @raise Out_of_bounds if [stop] is not a valid index of [s]. *)
 
 val find : t -> t -> int


### PR DESCRIPTION
This is the last PR of the "remove BatReturn" usage series after #768 and #769. After this there are no more uses in the Batteries sources themselves. (They may remain some usage of internal usage of exceptions for control-flow, though.)