### PR TITLE
Update for compatibility with qcheck 0.6

### DIFF
--- a/opam
+++ b/opam
@@ -20,7 +20,8 @@ remove: [["ocamlfind" "remove" "batteries"]]
 depends: [
   "ocamlfind" {>= "1.5.3"}
   "ocamlbuild" {build}
-  "qtest" {test & >= "2.0.0" & < "2.5"}
+  "qtest" {test & >= "2.0.0"}
+  "qcheck" {test & >= "0.6"}
   "bisect" {test}
 ]
 available: [

--- a/opam
+++ b/opam
@@ -20,7 +20,7 @@ remove: [["ocamlfind" "remove" "batteries"]]
 depends: [
   "ocamlfind" {>= "1.5.3"}
   "ocamlbuild" {build}
-  "qtest" {test & >= "2.0.0"}
+  "qtest" {test & >= "2.5"}
   "qcheck" {test & >= "0.6"}
   "bisect" {test}
 ]

--- a/src/batArray.mlv
+++ b/src/batArray.mlv
@@ -175,7 +175,7 @@ let findi p xs =
   in
   loop 0
 (*$Q findi
-  (Q.pair (Q.array Q.small_int) (Q.fun1 Q.small_int Q.bool)) (fun (a, f) -> \
+  (Q.pair (Q.array Q.small_int) (Q.fun1 Q.Observable.int Q.bool)) (fun (a, Q.Fun(_,f)) -> \
     try let index = findi f a in \
         let i = ref (-1) in \
         for_all (fun elt -> incr i; \
@@ -187,7 +187,7 @@ let findi p xs =
 
 let find p xs = xs.(findi p xs)
 (*$Q find
-  (Q.pair (Q.array Q.small_int) (Q.fun1 Q.small_int Q.bool)) (fun (a, f) -> \
+  (Q.pair (Q.array Q.small_int) (Q.fun1 Q.Observable.int Q.bool)) (fun (a, Q.Fun(_,f)) -> \
     let a = map (fun x -> `a x) a in \
     let f (`a x) = f x in\
     try let elt = find f a in \
@@ -217,7 +217,7 @@ let filter p xs =
         assert false (*BISECT-VISIT*)
     )
 (*$Q filter
-  (Q.pair (Q.array Q.small_int) (Q.fun1 Q.small_int Q.bool)) (fun (a, f) -> \
+  (Q.pair (Q.array Q.small_int) (Q.fun1 Q.Observable.int Q.bool)) (fun (a, Q.Fun(_,f)) -> \
     let b = Array.to_list (filter f a) in \
     let b' = List.filter f (Array.to_list a) in \
     List.for_all (fun (x,y) -> x = y) (List.combine b b') \
@@ -276,7 +276,7 @@ let partition p xs =
         r) in
   xs1, xs2
 (*$Q partition
-  (Q.pair (Q.array Q.small_int) (Q.fun1 Q.small_int Q.bool)) (fun (a, f) -> \
+  (Q.pair (Q.array Q.small_int) (Q.fun1 Q.Observable.int Q.bool)) (fun (a, Q.Fun(_,f)) -> \
     let b1, b2 = partition f a in \
     let b1, b2 = Array.to_list b1, Array.to_list b2 in \
     let b1', b2' = List.partition f (Array.to_list a) in \
@@ -370,8 +370,8 @@ let range xs = BatEnum.(--^) 0 (Array.length xs)
 let filter_map p xs =
   of_enum (BatEnum.filter_map p (enum xs))
 (*$Q filter_map
-  (Q.pair (Q.array Q.small_int) (Q.fun1 Q.small_int (Q.option Q.int))) \
-  (fun (a, f) -> \
+  (Q.pair (Q.array Q.small_int) (Q.fun1 Q.Observable.int (Q.option Q.int))) \
+  (fun (a, Q.Fun (_,f)) -> \
     let a' = filter (fun elt -> f elt <> None) a in \
     let a' = map (f %> BatOption.get) a' in \
     let a = filter_map f a in \
@@ -661,8 +661,8 @@ let decorate_stable_sort f xs =
     = [|(0,2);(1,2);(1,3);(1,4)|]
 *)
 (*$Q decorate_stable_sort
-  (Q.pair (Q.array Q.small_int) (Q.fun1 Q.small_int (Q.option Q.int))) \
-    (fun (a, f) -> is_sorted_by f (decorate_stable_sort f a))
+  (Q.pair (Q.array Q.small_int) (Q.fun1 Q.Observable.int (Q.option Q.int))) \
+    (fun (a, Q.Fun(_,f)) -> is_sorted_by f (decorate_stable_sort f a))
 *)
 
 let decorate_fast_sort f xs =
@@ -670,8 +670,8 @@ let decorate_fast_sort f xs =
   let () = fast_sort (fun (i,_) (j,_) -> Pervasives.compare i j) decorated in
   map (fun (_,x) -> x) decorated
 (*$Q decorate_fast_sort
-  (Q.pair (Q.array Q.small_int) (Q.fun1 Q.small_int (Q.option Q.int))) \
-    (fun (a, f) -> is_sorted_by f (decorate_fast_sort f a))
+  (Q.pair (Q.array Q.small_int) (Q.fun1 Q.Observable.int (Q.option Q.int))) \
+    (fun (a, Q.Fun(_,f)) -> is_sorted_by f (decorate_fast_sort f a))
 *)
 
 let bsearch cmp arr x =

--- a/src/batList.mlv
+++ b/src/batList.mlv
@@ -172,8 +172,8 @@ let map f = function
     loop r t;
     inj r
 (*$Q map
-  (Q.pair (Q.fun1 Q.int Q.int) (Q.list Q.small_int)) \
-  (fun (f,l) -> map f l = List.map f l)
+  (Q.pair (Q.fun1 Q.Observable.int Q.int) (Q.list Q.small_int)) \
+  (fun (Q.Fun (_,f),l) -> map f l = List.map f l)
 *)
 
 let rec drop n = function


### PR DESCRIPTION
Unfortunately this does break backwards compatibility with qcheck 0.5,
so there is now an explicit opam dependency on qcheck >= 0.6.

Fixes #756.