### PR TITLE
Backport new 4.05 functions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -41,6 +41,13 @@ Changelog
   #775
   (Gabriel Scherer)
 
+- Support for the new OCaml release 4.05
+  the `*_opt` functions and List.compare_lengths, compare_length_with
+  are also backported to older OCaml releases, so code using them from
+  Batteries should be backwards-compatible
+  #777, #779
+  (Tej Chajed, Gabriel Scherer)
+
 ## v2.6.0 (minor release)
 
 - added Bat{Set,Map,Splay}.any and fixed Bat{Map,Splay}.choose

--- a/src/batBig_int.mliv
+++ b/src/batBig_int.mliv
@@ -180,13 +180,13 @@ val big_int_of_string : string -> big_int
 (** Convert a string to a big integer, in decimal.
     The string consists of an optional [-] or [+] sign,
     followed by one or several decimal digits. *)
-##V>=4.5##val big_int_of_string_opt: string -> big_int option
-##V>=4.5##(** Convert a string to a big integer, in decimal.
-##V>=4.5##    The string consists of an optional [-] or [+] sign,
-##V>=4.5##    followed by one or several decimal digits. Other the function
-##V>=4.5##    returns [None].
-##V>=4.5##    @since 4.05
-##V>=4.5##*)
+val big_int_of_string_opt: string -> big_int option
+(** Convert a string to a big integer, in decimal.
+    The string consists of an optional [-] or [+] sign,
+    followed by one or several decimal digits. Other the function
+    returns [None].
+    @since NEXT_RELEASE
+*)
 
 val to_string_in_binary : big_int -> string
 (** as [string_of_big_int], but in base 2 *)
@@ -249,12 +249,12 @@ val int_of_big_int : big_int -> int
 (** Convert a big integer to a small integer (type [int]).
     @raise Failure if the big integer
     is not representable as a small integer. *)
-##V>=4.5##val int_of_big_int_opt: big_int -> int option
-##V>=4.5##(** Convert a big integer to a small integer (type [int]).  Return
-##V>=4.5##    [None] if the big integer is not representable as a small
-##V>=4.5##    integer.
-##V>=4.5##    @since 4.05
-##V>=4.5##*)
+val int_of_big_int_opt: big_int -> int option
+(** Convert a big integer to a small integer (type [int]).  Return
+    [None] if the big integer is not representable as a small
+    integer.
+    @since NEXT_RELEASE
+*)
 
 val big_int_of_int32 : int32 -> big_int
 (** Convert a 32-bit integer to a big integer. *)
@@ -266,30 +266,30 @@ val int32_of_big_int : big_int -> int32
 (** Convert a big integer to a 32-bit integer.
     @raise Failure if the big integer is outside the
     range [[-2{^31}, 2{^31}-1]]. *)
-##V>=4.5##val int32_of_big_int_opt: big_int -> int32 option
-##V>=4.5##(** Convert a big integer to a 32-bit integer.  Return [None] if the
-##V>=4.5##    big integer is outside the range \[-2{^31}, 2{^31}-1\].
-##V>=4.5##    @since 4.05
-##V>=4.5##*)
+val int32_of_big_int_opt: big_int -> int32 option
+(** Convert a big integer to a 32-bit integer.  Return [None] if the
+    big integer is outside the range \[-2{^31}, 2{^31}-1\].
+    @since NEXT_RELEASE
+*)
 val nativeint_of_big_int : big_int -> nativeint
 (** Convert a big integer to a native integer.
     @raise Failure if the big integer is outside the
     range [[Nativeint.min_int, Nativeint.max_int]]. *)
-##V>=4.5##val nativeint_of_big_int_opt: big_int -> nativeint option
-##V>=4.5##(** Convert a big integer to a native integer. Return [None] if the
-##V>=4.5##    big integer is outside the range [[Nativeint.min_int,
-##V>=4.5##    Nativeint.max_int]];
-##V>=4.5##    @since 4.05
-##V>=4.5##*)
+val nativeint_of_big_int_opt: big_int -> nativeint option
+(** Convert a big integer to a native integer. Return [None] if the
+    big integer is outside the range [[Nativeint.min_int,
+    Nativeint.max_int]];
+    @since NEXT_RELEASE
+*)
 val int64_of_big_int : big_int -> int64
 (** Convert a big integer to a 64-bit integer.
     @raise Failure if the big integer is outside the
     range [[-2{^63}, 2{^63}-1]]. *)
-##V>=4.5##val int64_of_big_int_opt: big_int -> int64 option
-##V>=4.5##(** Convert a big integer to a 64-bit integer. Return [None] if the
-##V>=4.5##    big integer is outside the range \[-2{^63}, 2{^63}-1\].
-##V>=4.5##    @since 4.05
-##V>=4.5##*)
+val int64_of_big_int_opt: big_int -> int64 option
+(** Convert a big integer to a 64-bit integer. Return [None] if the
+    big integer is outside the range \[-2{^63}, 2{^63}-1\].
+    @since NEXT_RELEASE
+*)
 
 val float_of_big_int : big_int -> float
 (** Returns a floating-point number approximating the

--- a/src/batBig_int.mlv
+++ b/src/batBig_int.mlv
@@ -19,6 +19,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *)
 
+
 let big_int_base_default_symbols =
   let s = Bytes.create (10 + 26*2) in
   let set off c k = Bytes.set s k (char_of_int (k - off + (int_of_char c))) in
@@ -172,3 +173,10 @@ let print out t = BatIO.nwrite out (to_string t)
     ((of_int 3 --- of_int 1) /@ to_int |> List.of_enum) [3; 2; 1]
   *)
   (*$>*)
+
+
+##V<4.5##let big_int_of_string_opt s = try Some (big_int_of_string s) with _ -> None
+##V<4.5##let int_of_big_int_opt n = try Some (int_of_big_int n) with _ -> None
+##V<4.5##let int32_of_big_int_opt n = try Some (int32_of_big_int n) with _ -> None
+##V<4.5##let int64_of_big_int_opt n = try Some (int64_of_big_int n) with _ -> None
+##V<4.5##let nativeint_of_big_int_opt n = try Some (nativeint_of_big_int n) with _ -> None

--- a/src/batBigarray.mliv
+++ b/src/batBigarray.mliv
@@ -567,7 +567,7 @@ end
 ##V>=4.5##   of zero-dimensional arrays that only contain a single scalar value.
 ##V>=4.5##   Statically knowing the number of dimensions of the array allows
 ##V>=4.5##   faster operations, and more precise static type-checking.
-##V>=4.5##   @since 4.05.0 *)
+##V>=4.5##   @since NEXT_RELEASE and OCaml 4.05.0 *)
 ##V>=4.5##module Array0 : sig
 ##V>=4.5##  type ('a, 'b, 'c) t = ('a, 'b, 'c) Bigarray.Array0.t
 ##V>=4.5##  (** The type of zero-dimensional big arrays whose elements have
@@ -680,7 +680,7 @@ module Array1 : sig
 ##V>=4.5##     big array.  The integer parameter is the index of the scalar to
 ##V>=4.5##     extract.  See {!Bigarray.Genarray.slice_left} and
 ##V>=4.5##     {!Bigarray.Genarray.slice_right} for more details.
-##V>=4.5##     @since 4.05.0 *)
+##V>=4.5##     @since NEXT_RELEASE and OCaml 4.05.0 *)
 
   external blit: ('a, 'b, 'c) t -> ('a, 'b, 'c) t -> unit
     = "caml_ba_blit"
@@ -1084,7 +1084,7 @@ end
 ##V>=4.5##external genarray_of_array0 :
 ##V>=4.5##  ('a, 'b, 'c) Array0.t -> ('a, 'b, 'c) Genarray.t = "%identity"
 ##V>=4.5##(** Return the generic big array corresponding to the given zero-dimensional
-##V>=4.5##   big array. @since 4.05.0 *)
+##V>=4.5##   big array. @since NEXT_RELEASE and OCaml 4.05.0 *)
 
 external genarray_of_array1 :
   ('a, 'b, 'c) Array1.t -> ('a, 'b, 'c) Genarray.t = "%identity"
@@ -1105,7 +1105,7 @@ external genarray_of_array3 :
 ##V>=4.5##(** Return the zero-dimensional big array corresponding to the given
 ##V>=4.5##   generic big array.  Raise [Invalid_argument] if the generic big array
 ##V>=4.5##   does not have exactly zero dimension.
-##V>=4.5##   @since 4.05.0 *)
+##V>=4.5##   @since NEXT_RELEASE and OCaml 4.05.0 *)
 
 val array1_of_genarray : ('a, 'b, 'c) Genarray.t -> ('a, 'b, 'c) Array1.t
 (** Return the one-dimensional big array corresponding to the given
@@ -1144,7 +1144,7 @@ val reshape : ('a, 'b, 'c) Genarray.t -> int array -> ('a, 'b, 'c) Genarray.t
 ##V>=4.5##val reshape_0 : ('a, 'b, 'c) Genarray.t -> ('a, 'b, 'c) Array0.t
 ##V>=4.5##(** Specialized version of {!Bigarray.reshape} for reshaping to
 ##V>=4.5##   zero-dimensional arrays.
-##V>=4.5##   @since 4.05.0 *)
+##V>=4.5##   @since NEXT_RELEASE and OCaml 4.05.0 *)
 
 val reshape_1 : ('a, 'b, 'c) Genarray.t -> int -> ('a, 'b, 'c) Array1.t
 (** Specialized version of {!Bigarray.reshape} for reshaping to

--- a/src/batBytes.mliv
+++ b/src/batBytes.mliv
@@ -197,10 +197,10 @@ val index : t -> char -> int
 
     Raise [Not_found] if [c] does not occur in [s]. *)
 
-##V>=4.5##val index_opt: bytes -> char -> int option
-##V>=4.5##(** [index_opt s c] returns the index of the first occurrence of byte [c]
-##V>=4.5##    in [s] or [None] if [c] does not occur in [s].
-##V>=4.5##    @since 4.05 *)
+val index_opt: bytes -> char -> int option
+(** [index_opt s c] returns the index of the first occurrence of byte [c]
+    in [s] or [None] if [c] does not occur in [s].
+    @since NEXT_RELEASE *)
 
 val rindex : t -> char -> int
 (** [rindex s c] returns the index of the last occurrence of byte [c]
@@ -208,10 +208,10 @@ val rindex : t -> char -> int
 
     Raise [Not_found] if [c] does not occur in [s]. *)
 
-##V>=4.5##val rindex_opt: bytes -> char -> int option
-##V>=4.5##(** [rindex_opt s c] returns the index of the last occurrence of byte [c]
-##V>=4.5##    in [s] or [None] if [c] does not occur in [s].
-##V>=4.5##    @since 4.05 *)
+val rindex_opt: bytes -> char -> int option
+(** [rindex_opt s c] returns the index of the last occurrence of byte [c]
+    in [s] or [None] if [c] does not occur in [s].
+    @since NEXT_RELEASE *)
 
 val index_from : t -> int -> char -> int
 (** [index_from s i c] returns the index of the first occurrence of
@@ -221,13 +221,13 @@ val index_from : t -> int -> char -> int
     Raise [Invalid_argument] if [i] is not a valid position in [s].
     Raise [Not_found] if [c] does not occur in [s] after position [i]. *)
 
-##V>=4.5##val index_from_opt: bytes -> int -> char -> int option
-##V>=4.5##(** [index_from _opts i c] returns the index of the first occurrence of
-##V>=4.5##    byte [c] in [s] after position [i] or [None] if [c] does not occur in [s] after position [i].
-##V>=4.5##    [Bytes.index_opt s c] is equivalent to [Bytes.index_from_opt s 0 c].
-##V>=4.5##
-##V>=4.5##    Raise [Invalid_argument] if [i] is not a valid position in [s].
-##V>=4.5##    @since 4.05 *)
+val index_from_opt: bytes -> int -> char -> int option
+(** [index_from _opts i c] returns the index of the first occurrence of
+    byte [c] in [s] after position [i] or [None] if [c] does not occur in [s] after position [i].
+    [Bytes.index_opt s c] is equivalent to [Bytes.index_from_opt s 0 c].
+
+    Raise [Invalid_argument] if [i] is not a valid position in [s].
+    @since NEXT_RELEASE *)
 
 val rindex_from : t -> int -> char -> int
 (** [rindex_from s i c] returns the index of the last occurrence of
@@ -237,14 +237,14 @@ val rindex_from : t -> int -> char -> int
     Raise [Invalid_argument] if [i+1] is not a valid position in [s].
     Raise [Not_found] if [c] does not occur in [s] before position [i+1]. *)
 
-##V>=4.5##val rindex_from_opt: bytes -> int -> char -> int option
-##V>=4.5##(** [rindex_from_opt s i c] returns the index of the last occurrence
-##V>=4.5##    of byte [c] in [s] before position [i+1] or [None] if [c] does not
-##V>=4.5##    occur in [s] before position [i+1].  [rindex_opt s c] is equivalent to
-##V>=4.5##    [rindex_from s (Bytes.length s - 1) c].
-##V>=4.5##
-##V>=4.5##    Raise [Invalid_argument] if [i+1] is not a valid position in [s].
-##V>=4.5##    @since 4.05 *)
+val rindex_from_opt: bytes -> int -> char -> int option
+(** [rindex_from_opt s i c] returns the index of the last occurrence
+    of byte [c] in [s] before position [i+1] or [None] if [c] does not
+    occur in [s] before position [i+1].  [rindex_opt s c] is equivalent to
+    [rindex_from s (Bytes.length s - 1) c].
+
+    Raise [Invalid_argument] if [i+1] is not a valid position in [s].
+    @since NEXT_RELEASE *)
 
 val contains : t -> char -> bool
 (** [contains s c] tests if byte [c] appears in [s]. *)

--- a/src/batBytes.mlv
+++ b/src/batBytes.mlv
@@ -74,3 +74,9 @@ include Bytes
   equal ("Five" |> of_string |> uncapitalize_ascii |> to_string) "five"
   equal ("École" |> of_string |> uncapitalize_ascii |> to_string) "École"
  *)
+
+
+##V<4.5##let index_opt b c = try Some (index b c) with _ -> None
+##V<4.5##let rindex_opt b c = try Some (rindex b c) with _ -> None
+##V<4.5##let index_from_opt b i c = try Some (index_from b i c) with _ -> None
+##V<4.5##let rindex_from_opt b i c = try Some (rindex_from b i c) with _ -> None

--- a/src/batInt32.mliv
+++ b/src/batInt32.mliv
@@ -193,9 +193,9 @@ external of_string : string -> int32 = "caml_int32_of_string"
     a valid representation of an integer, or if the integer represented
     exceeds the range of integers representable in type [int32]. *)
 
-##V>=4.5##val of_string_opt: string -> int32 option
-##V>=4.5##(** Same as [of_string], but return [None] instead of raising.
-##V>=4.5##    @since 4.05 *)
+val of_string_opt: string -> int32 option
+(** Same as [of_string], but return [None] instead of raising.
+    @since NEXT_RELEASE *)
 
 val to_string : int32 -> string
 (** Return the string representation of its argument, in signed decimal. *)

--- a/src/batInt32.mlv
+++ b/src/batInt32.mlv
@@ -147,6 +147,7 @@ external to_float : int32 -> float = "caml_int32_to_float"
 ##V>=4.3## "caml_int32_to_float_unboxed" [@@unboxed] [@@noalloc]
 external of_string : string -> int32 = "caml_int32_of_string"
 ##V>=4.5##let of_string_opt = Int32.of_string_opt
+##V<4.5##let of_string_opt n = try Some (Int32.of_string n) with _ -> None
 external of_int64 : int64 -> int32 = "%int64_to_int32"
 external to_int64 : int32 -> int64 = "%int64_of_int32"
 external of_nativeint : nativeint -> int32 = "%int32_of_nativeint"

--- a/src/batInt64.mliv
+++ b/src/batInt64.mliv
@@ -191,9 +191,9 @@ external of_string : string -> int64 = "caml_int64_of_string"
     a valid representation of an integer, or if the integer represented
     exceeds the range of integers representable in type [int64]. *)
 
-##V>=4.5##val of_string_opt: string -> int64 option
-##V>=4.5##(** Same as [of_string], but return [None] instead of raising.
-##V>=4.5##    @since 4.05 *)
+val of_string_opt: string -> int64 option
+(** Same as [of_string], but return [None] instead of raising.
+    @since NEXT_RELEASE *)
 
 val to_string : int64 -> string
 (** Return the string representation of its argument, in decimal. *)

--- a/src/batInt64.mlv
+++ b/src/batInt64.mlv
@@ -57,6 +57,7 @@ external of_nativeint : nativeint -> int64 = "%int64_of_nativeint"
 external to_nativeint : int64 -> nativeint = "%int64_to_nativeint"
 external of_string : string -> int64 = "caml_int64_of_string"
 ##V>=4.5##let of_string_opt = Int64.of_string_opt
+##V<4.5##let of_string_opt n = try Some (Int64.of_string n) with _ -> None
 external bits_of_float : float -> int64 = "caml_int64_bits_of_float"
 ##V>=4.3## "caml_int64_bits_of_float_unboxed" [@@unboxed] [@@noalloc]
 external float_of_bits : int64 -> float = "caml_int64_float_of_bits"

--- a/src/batList.mliv
+++ b/src/batList.mliv
@@ -109,10 +109,11 @@ val at : 'a list -> int -> 'a
 (** [at l n] returns the n-th element of the list [l] or
     @raise Invalid_argument if the index is outside of [l] bounds.  O(l) *)
 
-##V>=4.5##val at_opt : 'a list -> int -> 'a option
-##V>=4.5##(** [at_opt] returns the n-th element of the list [l] or None if the index is
-##V>=4.5##    beyond the length of [l].
-##V>=4.5##    @raise Invalid_argument if the index is negative *)
+val at_opt : 'a list -> int -> 'a option
+(** [at_opt] returns the n-th element of the list [l] or None if the index is
+    beyond the length of [l].
+    @since NEXT_RELEASE
+    @raise Invalid_argument if the index is negative *)
 
 val rev : 'a list -> 'a list
 (** List reversal. *)
@@ -427,11 +428,11 @@ val find : ('a -> bool) -> 'a list -> 'a
     @raise Not_found if there is no value that satisfies [p] in the
     list [l]. *)
 
-##V>=4.5##val find_opt: ('a -> bool) -> 'a list -> 'a option
-##V>=4.5##(** [find_opt p l] returns the first element of the list [l] that
-##V>=4.5##    satisfies the predicate [p], or [None] if there is no value that
-##V>=4.5##    satisfies [p] in the list [l].
-##V>=4.5##    @since 4.05 *)
+val find_opt: ('a -> bool) -> 'a list -> 'a option
+(** [find_opt p l] returns the first element of the list [l] that
+    satisfies the predicate [p], or [None] if there is no value that
+    satisfies [p] in the list [l].
+    @since NEXT_RELEASE *)
 
 val find_exn : ('a -> bool) -> exn -> 'a list -> 'a
 (** [find_exn p e l] returns the first element of [l] such as [p x]
@@ -555,14 +556,14 @@ val assoc : 'a -> ('a * 'b) list -> 'b
     @raise Not_found if there is no value associated with [a] in the
     list [l]. *)
 
-##V>=4.5##val assoc_opt: 'a -> ('a * 'b) list -> 'b option
-##V>=4.5##(** [assoc_opt a l] returns the value associated with key [a] in the list of
-##V>=4.5##   pairs [l]. That is,
-##V>=4.5##   [assoc_opt a [ ...; (a,b); ...] = b]
-##V>=4.5##   if [(a,b)] is the leftmost binding of [a] in list [l].
-##V>=4.5##   Returns [None] if there is no value associated with [a] in the
-##V>=4.5##   list [l].
-##V>=4.5##   @since 4.05 *)
+val assoc_opt: 'a -> ('a * 'b) list -> 'b option
+(** [assoc_opt a l] returns the value associated with key [a] in the list of
+   pairs [l]. That is,
+   [assoc_opt a [ ...; (a,b); ...] = b]
+   if [(a,b)] is the leftmost binding of [a] in list [l].
+   Returns [None] if there is no value associated with [a] in the
+   list [l].
+   @since NEXT_RELEASE *)
 
 val assoc_inv : 'b -> ('a * 'b) list -> 'a
 (** [assoc_inv b l] returns the key associated with value [b] in the list of
@@ -584,10 +585,10 @@ val assq : 'a -> ('a * 'b) list -> 'b
 (** Same as {!List.assoc}, but uses physical equality instead of structural
     equality to compare keys. *)
 
-##V>=4.5##val assq_opt : 'a -> ('a * 'b) list -> 'b option
-##V>=4.5##(** Same as {!List.assoc_opt}, but uses physical equality instead of structural
-##V>=4.5##    equality to compare keys.
-##V>=4.5##    @since 4.05 *)
+val assq_opt : 'a -> ('a * 'b) list -> 'b option
+(** Same as {!List.assoc_opt}, but uses physical equality instead of structural
+    equality to compare keys.
+    @since NEXT_RELEASE *)
 
 val assq_inv : 'b -> ('a * 'b) list -> 'a
 (** Same as {!List.assoc_inv}, but uses physical equality instead of structural
@@ -907,13 +908,13 @@ module Comp (T : Comp) : Comp with type t = T.t list
 val nth : 'a list -> int -> 'a
 (** Obsolete. As [at]. *)
 
-##V>=4.5##val nth_opt: 'a list -> int -> 'a option
-##V>=4.5##(** Return the [n]-th element of the given list.
-##V>=4.5##    The first element (head of the list) is at position 0.
-##V>=4.5##    Return [None] if the list is too short.
-##V>=4.5##    Raise [Invalid_argument "List.nth"] if [n] is negative.
-##V>=4.5##    @since 4.05
-##V>=4.5##*)
+val nth_opt: 'a list -> int -> 'a option
+(** Return the [n]-th element of the given list.
+    The first element (head of the list) is at position 0.
+    Return [None] if the list is too short.
+    Raise [Invalid_argument "List.nth"] if [n] is negative.
+    @since NEXT_RELEASE
+*)
 
 val takewhile :  ('a -> bool) -> 'a list -> 'a list
 (** obsolete, as {!take_while} *)

--- a/src/batList.mliv
+++ b/src/batList.mliv
@@ -91,19 +91,19 @@ val last : 'a list -> 'a
 val length : 'a list -> int
 (** Return the length (number of elements) of the given list. *)
 
-##V>=4.5##val compare_lengths : 'a list -> 'b list -> int
-##V>=4.5##(** Compare the lengths of two lists. [compare_lengths l1 l2] is
-##V>=4.5##   equivalent to [compare (length l1) (length l2)], except that
-##V>=4.5##   the computation stops after itering on the shortest list.
-##V>=4.5##   @since 4.05.0
-##V>=4.5## *)
+val compare_lengths : 'a list -> 'b list -> int
+(** Compare the lengths of two lists. [compare_lengths l1 l2] is
+   equivalent to [compare (length l1) (length l2)], except that
+   the computation stops after itering on the shortest list.
+   @since NEXT_RELEASE
+ *)
 
-##V>=4.5##val compare_length_with : 'a list -> int -> int
-##V>=4.5##(** Compare the length of a list to an integer. [compare_length_with l n] is
-##V>=4.5##   equivalent to [compare (length l) n], except that
-##V>=4.5##   the computation stops after at most [n] iterations on the list.
-##V>=4.5##   @since 4.05.0
-##V>=4.5##*)
+val compare_length_with : 'a list -> int -> int
+(** Compare the length of a list to an integer. [compare_length_with l n] is
+   equivalent to [compare (length l) n], except that
+   the computation stops after at most [n] iterations on the list.
+   @since NEXT_RELEASE
+*)
 
 val at : 'a list -> int -> 'a
 (** [at l n] returns the n-th element of the list [l] or

--- a/src/batList.mlv
+++ b/src/batList.mlv
@@ -55,6 +55,49 @@ let mem_assoc = List.mem_assoc
 let rev_map2 = List.rev_map2
 (* ::VH:: END GLUE *)
 
+let rec compare_lengths la lb = match la, lb with
+  | [], [] -> 0
+  | [], _::_ -> -1
+  | _::_, [] -> 1
+  | _::la, _::lb -> compare_lengths la lb
+
+(*$T compare_lengths
+compare_lengths [] [] = 0
+compare_lengths [] [1] = -1
+compare_lengths [1] [] = 1
+compare_lengths [1; 2] [3; 4] = 0
+compare_lengths [1; 2; 3] [3; 4] = 1
+compare_lengths [1; 2] [2; 3; 4] = -1
+*)
+
+(*$Q compare_lengths
+  (Q.pair (Q.list Q.small_int) (Q.list Q.small_int)) \
+  (fun (la, lb) -> \
+    BatOrd.ord0 (compare_lengths la lb) \
+    = BatOrd.ord0 (Pervasives.compare (length la) (length lb)))
+*)
+
+let rec compare_length_with li n = match li, n with
+  | [], n -> Pervasives.compare 0 n
+  | _::tl, n -> compare_length_with tl (n-1)
+
+(*$T compare_length_with
+compare_length_with [] 0 = 0
+compare_length_with [] 1 = -1
+compare_length_with [1] 0 = 1
+compare_length_with [1; 2] 2 = 0
+compare_length_with [1; 2; 3] 2 = 1
+compare_length_with [1; 2] 3 = -1
+*)
+
+(*$Q compare_length_with
+  (Q.pair (Q.list Q.small_int) Q.small_int) \
+  (fun (li, n) -> \
+    BatOrd.ord0 (compare_length_with li n) \
+    = BatOrd.ord0 (Pervasives.compare (length li) n))
+*)
+
+
 (* Thanks to Jacques Garrigue for suggesting the following structure *)
 type 'a mut_list =  {
   hd: 'a;

--- a/src/batList.mlv
+++ b/src/batList.mlv
@@ -29,10 +29,13 @@ let stable_sort = List.stable_sort
 let sort = List.sort
 let assq = List.assq
 ##V>=4.5##let assq_opt = List.assq_opt
+##V<4.5##let assq_opt k li = try Some (assq k li) with Not_found -> None
 let assoc = List.assoc
 ##V>=4.5##let assoc_opt = List.assoc_opt
+##V<4.5##let assoc_opt k li = try Some (assoc k li) with Not_found -> None
 let find = List.find
 ##V>=4.5##let find_opt = List.find_opt
+##V<4.5##let find_opt p li = try Some (find p li) with Not_found -> None
 let exists = List.exists
 let for_all = List.for_all
 let fold_left = List.fold_left
@@ -106,14 +109,14 @@ let at = nth
   at [1;2;3] 2 = 3
 *)
 
-##V>=4.5##let at_opt l index =
-##V>=4.5##  if index < 0 then invalid_arg at_negative_index_msg;
-##V>=4.5##  try Some (at l index) with Invalid_argument _ -> None
-##V>=4.5##(*$T at_opt
-##V>=4.5##  at_opt [] 0 = None
-##V>=4.5##  try ignore (at_opt [1;2;3] (-1)); false with Invalid_argument _ -> true
-##V>=4.5##  at_opt [1;2;3] 2 = Some 3
-##V>=4.5##*)
+let at_opt l index =
+  if index < 0 then invalid_arg at_negative_index_msg;
+  try Some (at l index) with Invalid_argument _ -> None
+(*$T at_opt
+  at_opt [] 0 = None
+  try ignore (at_opt [1;2;3] (-1)); false with Invalid_argument _ -> true
+  at_opt [1;2;3] 2 = Some 3
+*)
 
 let mem_cmp cmp x l =
   exists (fun y -> cmp x y = 0) l
@@ -372,6 +375,7 @@ let group_consecutive p l =
 *)
 
 ##V>=4.5##let nth_opt = List.nth_opt
+##V<4.5##let nth_opt li n = try Some (nth li n) with _ -> None
 let takewhile = take_while
 let dropwhile = drop_while
 

--- a/src/batNativeint.mliv
+++ b/src/batNativeint.mliv
@@ -204,9 +204,9 @@ external of_string : string -> nativeint = "caml_nativeint_of_string"
     a valid representation of an integer, or if the integer represented
     exceeds the range of integers representable in type [nativeint]. *)
 
-##V>=4.5##val of_string_opt: string -> nativeint option
-##V>=4.5##(** Same as [of_string], but return [None] instead of raising.
-##V>=4.5##    @since 4.05 *)
+val of_string_opt: string -> nativeint option
+(** Same as [of_string], but return [None] instead of raising.
+    @since NEXT_RELEASE *)
 
 val to_string : nativeint -> string
 (** Return the string representation of its argument, in decimal. *)

--- a/src/batNativeint.mlv
+++ b/src/batNativeint.mlv
@@ -74,6 +74,7 @@ external to_int64 : nativeint -> int64 = "%int64_of_nativeint"
 
 external of_string : string -> nativeint = "caml_nativeint_of_string"
 ##V>=4.5##let of_string_opt = Nativeint.of_string_opt
+##V<4.5##let of_string_opt s = try Some (Nativeint.of_string s) with _ -> None
 external format : string -> nativeint -> string = "caml_nativeint_format"
 
 

--- a/src/batPrintexc.mliv
+++ b/src/batPrintexc.mliv
@@ -112,7 +112,7 @@ val print : _ BatInnerIO.output -> exn -> unit
 ##V>=4.5##(** Reraise the exception using the given raw_backtrace for the
 ##V>=4.5##    origin of the exception
 ##V>=4.5##
-##V>=4.5##    @since 4.05.0
+##V>=4.5##    @since NEXT_RELEASE and OCaml 4.05.0
 ##V>=4.5##*)
 
 ##V=4.1##(** {6 Current call stack} *)

--- a/src/batString.mliv
+++ b/src/batString.mliv
@@ -199,11 +199,11 @@ val index : string -> char -> int
 
     @raise Not_found if [c] does not occur in [s]. *)
 
-##V>=4.5##val index_opt: string -> char -> int option
-##V>=4.5##(** [String.index_opt s c] returns the index of the first
-##V>=4.5##    occurrence of character [c] in string [s], or
-##V>=4.5##    [None] if [c] does not occur in [s].
-##V>=4.5##    @since 4.05 *)
+val index_opt: string -> char -> int option
+(** [String.index_opt s c] returns the index of the first
+    occurrence of character [c] in string [s], or
+    [None] if [c] does not occur in [s].
+    @since NEXT_RELEASE *)
 
 val rindex : string -> char -> int
 (** [String.rindex s c] returns the character number of the last
@@ -211,11 +211,11 @@ val rindex : string -> char -> int
 
     @raise Not_found if [c] does not occur in [s]. *)
 
-##V>=4.5##val rindex_opt: string -> char -> int option
-##V>=4.5##(** [String.rindex_opt s c] returns the index of the last occurrence
-##V>=4.5##    of character [c] in string [s], or [None] if [c] does not occur in
-##V>=4.5##    [s].
-##V>=4.5##    @since 4.05 *)
+val rindex_opt: string -> char -> int option
+(** [String.rindex_opt s c] returns the index of the last occurrence
+    of character [c] in string [s], or [None] if [c] does not occur in
+    [s].
+    @since NEXT_RELEASE *)
 
 val index_from : string -> int -> char -> int
 (** [String.index_from s i c] returns the character number of the
@@ -225,16 +225,16 @@ val index_from : string -> int -> char -> int
     @raise Invalid_argument if [i] is not a valid position in [s].
     @raise Not_found if [c] does not occur in [s] after position [i]. *)
 
-##V>=4.5##val index_from_opt: string -> int -> char -> int option
-##V>=4.5##(** [String.index_from_opt s i c] returns the index of the
-##V>=4.5##    first occurrence of character [c] in string [s] after position [i]
-##V>=4.5##    or [None] if [c] does not occur in [s] after position [i].
-##V>=4.5##
-##V>=4.5##    [String.index_opt s c] is equivalent to [String.index_from_opt s 0 c].
-##V>=4.5##    Raise [Invalid_argument] if [i] is not a valid position in [s].
-##V>=4.5##
-##V>=4.5##    @since 4.05
-##V>=4.5##*)
+val index_from_opt: string -> int -> char -> int option
+(** [String.index_from_opt s i c] returns the index of the
+    first occurrence of character [c] in string [s] after position [i]
+    or [None] if [c] does not occur in [s] after position [i].
+
+    [String.index_opt s c] is equivalent to [String.index_from_opt s 0 c].
+    Raise [Invalid_argument] if [i] is not a valid position in [s].
+
+    @since NEXT_RELEASE
+*)
 
 val rindex_from : string -> int -> char -> int
 (** [String.rindex_from s i c] returns the character number of the
@@ -245,18 +245,18 @@ val rindex_from : string -> int -> char -> int
     @raise Invalid_argument if [i+1] is not a valid position in [s].
     @raise Not_found if [c] does not occur in [s] before position [i+1]. *)
 
-##V>=4.5##val rindex_from_opt: string -> int -> char -> int option
-##V>=4.5##(** [String.rindex_from_opt s i c] returns the index of the
-##V>=4.5##   last occurrence of character [c] in string [s] before position [i+1]
-##V>=4.5##   or [None] if [c] does not occur in [s] before position [i+1].
-##V>=4.5##
-##V>=4.5##   [String.rindex_opt s c] is equivalent to
-##V>=4.5##   [String.rindex_from_opt s (String.length s - 1) c].
-##V>=4.5##
-##V>=4.5##   Raise [Invalid_argument] if [i+1] is not a valid position in [s].
-##V>=4.5##
-##V>=4.5##    @since 4.05
-##V>=4.5##*)
+val rindex_from_opt: string -> int -> char -> int option
+(** [String.rindex_from_opt s i c] returns the index of the
+   last occurrence of character [c] in string [s] before position [i+1]
+   or [None] if [c] does not occur in [s] before position [i+1].
+
+   [String.rindex_opt s c] is equivalent to
+   [String.rindex_from_opt s (String.length s - 1) c].
+
+   Raise [Invalid_argument] if [i+1] is not a valid position in [s].
+
+    @since NEXT_RELEASE
+*)
 
 val contains : string -> char -> bool
 (** [String.contains s c] tests if character [c]

--- a/src/batString.mlv
+++ b/src/batString.mlv
@@ -1080,6 +1080,11 @@ struct
   *)
 end (* String.Exceptionless *)
 
+##V<4.5##let index_opt = Exceptionless.index
+##V<4.5##let rindex_opt = Exceptionless.rindex
+##V<4.5##let index_from_opt = Exceptionless.index_from
+##V<4.5##let rindex_from_opt = Exceptionless.rindex_from
+
 module Cap =
 struct
   type 'a t = string

--- a/src/batSys.mliv
+++ b/src/batSys.mliv
@@ -61,11 +61,11 @@ external getenv : string -> string = "caml_sys_getenv"
 (** Return the value associated to a variable in the process
     environment. @raise Not_found if the variable is unbound. *)
 
-##V>=4.5##val getenv_opt: string -> string option
-##V>=4.5##(** Return the value associated to a variable in the process
-##V>=4.5##    environment or [None] if the variable is unbound.
-##V>=4.5##    @since 4.05
-##V>=4.5##*)
+val getenv_opt: string -> string option
+(** Return the value associated to a variable in the process
+    environment or [None] if the variable is unbound.
+    @since 4.05
+*)
 
 external command : string -> int = "caml_sys_system_command"
 (** Execute the given shell command and return its exit code. *)

--- a/src/batSys.mlv
+++ b/src/batSys.mlv
@@ -35,3 +35,5 @@ let files_of d = BatArray.enum (readdir d)
 
 ##V>=4.3##external opaque_identity : 'a -> 'a = "%opaque"
 ##V<4.3##let opaque_identity = BatOpaqueInnerSys.opaque_identity
+
+##V<4.5##let getenv_opt v = try Some (getenv v) with Not_found -> None


### PR DESCRIPTION
This is a followup from #777. Ideally I would like a nice version of this to be merged before our 4.05.0-supporting release -- hopefully this week or the next one.

For now only the *_opt functions are backported. I would like to backport `compare_lengths` and `compare_length_with` before merging. @tchajed seemed to think that `Bigarray.Array0` could also receive some easy work, but I haven't looked at it yet.