### PR TITLE
batNum: handle negatives in of_float_string

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,10 @@ Changelog
 
 ## next minor release
 
+- BatNum: fix of_float_string to handle negative numbers properly
+  #780
+  (Anton Yabchinskiy)
+
 - added BatArray.min_max
   #757
   (Francois Berenger)

--- a/src/batNum.ml
+++ b/src/batNum.ml
@@ -104,11 +104,13 @@ let of_float_string a =
         let frac = pow num10 (of_int (String.length fpart_s)) in
         Infix.(fpart/frac)
     in
-    add ipart fpart
+    if lt_num ipart zero then sub ipart fpart
+    else add ipart fpart
   with Not_found -> of_string a
 
                     (**T
                        of_float_string "2.5" = of_string "5/2"
+                       of_float_string "-2.5" = of_string "-5/2"
                        of_float_string "2." = of_string "2"
                        of_float_string ".5" = of_string "1/2"
                     *)


### PR DESCRIPTION
Before:
```
Num.of_float_string "-2.5" |> Num.to_float;;
- : float = -1.5
```
After:
```
Num.of_float_string "-2.5" |> Num.to_float;;
- : float = -2.5
```