### PR TITLE
add a "num" dependency to mirror upstream opam file

### DIFF
--- a/opam
+++ b/opam
@@ -23,6 +23,7 @@ depends: [
   "qtest" {test & >= "2.5"}
   "qcheck" {test & >= "0.6"}
   "bisect" {test}
+  "num"
 ]
 available: [
   ocaml-version >= "3.12.1"


### PR DESCRIPTION
See https://github.com/ocaml/opam-repository/pull/9341

Note that, if/when "num" is split off the standard distribution, there
will be the question of keeping it or not in Batteries. It could be
come a separate package (batteries-num, depending on batteries) for
example.


This is the "opam preparation work" step of howto/release -- see #781 for the issue about preparing the next minor release.