### PR TITLE
add BatMap.Big_int and BatSet.Big_int modules

### DIFF
--- a/src/batMap.ml
+++ b/src/batMap.ml
@@ -932,6 +932,7 @@ module Nativeint = Make (BatNativeint)
 module Float = Make (BatFloat)
 module Char = Make (BatChar)
 module String = Make (BatString)
+module Big_int = Make (BatBig_int)
 
 (**
  * PMap - Polymorphic maps

--- a/src/batMap.mli
+++ b/src/batMap.mli
@@ -385,6 +385,7 @@ module Nativeint : S with type key = nativeint
 module Float : S with type key = float
 module Char : S with type key = char
 module String : S with type key = string
+module Big_int : S with type key = BatBig_int.t
 
 (** {4 Polymorphic maps}
 

--- a/src/batSet.ml
+++ b/src/batSet.ml
@@ -755,6 +755,7 @@ module Nativeint = Make (BatNativeint)
 module Float = Make (BatFloat)
 module Char = Make (BatChar)
 module String = Make (BatString)
+module Big_int = Make (BatBig_int)
 
 module Make2(O1 : OrderedType)(O2 : OrderedType) = struct
   module Set1 = Make(O1)

--- a/src/batSet.mli
+++ b/src/batSet.mli
@@ -393,6 +393,7 @@ module Nativeint : S with type elt = nativeint
 module Float : S with type elt = float
 module Char : S with type elt = char
 module String : S with type elt = string
+module Big_int : S with type elt = BatBig_int.t
 
 (** {4 Polymorphic sets}
 


### PR DESCRIPTION
In the spirit of already existing (convenient) modules:
- `BatSet.Int`, `BatMap.Int`
- `BatSet.String`, `BatMap.String`
- ...

this PR adds two new similar modules:
- `BatSet.Big_int`
- `BatMap.Big_int`
