### PR TITLE
Revised docs for seq and from_loop, moved seq before from_loop

### DIFF
--- a/src/batLazyList.mli
+++ b/src/batLazyList.mli
@@ -105,17 +105,22 @@ val from_while: (unit -> 'a option) -> 'a t
    results of [next].
    The list ends whenever [next] returns [None]. *)
 
+val seq: 'a -> ('a -> 'a) -> ('a -> bool) -> 'a t
+(**[seq init step cond] creates a lazy list from the successive results
+   of applying [next] to [data], then to the result, etc.  The list
+   continues until the condition [cond] fails.  E.g. [seq 1 ((+) 1) ((>) 100)]
+   returns [[^1, 2, ... 99^]].  To create an infinite lazy list, pass 
+   [(fun _ -> true)] as [cond].  If [cond init] is false, the result is empty. *)
+
 val from_loop: 'b -> ('b -> ('a * 'b)) -> 'a t
 (**[from_loop data next] creates a (possibly infinite) lazy list from
    the successive results of applying [next] to [data], then to the
-   result, etc. The list ends whenever the function raises
-   {!LazyList.No_more_elements}.*)
-
-val seq: 'a -> ('a -> 'a) -> ('a -> bool) -> 'a t
-(** [seq init step cond] creates a sequence of data, which starts
-    from [init],  extends by [step],  until the condition [cond]
-    fails. E.g. [seq 1 ((+) 1) ((>) 100)] returns [[^1, 2, ... 99^]]. If [cond
-    init] is false, the result is empty. *)
+   result, etc.  The list ends whenever the function raises
+   {!LazyList.No_more_elements}.  [next] should returns a pair in which the 
+   first element is typically the previous element of the resulting lazy list.  
+   However, note that [data] and the elements of the resulting lazy list need 
+   not have the same type.  Here is an example in which they do:
+   [from_loop 0 (fun n -> (n, n + 1))] *)
 
 val unfold: 'b -> ('b -> ('a * 'b) option) -> 'a t
 (**[unfold data next] creates a (possibly infinite) lazy list from

--- a/src/batLazyList.mli
+++ b/src/batLazyList.mli
@@ -120,7 +120,7 @@ val from_loop: 'b -> ('b -> ('a * 'b)) -> 'a t
    first element is typically the previous element of the resulting lazy list.  
    However, note that [data] and the elements of the resulting lazy list need 
    not have the same type.  Here is an example in which they do:
-   [from_loop 0 (fun n -> (n, n + 1))] *)
+   [from_loop 0 (fun n -> (n, n + 1))], which returns [^0, 1, 2, ... ^] *)
 
 val unfold: 'b -> ('b -> ('a * 'b) option) -> 'a t
 (**[unfold data next] creates a (possibly infinite) lazy list from

--- a/src/batLazyList.mli
+++ b/src/batLazyList.mli
@@ -120,7 +120,7 @@ val from_loop: 'b -> ('b -> ('a * 'b)) -> 'a t
    first element is typically the previous element of the resulting lazy list.  
    However, note that [data] and the elements of the resulting lazy list need 
    not have the same type.  Here is an example in which they do:
-   [from_loop 0 (fun n -> (n, n + 1))], which returns [^0, 1, 2, ... ^] *)
+   [from_loop 0 (fun n -> (n, n + 1))], which returns [[^0, 1, 2, ... ^]] *)
 
 val unfold: 'b -> ('b -> ('a * 'b) option) -> 'a t
 (**[unfold data next] creates a (possibly infinite) lazy list from


### PR DESCRIPTION
`seq`: Revised basic description to fit first part of `from_loop` doc,
which seems clearer.  Also added note that you can create an infinite
list by passing a function that constantly returns true.

`from_loop`: Gave additional detail about what the `next` function
is supposed to do, and noted that its result pair might contain
different types.  Added a simple example where the types are
the same.  (This example could be done more simpy using `seq`.
I still don't understand the purpose of `from_loop`.)

I moved `seq` before `from_loop` because it's a more basic version of this
kind of operation.  `from_loop` is more specialized, and complicated,
but its name might suggest that it's the normal way of making a lazy
list by repeated application of a function.  Users should see `seq`
first before trying to work out what `from_loop` is for.