### PR TITLE
Revised docs for seq, unfold, from_loop in LazyList

### DIFF
--- a/src/batLazyList.ml
+++ b/src/batLazyList.ml
@@ -74,13 +74,11 @@ let seq data next cond =
     else              Nil
   in lazy (aux data)
 
-
 let unfold (data:'b) (next: 'b -> ('a * 'b) option) =
   let rec aux data = match next data with
     | Some(a,b) -> Cons(a, lazy (aux b))
     | None      -> Nil
   in lazy (aux data)
-
 
 let from_loop (data:'b) (next:'b -> ('a * 'b)) : 'a t=
   let f' data =

--- a/src/batLazyList.mli
+++ b/src/batLazyList.mli
@@ -106,26 +106,52 @@ val from_while: (unit -> 'a option) -> 'a t
    The list ends whenever [next] returns [None]. *)
 
 val seq: 'a -> ('a -> 'a) -> ('a -> bool) -> 'a t
-(**[seq init step cond] creates a lazy list from the successive results
+(**[seq data next cond] creates a lazy list from the successive results
    of applying [next] to [data], then to the result, etc.  The list
    continues until the condition [cond] fails.  E.g. [seq 1 ((+) 1) ((>) 100)]
    returns [[^1, 2, ... 99^]].  To create an infinite lazy list, pass 
    [(fun _ -> true)] as [cond].  If [cond init] is false, the result is empty. *)
 
+val unfold: 'b -> ('b -> ('a * 'b) option) -> 'a t
+(**[unfold data next] creates a (possibly infinite) lazy list from
+   the successive results of applying [next] to [data], then to the
+   result, etc. The list ends whenever [next] returns [None].  [next] 
+   should return an [option] of a pair whose first element will be the
+   current value of the sequence, and whose second element will be passed 
+   (lazily) to [next] in order to compute the following element.  One use 
+   is to allows each element of the resulting sequence to depend on the 
+   previous two elements, as in this definition of a Fibonacci sequence:
+
+   {[
+     let data = (1, 1)
+     let next (x, y) = Some (x, (y, x + y))
+     let fib = unfold data next
+   ]}
+
+   The first element [x] of the pair within [Some] will be the current 
+   value of the sequence; the next value and subsequent value are recorded
+   as [y] and [x + y]. *)
+
 val from_loop: 'b -> ('b -> ('a * 'b)) -> 'a t
 (**[from_loop data next] creates a (possibly infinite) lazy list from
    the successive results of applying [next] to [data], then to the
    result, etc.  The list ends whenever the function raises
-   {!LazyList.No_more_elements}.  [next] should returns a pair in which the 
-   first element is typically the previous element of the resulting lazy list.  
-   However, note that [data] and the elements of the resulting lazy list need 
-   not have the same type.  Here is an example in which they do:
-   [from_loop 0 (fun n -> (n, n + 1))], which returns [[^0, 1, 2, ... ^]] *)
+   {!LazyList.No_more_elements}.  [next] should return a pair whose first 
+   element will be the current value of the sequence, and whose second 
+   element will be passed (lazily) to [next] in order to compute the following
+   element.  One use is to allows each element of the resulting sequence to
+   depend on the previous two elements, as in this definition of a Fibonacci 
+   sequence:
 
-val unfold: 'b -> ('b -> ('a * 'b) option) -> 'a t
-(**[unfold data next] creates a (possibly infinite) lazy list from
-   the successive results of applying [next] to [data], then to the
-   result, etc. The list ends whenever the function returns [None]*)
+   {[
+     let data = (1, 1)
+     let next (x, y) = (x, (y, x + y))
+     let fib = unfold data next
+   ]}
+
+   The first element [x] of the result of [next] will be the current 
+   value of the sequence; the next value and subsequent value are recorded
+   as [y] and [x + y]. *)
 
 val init : int -> (int -> 'a) -> 'a t
 (** Similar to [Array.init], [init n f] returns the lazy list

--- a/src/batLazyList.mli
+++ b/src/batLazyList.mli
@@ -105,17 +105,22 @@ val from_while: (unit -> 'a option) -> 'a t
    results of [next].
    The list ends whenever [next] returns [None]. *)
 
+val seq: 'a -> ('a -> 'a) -> ('a -> bool) -> 'a t
+(**[seq init step cond] creates a lazy list from the successive results
+   of applying [next] to [data], then to the result, etc.  The list
+   continues until the condition [cond] fails.  E.g. [seq 1 ((+) 1) ((>) 100)]
+   returns [[^1, 2, ... 99^]].  To create an infinite lazy list, pass 
+   [(fun _ -> true)] as [cond].  If [cond init] is false, the result is empty. *)
+
 val from_loop: 'b -> ('b -> ('a * 'b)) -> 'a t
 (**[from_loop data next] creates a (possibly infinite) lazy list from
    the successive results of applying [next] to [data], then to the
-   result, etc. The list ends whenever the function raises
-   {!LazyList.No_more_elements}.*)
-
-val seq: 'a -> ('a -> 'a) -> ('a -> bool) -> 'a t
-(** [seq init step cond] creates a sequence of data, which starts
-    from [init],  extends by [step],  until the condition [cond]
-    fails. E.g. [seq 1 ((+) 1) ((>) 100)] returns [[^1, 2, ... 99^]]. If [cond
-    init] is false, the result is empty. *)
+   result, etc.  The list ends whenever the function raises
+   {!LazyList.No_more_elements}.  [next] should returns a pair in which the 
+   first element is typically the previous element of the resulting lazy list.  
+   However, note that [data] and the elements of the resulting lazy list need 
+   not have the same type.  Here is an example in which they do:
+   [from_loop 0 (fun n -> (n, n + 1))] *)
 
 val unfold: 'b -> ('b -> ('a * 'b) option) -> 'a t
 (**[unfold data next] creates a (possibly infinite) lazy list from

--- a/src/batLazyList.mli
+++ b/src/batLazyList.mli
@@ -108,19 +108,20 @@ val from_while: (unit -> 'a option) -> 'a t
 val seq: 'a -> ('a -> 'a) -> ('a -> bool) -> 'a t
 (**[seq data next cond] creates a lazy list from the successive results
    of applying [next] to [data], then to the result, etc.  The list
-   continues until the condition [cond] fails.  E.g. [seq 1 ((+) 1) ((>) 100)]
-   returns [[^1, 2, ... 99^]].  To create an infinite lazy list, pass 
-   [(fun _ -> true)] as [cond].  If [cond init] is false, the result is empty. *)
+   continues until the condition [cond] fails.  For example, 
+   [seq 1 ((+) 1) ((>) 100)] returns [[^1, 2, ... 99^]].  If [cond init] 
+   is false, the result is empty.  To create an infinite lazy list, pass 
+   [(fun _ -> true)] as [cond]. *)
 
 val unfold: 'b -> ('b -> ('a * 'b) option) -> 'a t
 (**[unfold data next] creates a (possibly infinite) lazy list from
    the successive results of applying [next] to [data], then to the
-   result, etc. The list ends whenever [next] returns [None].  [next] 
-   should return an [option] of a pair whose first element will be the
-   current value of the sequence, and whose second element will be passed 
+   result, etc. The list ends whenever [next] returns [None].  The function 
+   [next] should return a pair [option] whose first element will be the
+   current value of the sequence; the second element will be passed 
    (lazily) to [next] in order to compute the following element.  One use 
-   is to allows each element of the resulting sequence to depend on the 
-   previous two elements, as in this definition of a Fibonacci sequence:
+   of [unfold] is to make each element of the resulting sequence to depend 
+   on the previous two elements, as in this Fibonacci sequence definition:
 
    {[
      let data = (1, 1)
@@ -129,18 +130,18 @@ val unfold: 'b -> ('b -> ('a * 'b) option) -> 'a t
    ]}
 
    The first element [x] of the pair within [Some] will be the current 
-   value of the sequence; the next value and subsequent value are recorded
-   as [y] and [x + y]. *)
+   value of the sequence; the next value and the one after that are
+   recorded as [y] and [x + y]. *)
 
 val from_loop: 'b -> ('b -> ('a * 'b)) -> 'a t
 (**[from_loop data next] creates a (possibly infinite) lazy list from
    the successive results of applying [next] to [data], then to the
    result, etc.  The list ends whenever the function raises
-   {!LazyList.No_more_elements}.  [next] should return a pair whose first 
-   element will be the current value of the sequence, and whose second 
+   {!LazyList.No_more_elements}.  The function [next] should return a pair 
+   whose first element will be the current value of the sequence; the second 
    element will be passed (lazily) to [next] in order to compute the following
-   element.  One use is to allows each element of the resulting sequence to
-   depend on the previous two elements, as in this definition of a Fibonacci 
+   element.  One use of [unfold] is to make each element of the resulting sequence 
+   to depend on the previous two elements, as in this definition of a Fibonacci 
    sequence:
 
    {[
@@ -150,8 +151,8 @@ val from_loop: 'b -> ('b -> ('a * 'b)) -> 'a t
    ]}
 
    The first element [x] of the result of [next] will be the current 
-   value of the sequence; the next value and subsequent value are recorded
-   as [y] and [x + y]. *)
+   value of the sequence; the next value and the one after that are 
+   recorded as [y] and [x + y]. *)
 
 val init : int -> (int -> 'a) -> 'a t
 (** Similar to [Array.init], [init n f] returns the lazy list

--- a/src/batLazyList.mli
+++ b/src/batLazyList.mli
@@ -120,7 +120,7 @@ val from_loop: 'b -> ('b -> ('a * 'b)) -> 'a t
    first element is typically the previous element of the resulting lazy list.  
    However, note that [data] and the elements of the resulting lazy list need 
    not have the same type.  Here is an example in which they do:
-   [from_loop 0 (fun n -> (n, n + 1))] *)
+   [from_loop 0 (fun n -> (n, n + 1))], which returns [^0, 1, 2, ... ^] *)
 
 val unfold: 'b -> ('b -> ('a * 'b) option) -> 'a t
 (**[unfold data next] creates a (possibly infinite) lazy list from

--- a/src/batLazyList.mli
+++ b/src/batLazyList.mli
@@ -120,7 +120,7 @@ val from_loop: 'b -> ('b -> ('a * 'b)) -> 'a t
    first element is typically the previous element of the resulting lazy list.  
    However, note that [data] and the elements of the resulting lazy list need 
    not have the same type.  Here is an example in which they do:
-   [from_loop 0 (fun n -> (n, n + 1))], which returns [^0, 1, 2, ... ^] *)
+   [from_loop 0 (fun n -> (n, n + 1))], which returns [[^0, 1, 2, ... ^]] *)
 
 val unfold: 'b -> ('b -> ('a * 'b) option) -> 'a t
 (**[unfold data next] creates a (possibly infinite) lazy list from


### PR DESCRIPTION
The start of the `seq` docs are now molded on start of the docs for `unfold` and `from_loop`, which I think was clearer.  Also added a note about how to create an infinite list.

`unfold`, `from_loop`: Added explanation of the signature of `next` and what it's for.  Added fibonacci example (which @gasche 

I also reordered the signatures so that the documentation would appear in an order that helps understanding a little bit.  `seq` is first because it's the simpler version, and `unfold` and `from_loop` are now adjacent since they do almost the same thing.  (`from_loop` is just a wrapper around `unfold`.)

Similar changes might be relevant for other modules such as `Enum`, but that can wait for another PR.