### PR TITLE
BatInt.Safe_int.mul performance improvements

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,9 @@ Changelog
 - add `BatString.count_string: string -> string -> int`
   #799
   (Francois Berenger)
+- Int: optimized implementation of Safe_int.mul
+  #808
+  (Max Mouratov)
 
 ## v2.8.0 (minor release)
 

--- a/src/batInt.ml
+++ b/src/batInt.ml
@@ -255,7 +255,7 @@ module BaseSafeInt = struct
 
   let mul (a: int) (b: int) : int =
     let open Pervasives in
-    if ((abs a) lor (abs b)) asr mul_shift_bits <> 0
+    if (a lor b) asr mul_shift_bits <> 0
     then begin match (a > 0, b > 0) with
       | (true, true) when a > (max_int / b) ->
           raise BatNumber.Overflow


### PR DESCRIPTION
This patch makes the fast-path of `BatInt.Safe_int.mul` less expensive, by getting rid of the absolute value computation (which incurs branching). The downside is that the fast-path supports only non-negative integers from now on.

I am responsible for making the fast-path support negative numbers (#590). It made sense for a particular application of mine, but further experience showed that multiplication of positive integers is much more common in practice, in a wide variety of situations.