### PR TITLE
disable print_string_cap_ro/rw in battop to match #673

### DIFF
--- a/battop.ml
+++ b/battop.ml
@@ -63,8 +63,10 @@ open Batteries;;
 #install_printer BatteriesPrint.print_uchar;;
 #install_printer BatteriesPrint.print_ustring;;
 #install_printer BatteriesPrint.print_rope;;
+(*
 #install_printer BatteriesPrint.print_string_cap_rw;;
 #install_printer BatteriesPrint.print_string_cap_ro;;
+ *)
 #install_printer BatteriesPrint.string_dynarray;;
 #install_printer BatteriesPrint.int_dynarray;;
 #install_printer BatteriesPrint.char_dynarray;;


### PR DESCRIPTION
I was getting errors when starting up the REPL. This fixes it by commenting out lines that used functions disabled by dd4dbb4 .