### PR TITLE
Fix: incorrect behaviour of Map.union

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,10 @@ Changelog
 - Int: optimized implementation of Safe_int.mul
   #808
   (Max Mouratov)
+- Fix: in case of conflicted bindings, [Map.union m1 m2] should
+  prefer the value from [m2], as stated in documentation.
+  #814
+  (Max Mouratov)
 
 ## v2.8.0 (minor release)
 

--- a/src/batMap.ml
+++ b/src/batMap.ml
@@ -683,7 +683,7 @@ module Concrete = struct
   let union cmp1 m1 cmp2 m2 =
     if compatible_cmp cmp1 m1 cmp2 m2 then
       let merge_fun _k a b = if a <> None then a else b in
-      merge merge_fun cmp2 m1 m2
+      merge merge_fun cmp2 m2 m1
     else
       foldi (fun k v m -> add k v cmp1 m) m2 m1
 

--- a/src/batMap.ml
+++ b/src/batMap.ml
@@ -1080,6 +1080,12 @@ let union m1 m2 =
   let comp = Pervasives.compare in
   Concrete.union comp m1 comp m2
 
+(*$T union
+  let m1 = empty |> add 1 1 |> add 2 2 in \
+  let m2 = empty |> add 2 20 |> add 3 30 in \
+  (union m1 m2 |> find 2 = 20) && (union m2 m1 |> find 2 = 2)
+*)
+
 let diff m1 m2 =
   let comp = Pervasives.compare in
   Concrete.diff comp m1 comp m2


### PR DESCRIPTION
In case of conflicted bindings, `Map.union m1 m2` should prefer the value from `m2`, as stated in documentation.