### PR TITLE
simpler (and faster?) implementation of BatArray.partition

### DIFF
--- a/src/batArray.mlv
+++ b/src/batArray.mlv
@@ -248,33 +248,34 @@ let filteri p xs =
 
 let find_all = filter
 
-let partition p xs =
-  let n = length xs in
-  (* Use a bitset to store which elements will be in which final array. *)
-  let bs = BatBitSet.create n in
-  for i = 0 to n-1 do
-    if p xs.(i) then BatBitSet.set bs i
-  done;
-  (* Allocate the final arrays and copy elements into them. *)
-  let n1 = BatBitSet.count bs in
-  let n2 = n - n1 in
-  let j = ref 0 in
-  let xs1 = init n1
-      (fun _ ->
-        (* Find the next set bit in the BitSet. *)
-        while not (BatBitSet.mem bs !j) do incr j done;
-        let r = xs.(!j) in
-        incr j;
-        r) in
-  let j = ref 0 in
-  let xs2 = init n2
-      (fun _ ->
-        (* Find the next clear bit in the BitSet. *)
-        while BatBitSet.mem bs !j do incr j done;
-        let r = xs.(!j) in
-        incr j;
-        r) in
-  xs1, xs2
+(* <=> List.partition *)
+let partition p a =
+  let n = length a in
+  if n = 0 then ([||], [||])
+  else
+    let mask = make n false in
+    let ok_count = ref 0 in
+    iteri (fun i x ->
+        if p x then
+          (unsafe_set mask i true;
+           incr ok_count)
+      ) a;
+    let ko_count = n - !ok_count in
+    let init = unsafe_get a 0 in
+    let ok = make !ok_count init in
+    let ko = make ko_count init in
+    let j = ref 0 in
+    let k = ref 0 in
+    iteri (fun i px ->
+        let x = unsafe_get a i in
+        if px then
+          (unsafe_set ok !j x;
+           incr j)
+        else
+          (unsafe_set ko !k x;
+           incr k)
+      ) mask;
+    (ok, ko)
 (*$Q partition
   (Q.pair (Q.array Q.small_int) (Q.fun1 Q.Observable.int Q.bool)) (fun (a, Q.Fun(_,f)) -> \
     let b1, b2 = partition f a in \

--- a/src/batArray.mlv
+++ b/src/batArray.mlv
@@ -253,28 +253,28 @@ let partition p a =
   let n = length a in
   if n = 0 then ([||], [||])
   else
-    let mask = make n false in
     let ok_count = ref 0 in
-    iteri (fun i x ->
-        if p x then
-          (unsafe_set mask i true;
-           incr ok_count)
-      ) a;
+    let mask =
+      init n (fun i ->
+          let pi = p (unsafe_get a i) in
+          if pi then incr ok_count;
+          pi) in
     let ko_count = n - !ok_count in
     let init = unsafe_get a 0 in
     let ok = make !ok_count init in
     let ko = make ko_count init in
     let j = ref 0 in
     let k = ref 0 in
-    iteri (fun i px ->
-        let x = unsafe_get a i in
-        if px then
-          (unsafe_set ok !j x;
-           incr j)
-        else
-          (unsafe_set ko !k x;
-           incr k)
-      ) mask;
+    for i = 0 to n - 1 do
+      let x = unsafe_get a i in
+      let px = unsafe_get mask i in
+      if px then
+        (unsafe_set ok !j x;
+         incr j)
+      else
+        (unsafe_set ko !k x;
+         incr k)
+    done;
     (ok, ko)
 (*$Q partition
   (Q.pair (Q.array Q.small_int) (Q.fun1 Q.Observable.int Q.bool)) (fun (a, Q.Fun(_,f)) -> \


### PR DESCRIPTION
I bet it is more efficient that the current implementation, at the cost of using more memory (the usual trade-off).
I have not benchmarked it.
If someone do benchmark it, and finds out that it is less efficient than the current implementation in general, then I owe this person one glass of cider.
The glass of cider will be awarded as soon as we meet in the real world, or I'll manage to send
you a full bottle in case this real world event being too far in the future.

PS: by cider, I mean 100% pure fermented apple juice with an alcohol content that cannot exceed 5%.
