### PR TITLE
Compile Batteries with -no-alias-deps

### DIFF
--- a/_tags
+++ b/_tags
@@ -11,4 +11,5 @@ true: package(bytes), warn_-3, bin_annot
 "examples": -traverse
 <src/batOpaqueInnerSys.*>: opaque
 true: safe_string
+true: no_alias_deps
 


### PR DESCRIPTION
The size cost of using batteries has always been a problem. OCaml 4.02
introduced --no-deps-libs for this exact purpose (see
http://caml.inria.fr/pub/docs/manual-ocaml/extn.html#s%3Amodule-alias).

I couldn't find any discussion relative to this but I'm well aware this is
unlikely to not have been considered already.

Simple test:

```
  % cat toto1.ml
  open Batteries
  let () = Printf.printf "hello\n"
  % cat toto2.ml
  let () = BatPrintf.printf "hello\n"
  % for f in toto1 toto2 ; do \
      ocamlfind ocamlopt $f.ml -o $f.opt -package batteries -linkpkg ;
    done
  % ls -l toto*opt
```

Before the patch:

```
  -rwxr-xr-x 1 rixed 5272428 Feb  7 05:43 toto1.opt*
  -rwxr-xr-x 1 rixed 2006588 Feb  7 05:43 toto2.opt*
```

After:

```
  -rwxr-xr-x 1 rixed 3098452 Feb  7 05:38 toto1.opt*
  -rwxr-xr-x 1 rixed 2006588 Feb  7 05:38 toto2.opt*
```

That's a 40% reduction in size of a program using only BatPrintf from
Batteries, still bigger than a program using explicitly only BatPrintf
because of batPervasives, I assume.

There are several ways i can imagine this patch would break other programs:

- it might break the build of some programs relying on some of their direct
  dependencies to link in others of their direct dependencies, which I would
  qualify as a bug in those builds;

- this could prevent the dynamic linkage of some plugins if it expects the
  whole of batteries to be available from the main program;

- programs relying on any side effects of some otherwise unused batteries
  module initialization code, but that sounds very unlikely.

Note that I'm not familiar with this option so there might be others, more
obvious issues. I'm confident you will know :-)

Note: I have no idea if/how the "pack" option that seems to be present in the
setup.ml could be used for the same purpose.