### PR TITLE
A clean-up of invalid_arg uses

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -34,7 +34,7 @@ Changelog
   raised exceptions
   #840, #754
   (FkHina)
-- Fix: [Array.insert] now throws a more relevant message on invalid indices
+- Fix: [Array.insert] should throw a more relevant message on invalid indices
   instead of the generic [invalid_arg "index out of bounds].
   The assertion is now documented.
   #841
@@ -45,6 +45,13 @@ Changelog
 - Fix documentation of [String.right].
   #849, #844
   (Max Mouratov, reported by Thibault Suzanne)
+- Fix: [Heap.del_min] should throw [Invalid_argument] with the specified
+  "del_min" message instead of "find_min_tree".
+  #850
+  (Max Mouratov)
+- More uniform and correct [Invalid_argument] messages.
+  #850
+  (Max Mouratov)
 
 ## v2.8.0 (minor release)
 

--- a/src/batArray.mlv
+++ b/src/batArray.mlv
@@ -382,7 +382,7 @@ let filter_map p xs =
 
 let iter2 f a1 a2 =
   if Array.length a1 <> Array.length a2
-  then raise (Invalid_argument "Array.iter2");
+  then invalid_arg "Array.iter2";
   for i = 0 to Array.length a1 - 1 do
     f a1.(i) a2.(i);
   done
@@ -406,7 +406,7 @@ let iter2 f a1 a2 =
 
 let iter2i f a1 a2 =
   if Array.length a1 <> Array.length a2
-  then raise (Invalid_argument "Array.iter2i");
+  then invalid_arg "Array.iter2i";
   for i = 0 to Array.length a1 - 1 do
     f i a1.(i) a2.(i);
   done
@@ -430,7 +430,7 @@ let iter2i f a1 a2 =
 
 let for_all2 p xs ys =
   let n = length xs in
-  if length ys <> n then raise (Invalid_argument "Array.for_all2");
+  if length ys <> n then invalid_arg "Array.for_all2";
   let rec loop i =
     if i = n then true
     else if p xs.(i) ys.(i) then loop (succ i)
@@ -450,7 +450,7 @@ let for_all2 p xs ys =
 
 let exists2 p xs ys =
   let n = length xs in
-  if length ys <> n then raise (Invalid_argument "Array.exists2");
+  if length ys <> n then invalid_arg "Array.exists2";
   let rec loop i =
     if i = n then false
     else if p xs.(i) ys.(i) then true
@@ -467,7 +467,7 @@ let exists2 p xs ys =
 
 let map2 f xs ys =
   let n = length xs in
-  if length ys <> n then raise (Invalid_argument "Array.map2");
+  if length ys <> n then invalid_arg "Array.map2";
   Array.init n (fun i -> f xs.(i) ys.(i))
 
 (*$T map2

--- a/src/batBig_int.mlv
+++ b/src/batBig_int.mlv
@@ -138,7 +138,7 @@ module BaseBig_int = struct
 
   let of_float f =
     try of_string (Printf.sprintf "%.0f" f)
-    with Failure _ -> invalid_arg "batBig_int.of_float"
+    with Failure _ -> invalid_arg "Big_int.of_float"
   (*$T of_float
     to_int (of_float 4.46) = 4
     to_int (of_float 4.56) = 5

--- a/src/batBitSet.ml
+++ b/src/batBitSet.ml
@@ -48,7 +48,7 @@ let capacity t = (Bytes.length !t) * 8
 let empty () = ref (Bytes.create 0)
 
 let create_ sfun c n = (* n is in bits *)
-  if n < 0 then invalid_arg ("BitSet."^sfun^": negative size");
+  if n < 0 then invalid_arg ("BitSet." ^ sfun ^ ": negative size");
   let size = n / 8 + (if n mod 8 = 0 then 0 else 1) in
   ref (Bytes.make size c)
 
@@ -71,7 +71,7 @@ type bit_op =
 let rec apply_bit_op sfun op t x =
   let pos = x / 8 in
   if pos < 0 then
-    invalid_arg ("BitSet."^sfun^": negative index")
+    invalid_arg ("BitSet." ^ sfun ^ ": negative index")
   else if pos < Bytes.length !t then
     let delta = x mod 8 in
     let c = Char.code (Bytes.unsafe_get !t pos) in
@@ -105,7 +105,7 @@ let toggle t x = apply_bit_op "toggle" Toggle t x
 let mem t x =
   let pos = x / 8 in
   if pos < 0 then
-    invalid_arg ("BitSet.mem: negative index")
+    invalid_arg "BitSet.mem: negative index"
   else if pos < Bytes.length !t then
     let delta = x mod 8 in
     let c = Char.code (Bytes.unsafe_get !t pos) in

--- a/src/batBool.ml
+++ b/src/batBool.ml
@@ -47,13 +47,13 @@ module BaseBool = struct
   let mul    = ( && )
   let sub _  = not (*Weird extrapolation*)
   let div _ _=
-    raise (Invalid_argument "Bool.div")
+    invalid_arg "Bool.div"
 
   let modulo _ _ =
-    raise (Invalid_argument "Bool.modulo")
+    invalid_arg "Bool.modulo"
 
   let pow _ _ =
-    raise (Invalid_argument "Bool.pow")
+    invalid_arg "Bool.pow"
 
   let compare = compare
 
@@ -74,7 +74,7 @@ module BaseBool = struct
   let of_string = function
     | "true" | "tt" | "1" -> true
     | "false"| "ff" | "0" -> false
-    | _                   -> raise (Invalid_argument "Bool.of_string")
+    | _                   -> invalid_arg "Bool.of_string"
 
   let to_string = string_of_bool
 end

--- a/src/batDigest.mlv
+++ b/src/batDigest.mlv
@@ -62,13 +62,13 @@ let channel inp len = (*TODO: Make efficient*)
 *)
 
 let from_hex s =
-  if String.length s <> 32 then raise (Invalid_argument "Digest.from_hex");
+  if String.length s <> 32 then invalid_arg "Digest.from_hex";
   let digit c =
     match c with
     | '0'..'9' -> Char.code c - Char.code '0'
     | 'A'..'F' -> Char.code c - Char.code 'A' + 10
     | 'a'..'f' -> Char.code c - Char.code 'a' + 10
-    | _ -> raise (Invalid_argument "Digest.from_hex")
+    | _ -> invalid_arg "Digest.from_hex"
   in
   let byte i = digit s.[i] lsl 4 + digit s.[i+1] in
   BatBytesCompat.string_init 16 (fun i -> Char.chr (byte (2 * i)))

--- a/src/batEnum.ml
+++ b/src/batEnum.ml
@@ -189,7 +189,7 @@ let from2 next clone =
   e
 
 let init n f = (*Experimental fix for init*)
-  if n < 0 then invalid_arg "BatEnum.init";
+  if n < 0 then invalid_arg "Enum.init";
   let count = ref n in
   let f' () =
     match !count with
@@ -1148,7 +1148,7 @@ let unfold data next =
 
 let arg_min f enum =
   match get enum with
-    None -> invalid_arg "arg_min: Empty enum"
+    None -> invalid_arg "Enum.arg_min: Empty enum"
   | Some v ->
     let item, eval = ref v, ref (f v) in
     iter (fun v -> let fv = f v in
@@ -1157,7 +1157,7 @@ let arg_min f enum =
 
 let arg_max f enum =
   match get enum with
-    None -> invalid_arg "arg_max: Empty enum"
+    None -> invalid_arg "Enum.arg_max: Empty enum"
   | Some v ->
     let item, eval = ref v, ref (f v) in
     iter (fun v -> let fv = f v in
@@ -1349,7 +1349,7 @@ let print ?(first="") ?(last="") ?(sep=" ") print_a  out e =
   _print_common ~first ~last ~sep ~limit:max_int print_a out e
 
 let print_at_most ?(first="") ?(last="") ?(sep=" ") ~limit print_a out e =
-  if limit <= 0 then raise (Invalid_argument "enum.print_at_most");
+  if limit <= 0 then invalid_arg "Enum.print_at_most";
   _print_common ~first ~last ~sep ~limit print_a out e
 
 (*$T print_at_most

--- a/src/batFile.ml
+++ b/src/batFile.ml
@@ -45,8 +45,8 @@ let perm l =
     ~f:(fun acc x -> acc lor x)
 
 let unix_perm i =
-  if 0<= i && i <= 511 then i
-  else raise (Invalid_argument (Printf.sprintf "Unix permission %o " i))
+  if 0 <= i && i <= 511 then i
+  else Printf.ksprintf invalid_arg "File.unix_perm: Unix permission %o" i
 
 (* Opening *)
 type open_in_flag =

--- a/src/batFingerTree.ml
+++ b/src/batFingerTree.ml
@@ -1171,7 +1171,8 @@ let reverse t = Generic.reverse ~monoid:nat_plus_monoid ~measure:size_measurer t
 
 let split f t = Generic.split ~monoid:nat_plus_monoid ~measure:size_measurer f t
 let split_at t i =
-  if i < 0 || i >= size t then invalid_arg "Index out of bounds";
+  if i < 0 || i >= size t then
+    invalid_arg "FingerTree.split_at: Index out of bounds";
   split (fun index -> i < index) t
 (*$T split_at
   let n = 50 in \
@@ -1185,7 +1186,8 @@ let split_at t i =
 
 let lookup f t = Generic.lookup ~monoid:nat_plus_monoid ~measure:size_measurer f t
 let get t i =
-  if i < 0 || i >= size t then invalid_arg "Index out of bounds";
+  if i < 0 || i >= size t then
+    invalid_arg "FingerTree.get: Index out of bounds";
   lookup (fun index -> i < index) t
 (*$T get
   let n = 50 in \
@@ -1198,7 +1200,8 @@ let get t i =
 *)
 
 let set t i v =
-  if i < 0 || i >= size t then invalid_arg "Index out of bounds";
+  if i < 0 || i >= size t then
+    invalid_arg "FingerTree.set: Index out of bounds";
   let left, right = split_at t i in
   append (snoc left v) (tail_exn right)
 (*$T set

--- a/src/batHeap.ml
+++ b/src/batHeap.ml
@@ -108,7 +108,7 @@ let find_min bh = match bh.mind with
 
 
 let rec find_min_tree ts k = match ts with
-  | [] -> failwith "find_min_tree"
+  | [] -> invalid_arg "del_min"
   | [t] -> k t
   | t :: ts ->
     find_min_tree ts begin
@@ -285,7 +285,7 @@ module Make (Ord : BatInterfaces.OrderedType) = struct
     | Some d -> d
 
   let rec find_min_tree ts k = match ts with
-    | [] -> failwith "find_min_tree"
+    | [] -> invalid_arg "del_min"
     | [t] -> k t
     | t :: ts ->
       find_min_tree ts begin

--- a/src/batHeap.ml
+++ b/src/batHeap.ml
@@ -107,35 +107,44 @@ let find_min bh = match bh.mind with
 *)
 
 
-let rec find_min_tree ts k = match ts with
-  | [] -> invalid_arg "del_min"
-  | [t] -> k t
-  | t :: ts ->
-    find_min_tree ts begin
-      fun u ->
-        if Pervasives.compare t.root u.root <= 0
-        then k t else k u
-    end
+let rec find_min_tree ts ~kfail ~ksuccess =
+  match ts with
+    | [] ->
+        kfail ()
+    | [t] ->
+        ksuccess t
+    | t :: ts ->
+        find_min_tree ts ~kfail ~ksuccess:(fun u ->
+          if Pervasives.compare t.root u.root <= 0 then
+            ksuccess t
+          else
+            ksuccess u)
 
-let rec del_min_tree bts k = match bts with
-  | [] -> invalid_arg "del_min"
-  | [t] -> k t []
-  | t :: ts ->
-    del_min_tree ts begin
-      fun u uts ->
-        if Pervasives.compare t.root u.root <= 0
-        then k t ts
-        else k u (t :: uts)
-    end
+let rec del_min_tree bts ~kfail ~ksuccess =
+  match bts with
+    | [] ->
+        kfail ()
+    | [t] ->
+        ksuccess t []
+    | t :: ts ->
+        del_min_tree ts ~kfail ~ksuccess:(fun u uts ->
+          if Pervasives.compare t.root u.root <= 0 then
+            ksuccess t ts
+          else
+            ksuccess u (t :: uts))
 
 let del_min bh =
-  del_min_tree bh.data begin
-    fun bt data ->
-      let size = bh.size - 1 in
-      let data = merge_data (List.rev bt.kids) data in
-      let mind = if size = 0 then None else Some (find_min_tree data (fun t -> t)).root in
-      { size = size ; data = data ; mind = mind }
-  end
+  let kfail () = invalid_arg "del_min" in
+  del_min_tree bh.data ~kfail ~ksuccess:(fun bt data ->
+    let size = bh.size - 1 in
+    let data = merge_data (List.rev bt.kids) data in
+    let mind =
+      if size = 0 then
+        None
+      else
+        Some (find_min_tree data ~kfail ~ksuccess:(fun t -> t)).root
+    in
+    { size; data; mind })
 
 let of_list l = List.fold_left insert empty l
 
@@ -284,35 +293,44 @@ module Make (Ord : BatInterfaces.OrderedType) = struct
     | None -> invalid_arg "find_min"
     | Some d -> d
 
-  let rec find_min_tree ts k = match ts with
-    | [] -> invalid_arg "del_min"
-    | [t] -> k t
-    | t :: ts ->
-      find_min_tree ts begin
-        fun u ->
-          if Ord.compare t.root u.root <= 0
-          then k t else k u
-      end
+  let rec find_min_tree ts ~kfail ~ksuccess =
+    match ts with
+      | [] ->
+          kfail ()
+      | [t] ->
+          ksuccess t
+      | t :: ts ->
+          find_min_tree ts ~kfail ~ksuccess:(fun u ->
+            if Ord.compare t.root u.root <= 0 then
+              ksuccess t
+            else
+              ksuccess u)
 
-  let rec del_min_tree bts k = match bts with
-    | [] -> invalid_arg "del_min"
-    | [t] -> k t []
-    | t :: ts ->
-      del_min_tree ts begin
-        fun u uts ->
-          if Ord.compare t.root u.root <= 0
-          then k t ts
-          else k u (t :: uts)
-      end
+  let rec del_min_tree bts ~kfail ~ksuccess =
+    match bts with
+      | [] ->
+          kfail ()
+      | [t] ->
+          ksuccess t []
+      | t :: ts ->
+          del_min_tree ts ~kfail ~ksuccess:(fun u uts ->
+            if Ord.compare t.root u.root <= 0 then
+              ksuccess t ts
+            else
+              ksuccess u (t :: uts))
 
   let del_min bh =
-    del_min_tree bh.data begin
-      fun bt data ->
-        let size = bh.size - 1 in
-        let data = merge_data (List.rev bt.kids) data in
-        let mind = if size = 0 then None else Some (find_min_tree data (fun t -> t)).root in
-        { size = size ; data = data ; mind = mind }
-    end
+    let kfail () = invalid_arg "del_min" in
+    del_min_tree bh.data ~kfail ~ksuccess:(fun bt data ->
+      let size = bh.size - 1 in
+      let data = merge_data (List.rev bt.kids) data in
+      let mind =
+        if size = 0 then
+          None
+        else
+          Some (find_min_tree data ~kfail ~ksuccess:(fun t -> t)).root
+      in
+      { size; data; mind })
 
   let to_list bh =
     let rec aux acc bh =

--- a/src/batISet.ml
+++ b/src/batISet.ml
@@ -86,7 +86,7 @@ let before n s = if n = min_int then empty else until (n - 1) s
 *)
 
 let add_range n1 n2 s =
-  if n1 > n2 then invalid_arg (Printf.sprintf "ISet.add_range - %d > %d" n1 n2) else
+  if n1 > n2 then Printf.ksprintf invalid_arg "ISet.add_range - %d > %d" n1 n2 else
     let n1, l =
       if n1 = min_int then n1, empty else
         let l = until (n1 - 1) s in

--- a/src/batInt.ml
+++ b/src/batInt.ml
@@ -57,7 +57,7 @@ module BaseInt = struct
 
   let pow a b =
     if b < 0
-    then raise (Invalid_argument "Int.pow")
+    then invalid_arg "Int.pow"
     else
       let div_two n = n / 2
       and mod_two n = n mod 2
@@ -271,7 +271,7 @@ module BaseSafeInt = struct
 
   let pow a b =
     if b < 0
-    then raise (Invalid_argument "Safe_int.pow")
+    then invalid_arg "Int.Safe_int.pow"
     else
       let div_two n = n / 2
       and mod_two n = n mod 2

--- a/src/batInt32.mlv
+++ b/src/batInt32.mlv
@@ -102,9 +102,9 @@ let unpack str pos =
 
 let unpack_big str pos =
   if Bytes.length str < pos + 4 then
-    invalid_arg "Int32.unpack: pos + 4 not within string";
+    invalid_arg "Int32.unpack_big: pos + 4 not within string";
   if pos < 0 then
-    invalid_arg "Int32.unpack: pos negative";
+    invalid_arg "Int32.unpack_big: pos negative";
   let shift n = Int32.shift_left n 8
   and add b n = Int32.add (of_byte b) n in
   of_byte (Bytes.unsafe_get str pos) |> shift

--- a/src/batLazyList.ml
+++ b/src/batLazyList.ml
@@ -90,14 +90,14 @@ let init n f =
   let rec aux i =
     if i < n then lazy (Cons (f i, aux ( i + 1 ) ) )
     else          nil
-  in if n < 0 then raise (Invalid_argument "LazyList.init")
+  in if n < 0 then invalid_arg "LazyList.init"
   else          aux 0
 
 let make n x =
   let rec aux i =
     if i < n then lazy (Cons (x, aux ( i + 1 ) ) )
     else          nil
-  in if n < 0 then raise (Invalid_argument "LazyList.make")
+  in if n < 0 then invalid_arg "LazyList.make"
   else          aux 0
 
 (**

--- a/src/batList.mlv
+++ b/src/batList.mlv
@@ -132,8 +132,8 @@ let is_empty = function
   not (is_empty [1])
 *)
 
-let at_negative_index_msg = "Negative index not allowed"
-let at_after_end_msg = "Index past end of list"
+let at_negative_index_msg = "List: Negative index not allowed"
+let at_after_end_msg = "List: Index past end of list"
 
 let nth l index =
   if index < 0 then invalid_arg at_negative_index_msg;
@@ -282,7 +282,7 @@ let takedrop n l =
 *)
 
 let ntake n l =
-  if n < 1 then invalid_arg "BatList.ntake";
+  if n < 1 then invalid_arg "List.ntake";
   let took, left = takedrop n l in
   let acc = Acc.create took in
   let rec loop dst = function
@@ -573,7 +573,7 @@ let map2 f l1 l2 =
     | [], [] -> ()
     | h1 :: t1, h2 :: t2 ->
       loop (Acc.accum dst (f h1 h2)) t1 t2
-    | _ -> invalid_arg "map2: Different_list_size"
+    | _ -> invalid_arg "List.map2: Different_list_size"
   in
   let dummy = Acc.dummy () in
   loop dummy l1 l2;
@@ -585,7 +585,7 @@ let map2i f l1 l2 =
     | [], [] -> ()
     | h1 :: t1, h2 :: t2 ->
       loop (succ i) (Acc.accum dst (f i h1 h2)) t1 t2
-    | _ -> invalid_arg "map2i: Different_list_size"
+    | _ -> invalid_arg "List.map2i: Different_list_size"
   in
   let dummy = Acc.dummy () in
   loop 0 dummy l1 l2;
@@ -606,14 +606,14 @@ let rec iter2 f l1 l2 =
   match l1, l2 with
   | [], [] -> ()
   | h1 :: t1, h2 :: t2 -> f h1 h2; iter2 f t1 t2
-  | _ -> invalid_arg "iter2: Different_list_size"
+  | _ -> invalid_arg "List.iter2: Different_list_size"
 
 let iter2i f l1 l2 =
   let rec loop i l1 l2 =
     match l1, l2 with
     | [], [] -> ()
     | h1 :: t1, h2 :: t2 -> f i h1 h2; loop (succ i) t1 t2
-    | _ -> invalid_arg "iter2: Different_list_size"
+    | _ -> invalid_arg "List.iter2i: Different_list_size"
   in loop 0 l1 l2
 
 (*$T iter2i
@@ -633,14 +633,14 @@ let rec fold_left2 f accum l1 l2 =
   match l1, l2 with
   | [], [] -> accum
   | h1 :: t1, h2 :: t2 -> fold_left2 f (f accum h1 h2) t1 t2
-  | _ -> invalid_arg "fold_left2: Different_list_size"
+  | _ -> invalid_arg "List.fold_left2: Different_list_size"
 
 let fold_right2 f l1 l2 init =
   let rec tail_loop acc l1 l2 =
     match l1, l2 with
     | [] , [] -> acc
     | h1 :: t1 , h2 :: t2 -> tail_loop (f h1 h2 acc) t1 t2
-    | _ -> invalid_arg "fold_left2: Different_list_size"
+    | _ -> invalid_arg "List.fold_right2: Different_list_size"
   in
   let rec loop n l1 l2 =
     match l1, l2 with
@@ -650,7 +650,7 @@ let fold_right2 f l1 l2 init =
         f h1 h2 (loop (n+1) t1 t2)
       else
         f h1 h2 (tail_loop init (rev t1) (rev t2))
-    | _ -> invalid_arg "fold_right2: Different_list_size"
+    | _ -> invalid_arg "List.fold_right2: Different_list_size"
   in
   loop 0 l1 l2
 
@@ -659,7 +659,7 @@ let for_all2 p l1 l2 =
     match l1, l2 with
     | [], [] -> true
     | h1 :: t1, h2 :: t2 -> if p h1 h2 then loop t1 t2 else false
-    | _ -> invalid_arg "for_all2: Different_list_size"
+    | _ -> invalid_arg "List.for_all2: Different_list_size"
   in
   loop l1 l2
 
@@ -668,7 +668,7 @@ let exists2 p l1 l2 =
     match l1, l2 with
     | [], [] -> false
     | h1 :: t1, h2 :: t2 -> if p h1 h2 then true else loop t1 t2
-    | _ -> invalid_arg "exists2: Different_list_size"
+    | _ -> invalid_arg "List.exists2: Different_list_size"
   in
   loop l1 l2
 
@@ -700,7 +700,7 @@ let remove_assq x lst =
 
 let remove_at i lst =
   let rec loop dst i = function
-    | [] -> invalid_arg "BatList.remove_at"
+    | [] -> invalid_arg "List.remove_at"
     | x :: xs ->
       if i = 0 then
         dst.tl <- xs
@@ -708,7 +708,7 @@ let remove_at i lst =
         loop (Acc.accum dst x) (i - 1) xs
   in
   if i < 0 then
-    invalid_arg "BatList.remove_at"
+    invalid_arg "List.remove_at"
   else
     let dummy = Acc.dummy () in
     loop dummy i lst;
@@ -1342,8 +1342,11 @@ let print ?(first="[") ?(last="]") ?(sep="; ") print_a  out = function
 
 let t_printer a_printer _paren out x = print (a_printer false) out x
 
-let reduce f = function [] -> invalid_arg "Empty List"
-                      | h::t -> fold_left f h t
+let reduce f = function
+  | [] ->
+      invalid_arg "List.reduce: Empty List"
+  | h :: t ->
+      fold_left f h t
 
 let min l = reduce Pervasives.min l
 let max l = reduce Pervasives.max l

--- a/src/batPathGen.ml
+++ b/src/batPathGen.ml
@@ -597,7 +597,7 @@ module Make = functor (S : StringType) -> struct
   let concat basepath relpath =
     let simple_concat () =
       if is_relative relpath then relpath @ basepath
-      else raise (Invalid_argument "Path.concat")
+      else invalid_arg "PathGen.concat"
     in
     if windows then
       begin
@@ -606,7 +606,7 @@ module Make = functor (S : StringType) -> struct
           (* special rules *)
           begin
             match relpath with
-            | nm :: _ when isnul nm -> raise (Invalid_argument "Path.concat")
+            | nm :: _ when isnul nm -> invalid_arg "PathGen.concat"
             | _ -> relpath @ basepath (* allow drive-letter inside the path *)
           end
         | _ -> simple_concat ()
@@ -650,8 +650,8 @@ module Make = functor (S : StringType) -> struct
 
   let parent path =
     match path with
-    | [] -> raise (Invalid_argument "Path.parent")
-    | [rt] when isroot rt -> raise (Invalid_argument "Path.parent")
+    | [] -> invalid_arg "PathGen.parent"
+    | [rt] when isroot rt -> invalid_arg "PathGen.parent"
     | _ :: par -> par
 
   let belongs base sub =
@@ -670,8 +670,8 @@ module Make = functor (S : StringType) -> struct
     match rbase, rsub with
     | hb::_, hs::_ when hb = hs -> fold rbase rsub
     | hb::_, hs::_ -> false
-    | rt::_, _ when isroot rt -> raise (Invalid_argument "Path.belongs")
-    | _, rt::_ when isroot rt -> raise (Invalid_argument "Path.belongs")
+    | rt::_, _ when isroot rt -> invalid_arg "PathGen.belongs"
+    | _, rt::_ when isroot rt -> invalid_arg "PathGen.belongs"
     | _, _ -> fold rbase rsub
 
   let gen_relative_to parent_only base sub =
@@ -688,8 +688,8 @@ module Make = functor (S : StringType) -> struct
     let rsub = List.rev sub in
     let rrel = match rbase, rsub with
       | hb::_, hs::_ when hb = hs -> fold rbase rsub
-      | rt::_, _ when isroot rt -> raise (Invalid_argument "Path.relative_to_*")
-      | _, rt::_ when isroot rt -> raise (Invalid_argument "Path.relative_to_*")
+      | rt::_, _ when isroot rt -> invalid_arg "PathGen.relative_to_*"
+      | _, rt::_ when isroot rt -> invalid_arg "PathGen.relative_to_*"
       | _, _ -> fold rbase rsub
     in
     List.rev rrel
@@ -745,8 +745,8 @@ module Make = functor (S : StringType) -> struct
 
   let with_nonempty path fu =
     match path with
-    | [] -> raise (Invalid_argument "Path.parent")
-    | [rt] when isroot rt -> raise (Invalid_argument "Path.parent")
+    | [] -> invalid_arg "PathGen.name"
+    | [rt] when isroot rt -> invalid_arg "PathGen.name"
     | name :: parent -> (fu name parent)
 
   let name path = with_nonempty path
@@ -811,7 +811,7 @@ module Make = functor (S : StringType) -> struct
     match List.rev abs with
     | nul :: _ when isnul nul -> None
     | drv :: _ when is_win_disk_letter drv -> Some (S.get drv 0)
-    | _ -> raise (Invalid_argument "Path.drive_letter")
+    | _ -> invalid_arg "PathGen.drive_letter"
 
 end
 

--- a/src/batRefList.ml
+++ b/src/batRefList.ml
@@ -115,7 +115,7 @@ module Index = struct
     let p = ref (-1) in
     let rec del_aux = function
       | x::l -> incr p; if !p = pos then l else x::(del_aux l)
-      | [] -> invalid_arg "remove_at: index not found"
+      | [] -> invalid_arg "RefList.Index.remove_at: index not found"
     in
     rl := del_aux !rl
 
@@ -134,7 +134,7 @@ module Index = struct
   let set rl pos newitem =
     let p = ref (-1) in
     rl := List.map (fun item -> incr p; if !p = pos then newitem else item) !rl;
-    if !p < pos || pos < 0 then invalid_arg "Index out of range"
+    if !p < pos || pos < 0 then invalid_arg "RefList.Index.set: Index out of range"
 
 
 end

--- a/src/batSeq.ml
+++ b/src/batSeq.ml
@@ -49,15 +49,15 @@ let rec enum_of_ref r =
 let enum s = enum_of_ref (ref s)
 
 let hd s = match s () with
-  | Nil -> raise (Invalid_argument "Seq.hd")
+  | Nil -> invalid_arg "Seq.hd"
   | Cons(e, _s) -> e
 
 let tl s = match s () with
-  | Nil -> raise (Invalid_argument "Seq.tl")
+  | Nil -> invalid_arg "Seq.tl"
   | Cons(_e, s) -> s
 
 let first s = match s () with
-  | Nil -> raise (Invalid_argument "Seq.first")
+  | Nil -> invalid_arg "Seq.first"
   | Cons(e, _s) -> e
 
 let last s =
@@ -66,7 +66,7 @@ let last s =
     | Cons(e, s) -> aux e s
   in
   match s () with
-  | Nil -> raise (Invalid_argument "Seq.last")
+  | Nil -> invalid_arg "Seq.last"
   | Cons(e, s) -> aux e s
 
 let is_empty s = s () = Nil
@@ -74,7 +74,7 @@ let is_empty s = s () = Nil
 let at s n =
   let rec aux s n =
     match s () with
-    | Nil -> raise (Invalid_argument "Seq.at")
+    | Nil -> invalid_arg "Seq.at"
     | Cons(e, s) ->
       if n = 0 then
         e
@@ -197,15 +197,15 @@ let rec fold_right f s acc = match s () with
   | Cons(e, s) -> f e (fold_right f s acc)
 
 let reduce f s = match s () with
-  | Nil -> raise (Invalid_argument "Seq.reduce")
+  | Nil -> invalid_arg "Seq.reduce"
   | Cons(e, s) -> fold_left f e s
 
 let max s = match s () with
-  | Nil -> raise (Invalid_argument "Seq.max")
+  | Nil -> invalid_arg "Seq.max"
   | Cons(e, s) -> fold_left Pervasives.max e s
 
 let min s = match s () with
-  | Nil -> raise (Invalid_argument "Seq.min")
+  | Nil -> invalid_arg "Seq.min"
   | Cons(e, s) -> fold_left Pervasives.min e s
 
 let equal ?(eq=(=)) s1 s2 =
@@ -318,7 +318,7 @@ let rec combine s1 s2 () = match s1 (), s2 () with
   | Cons(e1, s1), Cons(e2, s2) ->
     Cons((e1, e2), combine s1 s2)
   | _ ->
-    raise (Invalid_argument "Seq.combine")
+    invalid_arg "Seq.combine"
 
 let print ?(first="[") ?(last="]") ?(sep="; ") print_a out s = match s () with
   | Nil ->

--- a/src/batString.mlv
+++ b/src/batString.mlv
@@ -83,7 +83,7 @@ let ends_with str p =
 let find_from str pos sub =
   let len = length str in
   let sublen = length sub in
-  if pos < 0 || pos > len then raise (Invalid_argument "String.find_from");
+  if pos < 0 || pos > len then invalid_arg "String.find_from";
   if sublen = 0 then pos else
     let rec find ~str ~sub i =
       if i > len - sublen then raise Not_found
@@ -125,7 +125,7 @@ let find str sub = find_from str 0 sub
 let rfind_from str pos sub =
   let sublen = length sub
   and len = length str in
-  if pos + 1 < 0 || pos + 1 > len then raise (Invalid_argument "String.rfind_from");
+  if pos + 1 < 0 || pos + 1 > len then invalid_arg "String.rfind_from";
   if sublen = 0 then pos + 1 else
     let rec find ~str ~sub i =
       if i < 0 then raise Not_found
@@ -203,7 +203,7 @@ let find_all str sub =
 *)
 
 let count_string str sub =
-  if sub = "" then raise (Invalid_argument "String.count_string");
+  if sub = "" then invalid_arg "String.count_string";
   let m = length str in
   let n = length sub in
   let rec loop acc i =
@@ -336,7 +336,7 @@ let rsplit str ~by:sep =
 *)
 let nsplit str ~by:sep =
   if str = "" then []
-  else if sep = "" then invalid_arg "nsplit: empty sep not allowed"
+  else if sep = "" then invalid_arg "String.nsplit: empty sep not allowed"
   else
     (* str is non empty *)
     let seplen = String.length sep in
@@ -417,7 +417,7 @@ let slice ?(first = 0) ?(last = Sys.max_string_length) s =
 
 let lchop ?(n = 1) s =
   if n < 0 then
-    invalid_arg "lchop: number of characters to chop is negative"
+    invalid_arg "String.lchop: number of characters to chop is negative"
   else
     let slen = length s in
     if slen <= n then "" else sub s n (slen - n)
@@ -432,7 +432,7 @@ let lchop ?(n = 1) s =
 
 let rchop ?(n = 1) s =
   if n < 0 then
-    invalid_arg "rchop: number of characters to chop is negative"
+    invalid_arg "String.rchop: number of characters to chop is negative"
   else
     let slen = length s in
     if slen <= n then "" else sub s 0 (slen - n)
@@ -446,9 +446,9 @@ let rchop ?(n = 1) s =
 
 let chop ?(l = 1) ?(r = 1) s =
   if l < 0 then
-    invalid_arg "chop: number of characters to chop on the left is negative";
+    invalid_arg "String.chop: number of characters to chop on the left is negative";
   if r < 0 then
-    invalid_arg "chop: number of characters to chop on the right is negative";
+    invalid_arg "String.chop: number of characters to chop on the right is negative";
   let slen = length s in
   if slen < l + r then ""
   else sub s l (slen - l - r)
@@ -769,7 +769,8 @@ let replace ~str ~sub ~by =
 
 
 let nreplace ~str ~sub ~by =
-  if sub = "" then invalid_arg "nreplace: cannot replace all empty substrings" ;
+  if sub = "" then
+    invalid_arg "String.nreplace: cannot replace all empty substrings" ;
   let strlen = length str in
   let sublen = length sub in
   let bylen = length by in

--- a/src/batSubstring.ml
+++ b/src/batSubstring.ml
@@ -153,7 +153,7 @@ let triml k (str,off,len) =
 *)
 
 let trimr k (str,off,len) =
-  if k < 0 then invalid_arg "Substring.triml: negative trim not allowed";
+  if k < 0 then invalid_arg "Substring.trimr: negative trim not allowed";
   if k > len then (str, off, 0) else (str, off, len-k)
 
 (*$T trimr

--- a/src/batText.ml
+++ b/src/batText.ml
@@ -173,7 +173,7 @@ let bal_if_needed l r =
   if height r < max_height then r else balance r
 
 let concat_str l = function
-  | Empty | Concat(_,_,_,_,_) -> invalid_arg "concat_str"
+  | Empty | Concat(_,_,_,_,_) -> invalid_arg "Text.concat_str"
   | Leaf (lenr, rs) as r ->
     match l with
     | Empty -> r
@@ -917,7 +917,7 @@ let rsplit (r:t) sep =
     avoid a call to [List.rev].  *)
 let nsplit str sep =
   if is_empty str then []
-  else if is_empty sep then invalid_arg "nsplit: empty sep not allowed"
+  else if is_empty sep then invalid_arg "Text.nsplit: empty sep not allowed"
   else
     (* str is not empty *)
     let seplen = length sep in

--- a/src/batUnit.ml
+++ b/src/batUnit.ml
@@ -24,7 +24,7 @@ type t = unit
 let string_of () = unit_string
 let of_string = function
   | "()" -> ()
-  | _  -> raise (Invalid_argument "unit_of_string")
+  | _  -> invalid_arg "Unit.of_string"
 let compare () () = 0
 let ord () () = BatOrd.Eq
 let equal () () = true

--- a/src/batUnix.mlv
+++ b/src/batUnix.mlv
@@ -115,14 +115,14 @@ let input_of_descr ?autoclose ?cleanup fd =
 
 let descr_of_input cin =
   try  descr_of_in_channel (input_get cin)
-  with Not_found -> raise (Invalid_argument "Unix.descr_of_in_channel")
+  with Not_found -> invalid_arg "Unix.descr_of_input"
 
 let output_of_descr ?cleanup fd =
   wrap_out ?cleanup (out_channel_of_descr fd)
 
 let descr_of_output cout =
   try  descr_of_out_channel (output_get (cast_output cout))
-  with Not_found -> raise (Invalid_argument "Unix.descr_of_out_channel")
+  with Not_found -> invalid_arg "Unix.descr_of_output"
 
 let in_channel_of_descr fd = input_of_descr ~autoclose:false ~cleanup:true fd
 let descr_of_in_channel = descr_of_input
@@ -191,7 +191,7 @@ let close_process_full (cin, cout, cin2) =
 
 let shutdown_connection cin =
   try shutdown_connection (input_get cin)
-  with Not_found -> raise (Invalid_argument "Unix.descr_of_in_channel")
+  with Not_found -> invalid_arg "Unix.shutdown_connection"
 
 let open_connection ?autoclose addr =
   let (cin, cout) = open_connection addr in

--- a/src/batVect.ml
+++ b/src/batVect.ml
@@ -622,7 +622,7 @@ let destructive_set v i x =
 let of_list l = of_array (Array.of_list l)
 
 let init n f =
-  if n < 0 || n > max_length then raise (Invalid_argument "Vect.init");
+  if n < 0 || n > max_length then invalid_arg "Vect.init";
   (* Create as many arrays as we need to store all the data *)
   let rec aux off acc =
     if off >= n then acc
@@ -1284,7 +1284,7 @@ struct
   let of_list l = of_array (Array.of_list l)
 
   let init n f =
-    if n < 0 || n > max_length then raise (Invalid_argument "Vect.init");
+    if n < 0 || n > max_length then invalid_arg "Vect.init";
     (* Create as many arrays as we need to store all the data *)
     let rec aux off acc =
       if off >= n then acc


### PR DESCRIPTION
This patch makes uses of `invalid_arg` more uniform, fixing the following kinds of irregularities:
* Lack of module name in a message (e.g. `Heap.find_min` threw "find_min");
* Lack of function name in a message (e.g. `List.reduce` threw "Empty list");
* Wrong module name in a message (e.g. `PathGen` functions threw messages with "Path");
* Wrong function name in a message (e.g. `List.fold_left2` threw a message with "fold_right2");
* Minor style issues: capitalization, punctuation, "Bat" prefixes;
* Use of `raise (Invalid_argument "...")` instead of `invalid_arg "..."`.