### PR TITLE
BatInt.Safe_int.mul performance improvements

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,7 +7,7 @@ Changelog
   #799
   (Francois Berenger)
 - Int: optimized implementation of Safe_int.mul
-  #808
+  #808, #851
   (Max Mouratov)
 
 ## v2.8.0 (minor release)


### PR DESCRIPTION
The previous overflow test from [CERT C](https://wiki.sei.cmu.edu/confluence/display/c/INT32-C.+Ensure+that+operations+on+signed+integers+do+not+result+in+overflow) is notable for avoiding an overflow while checking for overflow; hovewer, since overflows are perfectly defined in OCaml, a shorter test from Hacker's Delight is a better option.

This is a port of my changes from ocaml/ocaml#1520.