### PR TITLE
Hotfix: a regression in BatInt.Safe_int.mul

### DIFF
--- a/src/batInt.ml
+++ b/src/batInt.ml
@@ -258,7 +258,8 @@ module BaseSafeInt = struct
   let mul (a: int) (b: int) : int =
     let open Pervasives in
     let c = a * b in
-    if (a lor b) asr mul_shift_bits = 0 || b = 0 || c / b = a then
+    if (a lor b) asr mul_shift_bits = 0
+    || not ((a = min_int && b < 0) || (b <> 0 && c / b <> a)) then
       c
     else
       raise BatNumber.Overflow


### PR DESCRIPTION
#851 introduced a regression in one of the tests. I must have forgotten to run the testsuite (blushes).

While copying the formula from the OCaml compiler, I missed out the clause that was added in  ocaml/ocaml#1520, because I forgot to switch branches.

Here is the formula from OCaml, for reference:
```ocaml
let no_overflow_mul a b =
  not ((a = min_int && b < 0) || (b <> 0 && (a * b) / b <> a))
```