### PR TITLE
Map.equal used (=) instead of argument

### DIFF
--- a/src/batMap.ml
+++ b/src/batMap.ml
@@ -1118,7 +1118,7 @@ let bindings = Concrete.bindings
 let compare cmp_val m1 m2 =
   Concrete.compare Pervasives.compare Pervasives.compare m1 m2
 
-let equal eq_val m1 m2 = Concrete.equal Pervasives.compare (=) m1 m2
+let equal eq_val m1 m2 = Concrete.equal Pervasives.compare eq_val m1 m2
 
 module Exceptionless =
 struct


### PR DESCRIPTION
Map.equal does not use its argument for checking equality:

~~~ocaml
# BatMap.(equal (fun x y -> print_endline "eq"; x=y) (add 1 2 empty) (add 1 2 empty))
- : bool = true
~~~

The functorized versions are fine.