### PR TITLE
Feature parity of DynArray and Array

### DIFF
--- a/src/batDynArray.ml
+++ b/src/batDynArray.ml
@@ -574,7 +574,7 @@ let split a =
 
 let combine a1 a2 =
   if a1.len <> a2.len then
-    Pervasives.invalid_arg "DynArray.iter2i";
+    invalid_arg "DynArray.iter2i";
   let arr = imake a1.len in
   for i = 0 to a1.len - 1 do
     iset arr i (iget a1.arr i, iget a2.arr i)
@@ -1151,7 +1151,7 @@ let fold_righti f a x =
 
 let reduce f a =
   if a.len = 0 then
-    Pervasives.invalid_arg "DynArray.reduce: empty array"
+    invalid_arg "DynArray.reduce: empty array"
   else (
     let acc = ref (iget a.arr 0) in
     for i = 1 to a.len-1 do 
@@ -1222,7 +1222,7 @@ let min a = reduce Pervasives.min a
 let min_max a =
   let n = a.len in
   if n = 0 then
-    Pervasives.invalid_arg "DynArray.min_max: empty array"
+    invalid_arg "DynArray.min_max: empty array"
   else
     let mini = ref @@ iget a.arr 0 in
     let maxi = ref @@ iget a.arr 0 in
@@ -1292,7 +1292,7 @@ let favg a =
 
 let iter2 f a1 a2 =
   if a1.len <> a2.len then 
-    Pervasives.invalid_arg "DynArray.iter2";
+    invalid_arg "DynArray.iter2";
   for i = 0 to a1.len - 1 do
     f (iget a1.arr i) (iget a2.arr i);
   done
@@ -1308,7 +1308,7 @@ let iter2 f a1 a2 =
 
 let iter2i f a1 a2 =
   if a1.len <> a2.len then
-    Pervasives.invalid_arg "DynArray.iter2i";
+    invalid_arg "DynArray.iter2i";
   for i = 0 to a1.len - 1 do
     f i (iget a1.arr i) (iget a2.arr i);
   done
@@ -1325,7 +1325,7 @@ let iter2i f a1 a2 =
 let for_all2 p a1 a2 =
   let n = a1.len in
   if a2.len <> n then 
-    Pervasives.invalid_arg "DynArray.for_all2";
+    invalid_arg "DynArray.for_all2";
   let rec loop i =
     if i = n then
       true
@@ -1349,7 +1349,7 @@ let for_all2 p a1 a2 =
 let exists2 p a1 a2 =
   let n = a1.len in
   if a2.len <> n then 
-    Pervasives.invalid_arg "DynArray.exists2";
+    invalid_arg "DynArray.exists2";
   let rec loop i =
     if i = n then
       false
@@ -1370,7 +1370,7 @@ let exists2 p a1 a2 =
 let map2 f a1 a2 =
   let n = a1.len in
   if a2.len <> n then 
-    Pervasives.invalid_arg "DynArray.map2";
+    invalid_arg "DynArray.map2";
   init n (fun i -> f (iget a1.arr i) (iget a2.arr i))
 
 (*$T map2
@@ -1385,7 +1385,7 @@ let map2 f a1 a2 =
 let map2i f a1 a2 =
   let n = a1.len in
   if a2.len <> n then 
-    Pervasives.invalid_arg "DynArray.map2i";
+    invalid_arg "DynArray.map2i";
   init n (fun i -> f i (iget a1.arr i) (iget a2.arr i))
 
 (*$T map2i

--- a/src/batDynArray.ml
+++ b/src/batDynArray.ml
@@ -1239,13 +1239,13 @@ let min_max a =
       with Invalid_argument _ -> true
 *)
 
-let sum = reduce (+)
+let sum = fold_left (+) 0
 (*$T sum
   sum (of_list [1;2;3]) = 6
   sum (of_list [0]) = 0
  *)
 
-let fsum = reduce (+.)
+let fsum = fold_left (+.) 0.
 (*$T fsum
   fsum (of_list [1.0;2.0;3.0]) = 6.0
   fsum (of_list [0.0]) = 0.0

--- a/src/batDynArray.ml
+++ b/src/batDynArray.ml
@@ -156,12 +156,25 @@ let create() =
     bool_invariants v)
   *)
 
-let make initsize =
-  if initsize < 0 then invalid_arg initsize "make" "size";
+let singleton x = 
+  let a = {
+    resize = default_resizer;
+    len = 1;
+    arr = imake 1;
+  } in
+  iset a.arr 0 x;
+  a
+
+(*$T
+  to_list @@ singleton 42 = [42]
+*)
+
+let make initlen =
+  if initlen < 0 then invalid_arg initlen "make" "size";
   {
     resize = default_resizer;
     len = 0;
-    arr = imake initsize;
+    arr = imake initlen;
   }
 
 let init initlen f =
@@ -193,17 +206,83 @@ let get d idx =
   if idx < 0 || idx >= d.len then invalid_arg idx "get" "index";
   iget d.arr idx
 
-let last d =
-  if d.len = 0 then invalid_arg 0 "last" "<array len is 0>";
-  iget d.arr (d.len - 1)
-
 let set d idx v =
   if idx < 0 || idx >= d.len then invalid_arg idx "set" "index";
   iset d.arr idx v
 
+(* upd a i f = set a i (f @@ get a i) 
+   Faster (avoids duplication of bounds checks) and more convenient. *)
+let upd d idx f =
+  if idx < 0 || idx >= d.len then invalid_arg idx "set" "index";
+  iset d.arr idx (f @@ iget d.arr idx)
+
+let first d =
+  if d.len = 0 then invalid_arg 0 "first" "<array len is 0>";
+  iget d.arr 0
+
+let last d =
+  if d.len = 0 then invalid_arg 0 "last" "<array len is 0>";
+  iget d.arr (d.len - 1)
+
 (*$T
   let v = of_list [1;2;3;4] in set v 1 42; get v 1 = 42
   let v = of_list [1;2;3;4] in set v 1 42; last v = 4
+  let v = of_list [1;2;3;4] in set v 1 42; first v = 1
+  let v = of_list [1;2;3;4] in upd v 1 succ; get v 1 = 3
+*)
+
+let left a n =
+  let arr = imake n in
+  for i = 0 to n - 1 do
+    iset arr i (iget a.arr i)
+  done;
+  {
+    resize = a.resize;
+    len = n;
+    arr = arr;
+  }
+
+let right a n =
+  let arr = imake n in
+  (* for i = a.len - n to a.len - 1 do *)
+  let i = ref 0 in
+  let j = ref (a.len - n) in
+  while !i < n do
+    iset arr !i (iget a.arr !j);
+    incr i; incr j;
+  done;
+  {
+    resize = a.resize;
+    len = n;
+    arr = arr;
+  }
+
+(*$T
+  let v = left  (of_list [1;2;3;4;5;6;7;8]) 3 in to_list v = [1;2;3]
+  let v = right (of_list [1;2;3;4;5;6;7;8]) 3 in to_list v = [6;7;8]
+*)
+
+let head = left
+
+let tail a n =
+  let len = a.len - n in
+  let arr = imake len in
+  (* for i = n to a.len - 1 do *)
+  let i = ref 0 in
+  let j = ref n in
+  while !j < a.len do
+    iset arr !i (iget a.arr !j);
+    incr i; incr j;
+  done;
+  {
+    resize = a.resize;
+    len = len;
+    arr = arr;
+  }
+
+(*$T
+  let v = head (of_list [1;2;3;4;5;6;7;8]) 3 in to_list v = [1;2;3]
+  let v = tail (of_list [1;2;3;4;5;6;7;8]) 3 in to_list v = [4;5;6;7;8]
 *)
 
 let insert d idx v =
@@ -421,7 +500,96 @@ let sub src start len =
   }
 
 (*$T
-  let v = of_list [1;2;3] in let v2 = sub v 1 2 in to_list v2 = [2;3]
+  let v = of_list [1;2;3;4;5] in \
+    let v2 = sub v 1 3 in to_list v2 = [2;3;4]
+  let v = of_list [1;2;3;4;5] in \
+    let v2 = sub v 0 1 in to_list v2 = [1]
+  let v = of_list [1;2;3;4;5] in \
+    let v2 = sub v 4 1 in to_list v2 = [5]
+  let v = of_list [1;2;3;4;5] in \
+    let v2 = sub v 2 0 in to_list v2 = []
+  let v = of_list [1;2;3;4;5] in \
+    try ignore @@ sub v (-1) 2; false with Invalid_arg _ -> true
+  let v = of_list [1;2;3;4;5] in \
+    try ignore @@ sub v 5 2; false with Invalid_arg _ -> true
+  let v = of_list [1;2;3;4;5] in \
+    try ignore @@ sub v 3 3; false with Invalid_arg _ -> true
+  let v = of_list [1;2;3;4;5] in \
+    try ignore @@ sub v 3 (-1); false with Invalid_arg _ -> true
+*)
+
+let fill a start len x = 
+  if len < 0 then invalid_arg len "fill" "len";
+  if start < 0 || start+len > a.len then invalid_arg start "fill" "start";
+  for i = start to start + len - 1 do
+    iset a.arr i x
+  done
+
+(*$T
+  let v = of_list [1;2;3;4;5] in \
+    fill v 1 3 0; to_list v = [1;0;0;0;5]
+  let v = of_list [1;2;3;4;5] in \
+    fill v 0 1 0; to_list v = [0;2;3;4;5]
+  let v = of_list [1;2;3;4;5] in \
+    fill v 4 1 0; to_list v = [1;2;3;4;0]
+  let v = of_list [1;2;3;4;5] in \
+    fill v 2 0 0; to_list v = [1;2;3;4;5]
+  let v = of_list [1;2;3;4;5] in \
+    try fill v (-1) 2 0; false with Invalid_arg _ -> true
+  let v = of_list [1;2;3;4;5] in \
+    try fill v 5 2 0; false with Invalid_arg _ -> true
+  let v = of_list [1;2;3;4;5] in \
+    try fill v 3 3 0; false with Invalid_arg _ -> true
+  let v = of_list [1;2;3;4;5] in \
+    try fill v 3 (-1) 0; false with Invalid_arg _ -> true
+  let v = of_list [1;2;3;4;5] in \
+    try fill v (-1) 2 0; false with Invalid_arg _ -> true
+  let v = of_list [1;2;3;4;5] in \
+    try fill v 5 2 0; false with Invalid_arg _ -> true
+  let v = of_list [1;2;3;4;5] in \
+    try fill v 3 3 0; false with Invalid_arg _ -> true
+  let v = of_list [1;2;3;4;5] in \
+    try fill v 3 (-1) 0; false with Invalid_arg _ -> true
+*)
+
+let split a =
+  let n = a.len in
+  let left = make n in
+  let right = make n in
+  for i = 0 to n-1 do
+    let a,b = iget a.arr i in
+    iset left.arr i a;
+    iset right.arr i b
+  done;
+  left.len <- n;
+  right.len <- n;
+  (left, right)
+
+(*$T
+  let v = of_list [] in let l,r = split v in \
+    (to_list l, to_list r) = ([], [])
+  let v = of_list [(1,"a");(2,"b");(3,"c")] in let l,r = split v in \
+    (to_list l, to_list r) = ([1;2;3], ["a";"b";"c"])
+*)
+
+let combine a1 a2 =
+  if a1.len <> a2.len then
+    Pervasives.invalid_arg "DynArray.iter2i";
+  let arr = imake a1.len in
+  for i = 0 to a1.len - 1 do
+    iset arr i (iget a1.arr i, iget a2.arr i)
+  done;
+  {
+    resize = a1.resize; 
+    len = a1.len;
+    arr = arr;
+  }
+
+(*$T
+  let l,r = (of_list [], of_list []) in let c = combine l r in \
+    to_list c = []
+  let l, r = (of_list [1;2;3], of_list ["a";"b";"c"]) in let c = combine l r in \
+    to_list c = [(1,"a");(2,"b");(3,"c")]
 *)
 
 let iter f d =
@@ -508,7 +676,8 @@ let iteri f d =
   ) d
 *)
 
-let filter f d =
+(* Old implementation *)
+(*let filter f d =
   let l = d.len in
   let dest = make l in
   let a2 = d.arr in
@@ -532,41 +701,61 @@ let filter f d =
   done;
   dest.len <- !p;
   changelen dest !p;
-  dest
+  dest*)
 
-(*$R filter
-  let n = 20 in
-  let d = init n (fun i -> string_of_int i) in
-  let i = ref (-1) in
-  let d = filter (fun s ->
-     assert (Obj.tag (Obj.repr s) = Obj.string_tag); incr i;
-     !i mod 2 = 0) d in
-  assert_bool "filter" (length d = n / 2);
-  let acc = ref true in
-  iteri (fun idx s -> acc := (!acc && (s = string_of_int (2 * idx)))) d;
-  assert_bool "filter" !acc
+(* Efficient implementation using BitSet, lifted from BatArray implementation of filter *)
+let filter p a =
+  let n = a.len in
+  (* Use a bitset to store which elements will be in the final array. *)
+  let bs = BatBitSet.create n in
+  for i = 0 to n-1 do
+    if p @@ iget a.arr i then 
+      BatBitSet.set bs i
+  done;
+  (* Allocate the final array and copy elements into it. *)
+  let n' = BatBitSet.count bs in
+  let j = ref 0 in
+  init n'
+    (fun _ -> match BatBitSet.next_set_bit bs !j with
+      | Some i -> j := i+1; iget a.arr i
+      | None ->
+        (* not enough 1 bits - incorrect count? *)
+        assert false
+    )
+
+(*$T filter
+  let v = filter (fun x -> x mod 3 = 0) (of_list @@ BatList.range 1 `To 10) in \
+    to_list v = [3;6;9]
+  let v = filter (fun _ -> assert false) (create()) in \
+    to_list v = []
 *)
 
-(*$R filter
-  let n = 40 in
-  let d = init n (fun i -> string_of_int i) in
-  let i = ref (-1) in
-  ignore (filter (fun s -> assert (Obj.tag (Obj.repr s) = Obj.string_tag); incr i;
-          if !i = 0 then
-            for _count = 0 to n * 4 / 5 do delete_last d done;
-          true
-  ) d)
-*)
+let find_all = filter
 
-(*$R filter
-  let n = 40 in
-  let d = init n (fun i -> string_of_int i) in
-  let i = ref (-1) in
-  ignore (filter (fun s -> assert (Obj.tag (Obj.repr s) = Obj.string_tag); incr i;
-          if !i = 0 then
-            for _count = 0 to n * 4 do add d "poi" done;
-          true
-  ) d)
+let filteri p a =
+  let n = a.len in
+  (* Use a bitset to store which elements will be in the final array. *)
+  let bs = BatBitSet.create n in
+  for i = 0 to n-1 do
+    if p i @@ iget a.arr i then 
+      BatBitSet.set bs i
+  done;
+  (* Allocate the final array and copy elements into it. *)
+  let n' = BatBitSet.count bs in
+  let j = ref 0 in
+  init n'
+    (fun _ -> match BatBitSet.next_set_bit bs !j with
+      | Some i -> j := i+1; iget a.arr i
+      | None ->
+        (* not enough 1 bits - incorrect count? *)
+        assert false
+    )
+
+(*$T filteri
+  let v = filteri (fun i x -> (i+x) mod 2 = 0) (of_list [1;2;3;4;0;1;2;3]) in \
+    to_list v = [0;1;2;3]
+  let v = filteri (fun _ _ -> assert false) (create()) in \
+    to_list v = []
 *)
 
 let keep f d =
@@ -636,17 +825,140 @@ let filter_map f d =
   ) d)
 *)
 
-let index_of f d =
+let partition p a =
+  let n = a.len in
+  (* Use a bitset to store which elements will be in the final array. *)
+  let bs = BatBitSet.create n in
+  for i = 0 to n-1 do
+    if p @@ iget a.arr i then 
+      BatBitSet.set bs i
+  done;
+  (* Allocate the arrays and copy elements into them. *)
+  let n' = BatBitSet.count bs in
+  let pos = make n' in
+  let neg = make (n-n') in
+  for i = 0 to n-1 do
+    if BatBitSet.mem bs i then
+      add pos @@ iget a.arr i
+    else
+      add neg @@ iget a.arr i
+  done;
+  (pos, neg)
+
+(*$T partition
+  let v,w = partition (fun x -> x mod 3 = 0) (of_list @@ BatList.range 1 `To 10) in \
+    (to_list v, to_list w) = ([3;6;9], [1;2;4;5;7;8;10])
+  let v,w = partition (fun _ -> assert false) (create()) in \
+    empty v && empty w
+*)
+
+let for_all p a =
+  let n = a.len in
   let rec loop i =
-    if i >= d.len then
-      raise Not_found
-    else
-    if f (iget d.arr i) then
-      i
-    else
-      loop (i+1)
+    if i = n then true
+    else if p (iget a.arr i) then loop (succ i)
+    else false
   in
   loop 0
+
+(*$T for_all
+   for_all (fun x -> x mod 2 = 0) (of_list [2;4;6]) = true
+   for_all (fun x -> x mod 2 = 0) (of_list [2;3;6]) = false
+   for_all (fun _ -> false) (create()) = true
+*)
+
+let exists p a =
+  let n = a.len in
+  let rec loop i =
+    if i = n then false
+    else if p (iget a.arr i) then true
+    else loop (succ i)
+  in
+  loop 0
+
+(*$T exists
+   exists (fun x -> x mod 2 = 0) (of_list [1;4;5]) = true
+   exists (fun x -> x mod 2 = 0) (of_list [1;3;5]) = false
+   exists (fun _ -> false) (create()) = false
+*)
+
+
+let mem x a =
+  let n = a.len in
+  let rec loop i =
+    if i = n then
+      false
+    else if x = iget a.arr i then
+      true
+    else
+      loop (succ i)
+  in
+  loop 0
+
+(*$T mem
+   mem 2 (of_list [1;2;3]) = true
+   mem 2 (create()) = false
+   mem (ref 3) (of_list [ref 1; ref 2; ref 3]) = true
+*)
+
+let memq x a =
+  let n = a.len in
+  let rec loop i =
+    if i = n then
+      false
+    else if x == iget a.arr i then
+      true
+    else
+      loop (succ i)
+  in
+  loop 0
+
+(*$T memq
+   memq 2 (of_list [1;2;3]) = true
+   memq 2 (create()) = false
+   memq (ref 3) (of_list [ref 1; ref 2; ref 3]) = false
+*)
+
+let index_of p a =
+  let rec loop i =
+    if i = a.len then
+      raise Not_found
+    else if p (iget a.arr i) then
+      i
+    else
+      loop (succ i)
+  in
+  loop 0
+
+let findi = index_of
+(*$T findi
+  findi (fun x -> x mod 3 = 0) (of_list [1;2;3;4;5;6]) = 2
+  try ignore @@ findi (fun x -> x mod 3 = 0) (of_list [1;2;4;5]); false \
+    with Not_found -> true
+  try ignore @@ findi (fun _ -> assert false) (create()); false \
+    with Not_found -> true
+*)
+
+(* let find p a = iget a.arr (findi p a) *)
+let find p a =
+  let rec loop i =
+    if i = a.len then
+      raise Not_found
+    else 
+      let x = iget a.arr i in
+      if p x then
+        x
+      else
+        loop (succ i)
+  in
+  loop 0
+(*$T find
+  find (fun x -> x mod 3 = 0) (of_list [1;2;3;4;5;6]) = 3
+  try ignore @@ find (fun x -> x mod 3 = 0) (of_list [1;2;4;5]); false \
+    with Not_found -> true
+  try ignore @@ find (fun _ -> assert false) (create()); false \
+    with Not_found -> true
+*)
 
 let map f src =
   let len = src.len in
@@ -755,6 +1067,26 @@ let mapi f src =
   (* could be something else if the implementation changed *)
 *)
 
+let modify f a =
+  for i = 0 to length a - 1 do
+    iset a.arr i (f (iget a.arr i))
+  done
+
+(*$T modify
+  let a = (of_list [3;2;1]) in \
+    modify (fun x -> x + 1) a; to_list a = [4;3;2]
+*)
+
+let modifyi f a =
+  for i = 0 to length a - 1 do
+    iset a.arr i (f i (iget a.arr i))
+  done
+
+(*$T modifyi
+  let a = (of_list [3;2;1]) in \
+    modifyi (fun i x -> i * x) a; to_list a = [0;2;2]
+*)
+
 let fold_left f x a =
   let rec loop idx x =
     if idx >= a.len then x else loop (idx + 1) (f x (iget a.arr idx))
@@ -792,6 +1124,295 @@ let fold_right f a x =
             for _count = 0 to n - 1 - newlen do delete_last d done
   ) d ())
 *)
+
+let fold_lefti f x a =
+  let r = ref x in
+  for i = 0 to a.len - 1 do
+    r := f !r i (iget a.arr i)
+  done;
+  !r
+
+(*$T fold_lefti
+   fold_lefti (fun a i x -> a + i * x) 1 (of_list [2;4;5]) = 1 + 0 + 4 + 10
+   fold_lefti (fun a i x -> a + i * x) 1 (create()) = 1
+*)
+
+let fold_righti f a x =
+  let r = ref x in
+  for i = a.len - 1 downto 0 do
+    r := f i (iget a.arr i) !r
+  done;
+  !r
+
+(*$T fold_righti
+   fold_righti (fun i x a -> a + i * x) (of_list [2;4;5]) 1 = 1 + 0 + 4 + 10
+   fold_righti (fun i x a -> a + i * x) (create()) 1 = 1
+*)
+
+let reduce f a =
+  if a.len = 0 then
+    Pervasives.invalid_arg "DynArray.reduce: empty array"
+  else (
+    let acc = ref (iget a.arr 0) in
+    for i = 1 to a.len-1 do 
+      acc := f !acc (iget a.arr i)
+    done;
+    !acc
+  )
+
+(*$T reduce
+   reduce (+) (of_list [1;2;3]) = 6
+   reduce (fun _ -> assert false) (of_list [1]) = 1
+   try reduce (fun _ _ -> ()) (create()); false \
+     with Invalid_argument _ -> true
+*)
+
+let rev a = 
+  let n = a.len - 1 in
+  let newarr = imake (n+1) in
+  for i = 0 to n do
+    iset newarr i (iget a.arr (n-i))
+  done;
+  {
+    resize = a.resize;
+    len = a.len;
+    arr = newarr;
+  }
+
+(*$T
+  let a = rev (of_list [1;3;2;5]) in to_list a = [5;2;3;1]
+  let a = rev (of_list [1;3;2;5;-1]) in to_list a = [-1;5;2;3;1]
+  let a = rev (create()) in empty a
+ *)
+
+let rev_in_place a = 
+  let n = a.len - 1 in
+  let lim = a.len/2 - 1 in
+  for i = 0 to lim do
+    let x = iget a.arr (n-i) in
+    iset a.arr (n-i) (iget a.arr i);
+    iset a.arr i x
+  done
+
+(*$T
+  let a = of_list [1;3;2;5] in rev_in_place a; \
+    to_list a = [5;2;3;1]
+  let a = of_list [1;3;2;5;-1] in rev_in_place a; \
+    to_list a = [-1;5;2;3;1]
+  let a = create() in rev_in_place a; \
+    empty a
+ *)
+
+let max a = reduce Pervasives.max a
+(*$T
+  max (of_list [1;2;3]) = 3
+  max (of_list [2;3;1]) = 3
+  try ignore (max (create())); false \
+    with Invalid_argument _ -> true
+ *)
+
+let min a = reduce Pervasives.min a
+(*$T
+  min (of_list [1;2;3]) = 1
+  min (of_list [2;3;1]) = 1
+  try ignore (min (create())); false \
+    with Invalid_argument _ -> true
+ *)
+
+let min_max a =
+  let n = a.len in
+  if n = 0 then
+    Pervasives.invalid_arg "DynArray.min_max: empty array"
+  else
+    let mini = ref @@ iget a.arr 0 in
+    let maxi = ref @@ iget a.arr 0 in
+    for i = 1 to n-1 do
+      let x = iget a.arr i in
+      if x > !maxi then maxi := x;
+      if x < !mini then mini := x
+    done;
+    (!mini, !maxi)
+(*$T min_max
+    min_max (of_list [1]) = (1, 1)
+    min_max (of_list [1;-2;10;3]) = (-2, 10)
+    try ignore (min_max (create())); false \
+      with Invalid_argument _ -> true
+*)
+
+let sum = reduce (+)
+(*$T sum
+  sum (of_list [1;2;3]) = 6
+  sum (of_list [0]) = 0
+ *)
+
+let fsum = reduce (+.)
+(*$T fsum
+  fsum (of_list [1.0;2.0;3.0]) = 6.0
+  fsum (of_list [0.0]) = 0.0
+ *)
+
+let kahan_sum a =
+  let sum = ref 0. in
+  let err = ref 0. in
+  let n = a.len - 1 in
+  for i = 0 to n do
+    let x = iget a.arr i -. !err in
+    let new_sum = !sum +. x in
+    err := (new_sum -. !sum) -. x;
+    sum := new_sum +. 0.;
+    (* this suspicious +. 0. is added to help
+       the hand of the somewhat flaky unboxing optimizer;
+       it hopefully won't be necessary anymore
+       in a few OCaml versions *)
+  done;
+  !sum +. 0.
+
+(*$T kahan_sum
+  kahan_sum (create()) = 0.
+  kahan_sum (of_list [1.;2.]) = 3.
+  let n, x = 1_000, 1.1 in \
+  Float.approx_equal (float n *. x) (kahan_sum (init n (fun _ -> x)))
+*)
+
+let avg a =
+  (float_of_int @@ sum a) /. (float_of_int @@ length a)
+(*$T avg
+  avg (of_list [1;2;3]) = 2.
+  avg (of_list [0]) = 0.
+*) 
+
+let favg a =
+  (fsum a) /. (float_of_int @@ length a)
+(*$T favg
+  favg (of_list [1.0; 2.0; 3.0]) = 2.0
+  favg (of_list [0.0]) = 0.0
+*)
+
+
+
+let iter2 f a1 a2 =
+  if a1.len <> a2.len then 
+    Pervasives.invalid_arg "DynArray.iter2";
+  for i = 0 to a1.len - 1 do
+    f (iget a1.arr i) (iget a2.arr i);
+  done
+(*$T iter2
+  let x = ref 0 in \
+    iter2 (fun a b -> x := !x + a*b) (of_list [1;2;3]) (of_list [4;-5;6]); \
+    !x = 12
+  try iter2 (fun _ _ -> ()) (of_list [1]) (of_list [1;2;3]); false \
+    with Invalid_argument _ -> true
+  try iter2 (fun _ _ -> ()) (of_list [1]) (of_list []); false \
+    with Invalid_argument _ -> true
+*)
+
+let iter2i f a1 a2 =
+  if a1.len <> a2.len then
+    Pervasives.invalid_arg "DynArray.iter2i";
+  for i = 0 to a1.len - 1 do
+    f i (iget a1.arr i) (iget a2.arr i);
+  done
+(*$T iter2i
+  let x = ref 0 in \
+    iter2i (fun i a b -> x := !x + a*b + i) (of_list [1;2;3]) (of_list [4;-5;6]); \
+    !x = 15
+  try iter2i (fun _ _ _ -> ()) (of_list [1]) (of_list [1;2;3]); false \
+    with Invalid_argument _ -> true
+  try iter2i (fun _ _ _ -> ()) (of_list [1]) (of_list []); false \
+    with Invalid_argument _ -> true
+*)
+
+let for_all2 p a1 a2 =
+  let n = a1.len in
+  if a2.len <> n then 
+    Pervasives.invalid_arg "DynArray.for_all2";
+  let rec loop i =
+    if i = n then
+      true
+    else if p (iget a1.arr i) (iget a2.arr i) then
+      loop (succ i)
+    else
+      false
+  in
+  loop 0
+
+(*$T for_all2
+   for_all2 (=) (of_list [1;2;3]) (of_list [3;2;1]) = false
+   for_all2 (=) (of_list [1;2;3]) (of_list [1;2;3]) = true
+   for_all2 (<>) (of_list [1;2;3]) (of_list [3;2;1]) = false
+   try ignore (for_all2 (=) (of_list [1;2;3]) (of_list [1;2;3;4])); false \
+     with Invalid_argument _ -> true
+   try ignore (for_all2 (=) (of_list [1;2]) (of_list [])); false \
+     with Invalid_argument _ -> true
+*)
+
+let exists2 p a1 a2 =
+  let n = a1.len in
+  if a2.len <> n then 
+    Pervasives.invalid_arg "DynArray.exists2";
+  let rec loop i =
+    if i = n then
+      false
+    else if p (iget a1.arr i) (iget a2.arr i) then
+      true
+    else
+      loop (succ i)
+  in
+  loop 0
+
+(*$T exists2
+   exists2 (=) (of_list [1;2;3]) (of_list [3;2;1])
+   exists2 (<>) (of_list [1;2;3]) (of_list [1;2;3]) = false
+   try ignore (exists2 (=) (of_list [1;2]) (of_list [3])); false \
+     with Invalid_argument _ -> true
+*)
+
+let map2 f a1 a2 =
+  let n = a1.len in
+  if a2.len <> n then 
+    Pervasives.invalid_arg "DynArray.map2";
+  init n (fun i -> f (iget a1.arr i) (iget a2.arr i))
+
+(*$T map2
+   let v = map2 (-) (of_list [1;2;3]) (of_list [6;3;1]) in to_list v = [-5;-1;2]
+   let v = map2 (-) (of_list [2;4;6]) (of_list [1;2;3]) in to_list v = [1;2;3]
+   try ignore (map2 (-) (of_list [2;4]) (of_list [1;2;3])); false \
+     with Invalid_argument _ -> true
+   try ignore (map2 (-) (of_list [2;4]) (of_list [3])); false \
+     with Invalid_argument _ -> true
+*)
+
+let map2i f a1 a2 =
+  let n = a1.len in
+  if a2.len <> n then 
+    Pervasives.invalid_arg "DynArray.map2i";
+  init n (fun i -> f i (iget a1.arr i) (iget a2.arr i))
+
+(*$T map2i
+   let v = map2i (fun i a b -> a-b + i) (of_list [1;2;3]) (of_list [6;3;1]) in to_list v = [-5;0;4]
+   let v = map2i (fun i a b -> a-b + i) (of_list [2;4;6]) (of_list [1;2;3]) in to_list v = [1;3;5]
+   try ignore (map2i (fun i a b -> a-b + i) (of_list [2;4]) (of_list [1;2;3])); false \
+     with Invalid_argument _ -> true
+   try ignore (map2i (fun i a b -> a-b + i) (of_list [2;4]) (of_list [3])); false \
+     with Invalid_argument _ -> true
+*)
+
+let cartesian_product a1 a2 =
+  let na = a1.len in
+  let nb = a2.len in
+  init
+    (na * nb)
+    (fun j -> 
+      let i = j / nb in
+      (iget a1.arr i, iget a2.arr (j - i*nb))
+    )
+
+(*$T cartesian_product
+  let a = cartesian_product (of_list [1;2]) (of_list ["a";"b"]) in \
+    to_list a = [(1,"a"); (1,"b"); (2,"a"); (2,"b")]
+*)
+
+
 
 let enum d =
   let rec make start =
@@ -834,15 +1455,36 @@ let of_enum e =
     enum v |> of_enum |> to_list = l)
 *)
 
+let range xs = BatEnum.(--^) 0 (xs.len)
+
+
+
+module Exceptionless =
+struct
+  let find p a =
+    try Some (find p a)
+    with Not_found -> None
+
+  let findi p a =
+    try Some (findi p a)
+    with Not_found -> None
+end
+
+
+
 let unsafe_get a n =
   iget a.arr n
 
 let unsafe_set a n x =
   iset a.arr n x
 
+let unsafe_upd a n f =
+  iset a.arr n (f @@ iget a.arr n)
+
 let print ?(first="[|") ?(last="|]") ?(sep="; ") print_a out t =
   BatEnum.print ~first ~last ~sep print_a out (enum t)
 
 (*$T
   Printf.sprintf2 "%a" (print Int.print) (of_list [1;2]) = "[|1; 2|]"
+  Printf.sprintf2 "%a" (print Int.print) (of_list []) = "[||]"
 *)

--- a/src/batDynArray.mli
+++ b/src/batDynArray.mli
@@ -59,24 +59,49 @@ val init : int -> (int -> 'a) -> 'a t
 (** [init n f] returns an array of [n] elements filled with values
     returned by [f 0 , f 1, ... f (n-1)]. *)
 
+val singleton : 'a -> 'a t
+(** Create an array consisting of exactly one element. *)
+
 (** {6 Array manipulation functions} *)
-
-val empty : 'a t -> bool
-(** Return true if the number of elements in the array is 0. *)
-
-val length : 'a t -> int
-(** Return the number of elements in the array. *)
 
 val get : 'a t -> int -> 'a
 (** [get darr idx] gets the element in [darr] at index [idx]. If [darr] has
     [len] elements in it, then the valid indexes range from [0] to [len-1]. *)
 
-val last : 'a t -> 'a
-(** [last darr] returns the last element of [darr]. *)
-
 val set : 'a t -> int -> 'a -> unit
 (** [set darr idx v] sets the element of [darr] at index [idx] to value
     [v].  The previous value is overwritten. *)
+
+val upd : 'a t -> int -> ('a -> 'a) -> unit
+(** [upd darr idx f] sets the element of [darr] at index [idx] to value
+    [f (get darr idx)]). The previous value is overwritten *) 
+
+val length : 'a t -> int
+(** Return the number of elements in the array. *)
+
+val empty : 'a t -> bool
+(** Return true if the number of elements in the array is 0. *)
+
+val first : 'a t -> 'a
+(** [first darr] returns the first element of [darr]. *)
+
+val last : 'a t -> 'a
+(** [last darr] returns the last element of [darr]. *)
+
+val left : 'a t -> int -> 'a t
+(**[left r len] returns the array containing the [len] first
+   characters of [r]. If [r] contains less than [len] characters, it
+   returns [r]. *)
+
+val right : 'a t -> int -> 'a t
+(**[left r len] returns the array containing the [len] last characters of [r].
+   If [r] contains less than [len] characters, it returns [r]. *)
+
+val head : 'a t -> int -> 'a t
+(**as {!left}*)
+
+val tail : 'a t -> int -> 'a t
+(**[tail r pos] returns the array containing all but the [pos] first characters of [r] *)
 
 val insert : 'a t -> int -> 'a -> unit
 (** [insert darr idx v] inserts [v] into [darr] at index [idx].  All elements
@@ -85,11 +110,14 @@ val insert : 'a t -> int -> 'a -> unit
     element. *)
 
 val add : 'a t -> 'a -> unit
-(** [add darr v] appends [v] onto [darr].  [v] becomes the new
+(** [add darr v] appends [v] onto the end of [darr].  [v] becomes the new
     last element of [darr]. *)
 
 val append : 'a t -> 'a t -> unit
 (** [append src dst] adds all elements of [src] to the end of [dst]. *)
+
+(*val concat : 'a array list -> 'a array
+(** Same as [append], but concatenates a list of arrays. *)*)
 
 val delete : 'a t -> int -> unit
 (** [delete darr idx] deletes the element of [darr] at [idx].  All elements
@@ -101,8 +129,8 @@ val delete_last : 'a t -> unit
     of doing [delete darr ((length darr) - 1)]. *)
 
 val delete_range : 'a t -> int -> int -> unit
-(** [delete_range darr p len] deletes [len] elements starting at index [p].
-    All elements with an index greater than [p+len] are moved to fill
+(** [delete_range darr idx len] deletes [len] elements starting at index [idx].
+    All elements with an index greater than [idx+len] are moved to fill
     in the hole. *)
 
 val clear : 'a t -> unit
@@ -117,34 +145,66 @@ val compact : 'a t -> unit
 
 (** {6 Array copy and conversion} *)
 
-val to_list : 'a t -> 'a list
-(** [to_list darr] returns the elements of [darr] in order as a list. *)
-
-val to_array : 'a t -> 'a array
-(** [to_array darr] returns the elements of [darr] in order as an array. *)
-
 val enum : 'a t -> 'a BatEnum.t
 (** [enum darr] returns the enumeration of [darr] elements. *)
+
+val of_enum : 'a BatEnum.t -> 'a t
+(** [of_enum e] returns an array that holds, in order, the elements of [e]. *)
+
+(* val backwards : 'a array -> 'a BatEnum.t
+(** Returns an enumeration of the elements of an array, from last to first. *)
+
+val of_backwards : 'a BatEnum.t -> 'a array
+(** Build an array from an enumeration, with the first element of
+    the enumeration as the last element of the array and vice
+    versa. *) *)
+
+val range : 'a t -> int BatEnum.t
+(** [range a] returns an enumeration of all valid indices of the given
+    array, that is, [range a = 0 --^ length a] *)
+
+val to_list : 'a t -> 'a list
+(** [to_list darr] returns the elements of [darr] in order as a list. *)
 
 val of_list : 'a list -> 'a t
 (** [of_list lst] returns a dynamic array with the elements of [lst] in
     it in order. *)
 
+val to_array : 'a t -> 'a array
+(** [to_array darr] returns the elements of [darr] in order as an array. *)
+
 val of_array : 'a array -> 'a t
 (** [of_array arr] returns an array with the elements of [arr] in it
     in order. *)
 
-val of_enum : 'a BatEnum.t -> 'a t
-(** [of_enum e] returns an array that holds, in order, the elements of [e]. *)
-
 val copy : 'a t -> 'a t
-(** [copy src] returns a fresh copy of [src], such that no modification of
-    [src] affects the copy, or vice versa (all new memory is allocated for
+(** [copy a] returns a fresh copy of [a], such that no modification of
+    [a] affects the copy, or vice versa (all new memory is allocated for
     the copy).   *)
 
 val sub : 'a t -> int -> int -> 'a t
-(** [sub darr start len] returns an array holding the subset of [len]
-    elements from [darr] starting with the element at index [idx]. *)
+(** [sub a start len] returns an array holding the subset of [len]
+    elements from [a] starting with the element at index [idx]. 
+
+    @raise Invalid_arg if [start] and [len] do not
+    designate a valid subarray of [a]; that is, if
+    [start < 0], or [len < 0], or [start + len > Array.length a]. *)
+
+val fill : 'a t -> int -> int -> 'a -> unit
+(** [fill a start len x] modifies the array [a] in place,
+    storing [x] in elements number [start] to [start + len - 1].
+
+    @raise Invalid_arg if [start] and [len] do not
+    designate a valid subarray of [a]. *)
+
+val split : ('a * 'b) t -> 'a t * 'b t
+(** [split a] converts the array of pairs [a] into a pair of arrays. *)
+
+val combine : 'a t -> 'b t -> ('a * 'b) t
+(** [combine a b] converts arrays [[a0,...aN] [b0,...,bN]] into 
+    an array of pairs [[(a0,b0),...,(aN,bN)]]. 
+
+    @raise Invalid_argument if the two arrays have different lengths. *)
 
 (** {6 Array functional support} *)
 
@@ -167,6 +227,14 @@ val mapi : (int -> 'a -> 'b) -> 'a t -> 'b t
     and creates a dynamic array from the results - similar to [List.mapi] or
     [Array.mapi]. *)
 
+val modify : ('a -> 'a) -> 'a t -> unit
+(** [modify f a] replaces every element [x] of [a] with [f x]. *)
+
+val modifyi : (int -> 'a -> 'a) -> 'a t -> unit
+(** Same as {!modify}, but the function is applied to the index of
+    the element as the first argument, and the element itself as
+    the second argument. *)
+
 val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a
 (** [fold_left f x darr] computes [f ( ... ( f ( f a0 x) a1) ) ... )
     aN], where [a0,a1..aN] are the indexed elements of [darr]. *)
@@ -176,9 +244,18 @@ val fold_right : ('a -> 'b -> 'b) -> 'a t -> 'b -> 'b
     ... ) ) ], where [a0,a1..aN] are the indexed elements of
     [darr]. *)
 
-val index_of : ('a -> bool) -> 'a t -> int
-(** [index_of f darr] returns the index of the first element [x] in darr such
-    as [f x] returns [true] or raise [Not_found] if not found. *)
+val fold_lefti : ('a -> int -> 'b -> 'a) -> 'a -> 'b t -> 'a
+(** As [fold_left], but with the index of the element as additional argument *)
+
+val fold_righti : (int -> 'b -> 'a -> 'a) -> 'b t -> 'a -> 'a
+(** As [fold_right], but with the index of the element as additional argument *)
+
+val reduce : ('a -> 'a -> 'a) -> 'a t -> 'a
+(** [reduce f a] is [fold_left f a0 [a1, ... aN]].  This
+    is useful for merging a group of things that have no
+    reasonable default value to return if the group is empty.
+
+    @raise Invalid_argument on empty arrays. *)
 
 val keep : ('a -> bool) -> 'a t -> unit
 (** [keep p darr] removes in place all the element [x] of [darr]
@@ -200,10 +277,155 @@ val filter : ('a -> bool) -> 'a t -> 'a t
     was changed to {!keep}.
 *)
 
+val find_all : ('a -> bool) -> 'a t -> 'a t
+(** [find_all] is another name for [filter]. *)
+
+val filteri : (int -> 'a -> bool) -> 'a t -> 'a t
+(** As [filter] but with the index passed to the predicate. *)
+
 val filter_map : ('a -> 'b option) -> 'a t -> 'b t
 (** [filter_map f e] returns an array consisting of all elements
     [x] such that [f y] returns [Some x] , where [y] is an element
     of [e]. *)
+
+val partition : ('a -> bool) -> 'a t -> 'a t * 'a t
+(** [partition p a] returns a pair of arrays [(a1, a2)], where
+    [a1] is the array of all the elements of [a] that
+    satisfy the predicate [p], and [a2] is the array of all the
+    elements of [a] that do not satisfy [p].
+    The order of the elements in the input array is preserved. *)
+
+val for_all : ('a -> bool) -> 'a t -> bool
+(** [for_all p [a0; a1; ...; an]] checks if all elements of the
+    array satisfy the predicate [p].  That is, it returns [ (p a0)
+    && (p a1) && ... && (p an)]. *)
+
+val exists : ('a -> bool) -> 'a t -> bool
+(** [exists p [a0; a1; ...; an]] checks if at least one element of
+    the array satisfies the predicate [p].  That is, it returns [(p
+    a0) || (p a1) || ... || (p an)]. *)
+
+val find : ('a -> bool) -> 'a t -> 'a
+(** [find p a] returns the first element of array [a] that
+    satisfies the predicate [p].
+
+    @raise Not_found if there is no value that satisfies [p] in
+    the array [a]. *)
+
+val findi : ('a -> bool) -> 'a t -> int
+(** [findi p a] returns the index of the first element of array [a]
+    that satisfies the predicate [p].
+
+    @raise Not_found if there is no value that satisfies [p] in the
+    array [a].  *)
+
+val index_of : ('a -> bool) -> 'a t -> int
+(** Alias for findi *)
+
+val mem : 'a -> 'a t -> bool
+(** [mem m a] is true if and only if [m] is equal to an element of [a]. *)
+
+val memq : 'a -> 'a t -> bool
+(** Same as {!mem} but uses physical equality instead of
+    structural equality to compare array elements.  *)
+
+val rev : 'a t -> 'a t
+(** Array reversal.*)
+
+val rev_in_place : 'a t -> unit
+(** In-place array reversal.  The given array is updated. *)
+
+val max : 'a t -> 'a
+(** [max a] returns the largest value in [a] as judged by
+    [Pervasives.compare]
+
+    @raise Invalid_argument on empty input *)
+
+val min : 'a t -> 'a
+(** [min a] returns the smallest value in [a] as judged by
+    [Pervasives.compare]
+
+    @raise Invalid_argument on empty input *)
+
+val min_max : 'a t -> 'a * 'a
+(** [min_max a] returns the (smallest, largest) pair of values from [a]
+    as judged by [Pervasives.compare]
+
+    @raise Invalid_argument on empty input *)
+
+val sum : int t -> int
+(** [sum l] returns the sum of the integers of [l] *)
+
+val fsum : float t -> float
+(** [fsum l] returns the sum of the floats of [l] *)
+
+val kahan_sum : float t -> float
+(** [kahan_sum l] returns a numerically-accurate
+    sum of the floats of [l].
+
+    You should consider using Kahan summation when you really care
+    about very small differences in the result, while the result or
+    one of the intermediate sums can be very large (which usually
+    results in loss of precision of floating-point addition).
+
+    The worst-case rounding error is constant, instead of growing with
+    (the square root of) the length of the input array as with {!
+    fsum}. On the other hand, processing each element requires four
+    floating-point operations instead of one. See
+    {{: https://en.wikipedia.org/wiki/Kahan_summation_algorithm }
+    the wikipedia article} on Kahan summation for more details.
+*)
+
+val avg : int t -> float
+(** [avg l] returns the average of [l] *)
+
+val favg : float t -> float
+(** [favg l] returns the average of [l] *)
+
+
+
+
+(**{6 Operations on two arrays}*)
+
+val iter2 : ('a -> 'b -> unit) -> 'a t -> 'b t -> unit
+(** [iter2 f [a0, a1, ..., an] [b0, b1, ..., bn]]
+    performs calls [f a0 b0, f a1 b1, ..., f an bn] in that order.
+
+    @raise Invalid_argument if the two arrays have different lengths. *)
+
+val iter2i : (int -> 'a -> 'b -> unit) -> 'a t -> 'b t -> unit
+(** [iter2i f [a0, a1, ..., an] [b0, b1, ..., bn]]
+    performs calls [f 0 a0 b0, f 1 a1 b1, ..., f n an bn] in that
+    order.
+
+    @raise Invalid_argument if the two arrays have different
+    lengths. *)
+
+val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
+(** As {!map} but on two arrays.
+
+    @raise Invalid_argument if the two arrays have different lengths. *)
+
+val map2i : (int -> 'a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
+(** As {!mapi} but on two arrays.
+
+    @raise Invalid_argument if the two arrays have different lengths. *)
+
+val for_all2 : ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
+(** As {!for_all} but on two arrays.
+
+    @raise Invalid_argument if the two arrays have different lengths.*)
+
+val exists2 : ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
+(** As {!exists} but on two arrays.
+
+    @raise Invalid_argument if the two arrays have different lengths. *)
+
+val cartesian_product : 'a t -> 'b t -> ('a * 'b) t
+(** Cartesian product of the two arrays.
+    @since 2.2.0 *)
+
+
 
 
 (** {6 Array resizers} *)
@@ -319,6 +541,7 @@ val create_with : resizer_t -> 'a t
 
 val unsafe_get : 'a t -> int -> 'a
 val unsafe_set : 'a t -> int -> 'a -> unit
+val unsafe_upd : 'a t -> int -> ('a -> 'a) -> unit
 
 
 (** {6 Boilerplate code}*)
@@ -326,6 +549,19 @@ val unsafe_set : 'a t -> int -> 'a -> unit
 (** {7 Printing}*)
 
 val print :  ?first:string -> ?last:string -> ?sep:string -> ('a BatInnerIO.output -> 'b -> unit) -> 'a BatInnerIO.output -> 'b t -> unit
+
+(** Operations on {!DynArray} without exceptions.*)
+module Exceptionless : sig
+  val find : ('a -> bool) -> 'a t -> 'a option
+  (** [find p a] returns [Some x], where [x] is the first element of
+    array [a] that satisfies the predicate [p], or [None] if there
+    is no such element.*)
+
+  val findi : ('a -> bool) -> 'a t -> int option
+    (** [findi p a] returns [Some n], where [n] is the index of the
+        first element of array [a] that satisfies the predicate [p],
+        or [None] if there is no such element.*)
+end
 
 (**/**)
 val invariants : _ t -> unit


### PR DESCRIPTION
This patch adds multiple functions in DynArray that are present in Array but not in the former. As of this patch, the only functions which exist in Array but not in DynArray are

- Sorts and bsearch
- `backwards` and `of_backwards`

which I'm not comfortable handling (maybe someone else can help).

Also, `filter` was reimplemented in a more efficient way.

Finally, I added a function `upd` (short for "update") for the common idiom

`a.(i) <- f a.(i)`

which should be faster (no duplicate bounds checking) and more convenient; for example instead of 

`set a i (incr @@ get a i)`

one can write

`upd a i incr`.

Let me know what you think.