### PR TITLE
Batteries 2.9.0: clarify the "incomplete" compatibility status with respect to 4.07.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,20 @@ number of fixes, improvements and documentation clarification from our
 contributors. Thanks in particular to Max Mouratov for his varied
 contributions.
 
+This release is compatible with OCaml 4.07.0, but it is not complete
+with respect to the standard library of OCaml 4.07.0: this release saw
+a lot of changes to the standard library, which have not yet been made
+available in the corresponding Batteries module. This means that users
+of OCaml 4.07.0 (and Batteries 2.9.0) will have access to these
+functions, but users of older OCaml versions (and Batteries 2.9.0)
+will not. If you are looking for this kind of backward-compatibility
+of new functions, as provided by previous Batteries releases, we
+recommend trying the new 'stdcompat' library by Thierry Martinez:
+
+  https://github.com/thierry-martinez/stdcompat
+
+Full changelog:
+
 - add `BatString.cut_on_char : char -> int -> string -> string`
   (Kahina Fekir, Thibault Suzanne, request by François Bérenger)
   #807, #856


### PR DESCRIPTION
As a follow-up to #876, this clarifies the "incomplete" support for 4.07.0 in the Changelog -- to be used in release announcements, etc.

cc @UnixJunkie @thizanne @thierry-martinez