### PR TITLE
batNum fix

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,7 +3,10 @@ Changelog
 
 ## NEXT_RELEASE
 
-
+- fix `BatNum.of_float_string` on inputs between -1 and 0:
+  "-0.5" or "-.5" would be interpreted as "0.5" or ".5".
+  (Gabriel Scherer, report by Marcel Hark)
+  #886, #887
 
 ## v2.9.0 (minor release)
 

--- a/src/batNum.ml
+++ b/src/batNum.ml
@@ -108,10 +108,10 @@ let of_float_string a =
     else add ipart fpart
   with Not_found -> of_string a
 
-                    (**T
-                       of_float_string "2.5" = of_string "5/2"
-                       of_float_string "-2.5" = of_string "-5/2"
-                       of_float_string "-2.1" = of_string "-21/10"
-                       of_float_string "2." = of_string "2"
-                       of_float_string ".5" = of_string "1/2"
-                    *)
+(*$T
+   equal (of_float_string "2.5") (of_string "5/2")
+   equal (of_float_string "-2.5") (of_string "-5/2")
+   equal (of_float_string "-2.1") (of_string "-21/10")
+   equal (of_float_string "2.") (of_string "2")
+   equal (of_float_string ".5") (of_string "1/2")
+*)

--- a/src/batNum.ml
+++ b/src/batNum.ml
@@ -95,17 +95,11 @@ let print out t = BatInnerIO.nwrite out (to_string t)
 let of_float_string a =
   try
     let ipart_s,fpart_s = BatString.split a ~by:"." in
-    let ipart = if ipart_s = "" then zero else of_string ipart_s in
-    let fpart =
-      if fpart_s = "" then zero
-      else
-        let fpart = of_string fpart_s in
-        let num10 = of_int 10 in
-        let frac = pow num10 (of_int (String.length fpart_s)) in
-        Infix.(fpart/frac)
-    in
-    if lt_num ipart zero then sub ipart fpart
-    else add ipart fpart
+    if fpart_s = ""
+    then of_string ipart_s
+    else
+      let frac = pow (of_int 10) (of_int (String.length fpart_s)) in
+      div (of_string (ipart_s ^ fpart_s)) frac
   with Not_found -> of_string a
 
 (*$T
@@ -114,4 +108,6 @@ let of_float_string a =
    equal (of_float_string "-2.1") (of_string "-21/10")
    equal (of_float_string "2.") (of_string "2")
    equal (of_float_string ".5") (of_string "1/2")
+   equal (of_float_string "-0.5") (of_string "-1/2")
+   equal (of_float_string "-.5") (of_string "-1/2")
 *)


### PR DESCRIPTION
fix `BatNum.of_float_string` on inputs between -1 and 0:
"-0.5" or "-.5" would be interpreted as "0.5" or ".5".

Reported by @mthark in #886.