### PR TITLE
Fixing basic typos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ env:
 # notifications:
 #   email:
 #       - simon.cruanes.2007+travis@m4x.org
-#       - add other adresses here (or batteries-devel or something?)
+#       - add other addresses here (or batteries-devel or something?)

--- a/ChangeLog
+++ b/ChangeLog
@@ -448,7 +448,7 @@ then it is only available under OCaml 4.03.0.
 - basic .merlin file for merlin users
 - BatDeque.eq function to compare Deques by content
 - BatteriesExceptionless
-- More explicit overridding of ocamlbuild rules, use batteries.mllib
+- More explicit overriding of ocamlbuild rules, use batteries.mllib
 - Add Kahan summation (numerically-accurate sum of floats) to List,Array,Enum
 - Add BatOption.some
 - (text) improve element indexing in BatList's mli documentation

--- a/battop.ml
+++ b/battop.ml
@@ -1,5 +1,5 @@
 (*
- * Top - An interpreted preambule for the toplevel
+ * Top - An interpreted preamble for the toplevel
  * Copyright (C) 2009 David Rajchenbach-Teller, LIFO, Universite d'Orleans
  *
  * This library is free software; you can redistribute it and/or

--- a/benchsuite/bench_nreplace.ml
+++ b/benchsuite/bench_nreplace.ml
@@ -117,7 +117,7 @@ let nreplace_thelema2 ~str ~sub ~by =
     loop_copy 0 0 idxes ;
     newstr
 
-(* Independantly, MadRoach implemented the same idea with less luck aparently *)
+(* Independently, MadRoach implemented the same idea with less luck apparently *)
 let nreplace_madroach ~str ~sub ~by =
   let strlen = String.length str
   and sublen = String.length sub

--- a/build/odoc_batteries_factored.ml
+++ b/build/odoc_batteries_factored.ml
@@ -79,7 +79,7 @@ let has_parent a ~parent:b =
     result
 
 let merge_info_opt a b =
-  verbose ("Merging informations");
+  verbose ("Merging information");
   if a <> b then
     begin
       verbose ("1: "^(string_of_info_opt a));

--- a/build/odoc_generator_batlib.ml
+++ b/build/odoc_generator_batlib.ml
@@ -102,7 +102,7 @@ let has_parent a ~parent:b =
 let roots = ["Batteries"]
 
 let merge_info_opt a b =
-  verbose ("Merging informations");
+  verbose ("Merging information");
   if a <> b then
     begin
       verbose ("1: "^(string_of_info_opt a));

--- a/build/optcomp/pa_optcomp.ml
+++ b/build/optcomp/pa_optcomp.ml
@@ -78,7 +78,7 @@ let add_include_dir dir = dirs := dir :: !dirs
 
 module String_set = Set.Make(String)
 
-(* All depencies of the file being parsed *)
+(* All dependencies of the file being parsed *)
 let dependencies = ref String_set.empty
 
 (* Where to write dependencies *)
@@ -302,7 +302,7 @@ let rec parse_eol stream =
     | _ ->
         Loc.raise loc (Stream.Error "end of line expected")
 
-(* Return wether a keyword can be interpreted as an identifier *)
+(* Return whether a keyword can be interpreted as an identifier *)
 let keyword_is_id str =
   let rec aux i =
     if i = String.length str then
@@ -516,13 +516,13 @@ type state = {
   (* Input stream *)
 
   mutable bol : bool;
-  (* Wether we are at the beginning of a line *)
+  (* Whether we are at the beginning of a line *)
 
   mutable stack : context list;
   (* Nested contexts *)
 
   on_eoi : Gram.Token.t * Loc.t -> Gram.Token.t * Loc.t;
-  (* Eoi handler, it is used to restore the previous sate on #include
+  (* Eoi handler, it is used to restore the previous state on #include
      directives *)
 }
 

--- a/build/optcomp/sample.ml
+++ b/build/optcomp/sample.ml
@@ -77,7 +77,7 @@ type t = private int
 type t
 #endif
 
-(* It is also possible to split the expression over multible lines by
+(* It is also possible to split the expression over multiple lines by
    using parentheses: *)
 
 #let ocaml_major_version = fst ocaml_version
@@ -101,7 +101,7 @@ let x = 1
    is what is allowed:
 
    - litterals booleans, integers, strings and characters:
-   - basic interger operations: +, -, /, *, mod
+   - basic integer operations: +, -, /, *, mod
    - value comparing: =, <>, <, >, <=, >=
    - maximum and minimum: max, min
    - basic boolean operations: or, ||, &&, not

--- a/examples/euler/euler012.ml
+++ b/examples/euler/euler012.ml
@@ -6,7 +6,7 @@ let num_div x =
     if x mod i = 0 then incr count
   done;
   count := !count * 2; (* every factor < max_test has a corresponding one > *)
-  if x mod max_test = 0 then decr count; (* dont double count root if x square *)
+  if x mod max_test = 0 then decr count; (* don't double count root if x square *)
   !count
 
 let rec loop i n =

--- a/examples/pleac/strings.ml
+++ b/examples/pleac/strings.ml
@@ -383,7 +383,7 @@ val rest : string =
 Expanding Variables in User Input
 
 (* As far as I know there is no way to do this in OCaml due to
-   type-safety contraints built into the OCaml compiler -- it may be
+   type-safety constraints built into the OCaml compiler -- it may be
    feasible with *much* juju, but don't expect to see this anytime
    soon...
 
@@ -551,7 +551,7 @@ Escaping Characters
 ** interpreter or the compilers.
 **
 ** The "#load" line is only needed if you are running this in the
-** command interpretter.
+** command interpreter.
 **
 ** If you are using either of the ocaml compilers, you will need
 ** to remove the "#load" line and link in str.cmxa in the final

--- a/howto/release.md
+++ b/howto/release.md
@@ -74,7 +74,7 @@ upstream opam repository curators may have made changes to the public
 opam files, to reflect new packaging best practices and policies. You
 should check for any change to the latest version's `opam` file; if
 there is any, it should probably be reproduced into our local `opam`
-file, and commited.
+file, and committed.
 
 Note that the local file may have changed during the release lifetime
 to reflect new dependencies or changes in packaging policies. These

--- a/setup.ml
+++ b/setup.ml
@@ -2653,7 +2653,7 @@ module OASISFindlib = struct
           (fun lib_name status mp ->
              match status with
                | `Solved _ ->
-                 (* Solved initialy, no need to go further *)
+                 (* Solved initially, no need to go further *)
                  mp
                | `Unsolved _ ->
                  let _, mp = solve SetString.empty mp lib_name "<none>" in

--- a/src/batArray.mliv
+++ b/src/batArray.mliv
@@ -525,7 +525,7 @@ val insert : 'a array -> 'a -> int -> 'a array
 
 val print : ?first:string -> ?last:string -> ?sep:string ->
   ('a, 'b) BatIO.printer -> ('a t, 'b) BatIO.printer
-(** Print the contents of an array, with [~first] preceeding the first
+(** Print the contents of an array, with [~first] preceding the first
     item (default: "\[|"), [~last] following the last item (default:
     "|\]") and [~sep] separating items (default: "; ").  A printing
     function must be provided to print the items in the array.

--- a/src/batConcreteQueue_403.ml
+++ b/src/batConcreteQueue_403.ml
@@ -31,7 +31,7 @@ let filter_inplace f queue =
        loop (length + 1) cons next
   in
   let first = find_next queue.first in
-  (* returning a pair is unecessary, the writes could be made at the
+  (* returning a pair is unnecessary, the writes could be made at the
      end of 'loop', but the present style makes it obvious that all
      three writes are performed atomically, without allocation,
      function call or return (yield points) in between, guaranteeing

--- a/src/batEnum.mli
+++ b/src/batEnum.mli
@@ -50,7 +50,7 @@
     As most data structures in Batteries can be enumerated and built
     from enumerations, these operations may be used also on lists,
     arrays, hashtables, etc. When designing a new data structure, it
-    is usuallly a good idea to allow enumeration and construction
+    is usually a good idea to allow enumeration and construction
     from an enumeration.
 
     {b Note} Enumerations are not thread-safe. You should not attempt
@@ -792,7 +792,7 @@ val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int
 *)
 
 val ord : ('a -> 'a -> BatOrd.order) -> 'a t -> 'a t -> BatOrd.order
-(** Same as [compare] but returning a {!BatOrd.order} instead of an interger. *)
+(** Same as [compare] but returning a {!BatOrd.order} instead of an integer. *)
 
 val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
 (** [equal eq a b] returns [true] when [a] and [b] contain

--- a/src/batFingerTree.ml
+++ b/src/batFingerTree.ml
@@ -85,7 +85,7 @@ struct
    *   It is slightly faster when benchmarking construction/deconstruction
    *   even with dummy annotations.
 
-   * In many places, it looks like functions are defined twice in slighly
+   * In many places, it looks like functions are defined twice in slightly
    * different versions. This is for performance reasons, to avoid higher
    * order calls (made everything 30% slower on my tests).
   *)
@@ -735,7 +735,7 @@ struct
   (*            lookup               *)
   (*---------------------------------*)
   (* This is a simplification of splitTree that avoids rebuilding the tree
-   * two trees aroud the elements being looked up
+   * two trees around the elements being looked up
    * But you can't just find the element, so instead these functions find the
    * element _and_ the measure of the elements of the current node that are on
    * the left of the element.

--- a/src/batFingerTree.mli
+++ b/src/batFingerTree.mli
@@ -27,10 +27,10 @@
    the measurement function (this is needed because sometimes
    the type of the measure depends on the type of the elements).
 
-   This module also contains an instanciation of a finger tree that
+   This module also contains an instantiation of a finger tree that
    implements a functional sequence with the following characteristics:
    - amortized constant time addition and deletions at both ends
-   - contant time size operation
+   - constant time size operation
    - logarithmic lookup, update or deletion of the element at a given index
    - logarithmic splitting and concatenation
 
@@ -365,7 +365,7 @@ module Generic : sig
   val split : (('m -> bool) -> ('a, 'm) fg -> ('a, 'm) fg * ('a, 'm) fg, 'a, 'm) wrap
     (**
         [split p t], when [p] is monotonic, returns [(t1, t2)] where
-        [t1] is the longest prefix of [t] whose measure does not satifies
+        [t1] is the longest prefix of [t] whose measure does not satisfies
         [p], and [t2] is the rest of [t].
         @raise Empty is there is no such element
 

--- a/src/batFloat.mli
+++ b/src/batFloat.mli
@@ -69,7 +69,7 @@ val succ : float -> float
     equal to [x], due to rounding.*)
 
 val pred : float -> float
-(** Substract [1.] from a floating number. Note that, as per
+(** Subtract [1.] from a floating number. Note that, as per
     IEEE 754, if [x] is a large enough float number, [pred x]
     might be equal to [x], due to rounding.*)
 
@@ -407,7 +407,7 @@ sig
       equal to [x], due to rounding.*)
 
   val pred : float -> float
-  (** Substract [1.] from a floating number. Note that, as per
+  (** Subtract [1.] from a floating number. Note that, as per
       IEEE 754, if [x] is a large enough float number, [pred x]
       might be equal to [x], due to rounding.*)
 

--- a/src/batGc.mliv
+++ b/src/batGc.mliv
@@ -110,7 +110,7 @@ type control = Gc.control =
     mutable space_overhead : int;
     (** The major GC speed is computed from this parameter.
         This is the memory that will be "wasted" because the GC does not
-        immediatly collect unreachable blocks.  It is expressed as a
+        immediately collect unreachable blocks.  It is expressed as a
         percentage of the memory used for live data.
         The GC will work more (use more CPU time and collect
         blocks more eagerly) if [space_overhead] is smaller.

--- a/src/batHashtbl.mli
+++ b/src/batHashtbl.mli
@@ -37,7 +37,7 @@
 open Hashtbl
 
 type ('a, 'b) t = ('a, 'b) Hashtbl.t
-(** A Hashtable wth keys of type 'a and values 'b *)
+(** A Hashtable with keys of type 'a and values 'b *)
 
 (**{6 Base operations}*)
 

--- a/src/batIO.mli
+++ b/src/batIO.mli
@@ -364,7 +364,7 @@ val read_all : input -> string
 (** read all the contents of the input until [No_more_input] is raised. *)
 
 val pipe : unit -> input * unit output
-(** Create a pipe between an input and an ouput. Data written from
+(** Create a pipe between an input and an output. Data written from
     the output can be read from the input.
 *)
 
@@ -381,7 +381,7 @@ val pos_in : input -> input * (unit -> int)
 
 val progress_in : input -> (unit -> unit) -> input
 (** [progress_in inp f] create an input that calls [f ()]
-    whenever some content is succesfully read from it.*)
+    whenever some content is successfully read from it.*)
 
 val pos_out : 'a output -> unit output * (unit -> int)
 (** Create an output that provide a count function of the number of bytes
@@ -389,7 +389,7 @@ val pos_out : 'a output -> unit output * (unit -> int)
 
 val progress_out : 'a output -> (unit -> unit) -> unit output
 (** [progress_out out f] create an output that calls [f ()]
-    whenever some content is succesfully written to it.*)
+    whenever some content is successfully written to it.*)
 
 external cast_output : 'a output -> unit output = "%identity"
 (** You can safely transform any output to an unit output in a safe way
@@ -771,7 +771,7 @@ val to_input_channel : input -> in_channel
 (** {6 Generic BatIO Object Wrappers}
 
     These OO Wrappers have been written to provide easy support of
-    BatIO by external librairies. If you want your library to support
+    BatIO by external libraries. If you want your library to support
     BatIO without actually requiring Batteries to compile, you can
     implement the classes [in_channel], [out_channel],
     [poly_in_channel] and/or [poly_out_channel] which are the common
@@ -880,7 +880,7 @@ val synchronize_in : ?lock:BatConcurrent.lock -> input  -> input
    wreak havoc otherwise
 
    @param lock An optional lock. If none is provided, the lock will be specific
-   to this [input]. Specifiying a custom lock may be useful to associate one
+   to this [input]. Specifying a custom lock may be useful to associate one
    common lock for several inputs and/or outputs, for instance in the case
    of pipes.
 *)
@@ -892,7 +892,7 @@ val synchronize_out: ?lock:BatConcurrent.lock -> _ output -> unit output
    wreak havoc otherwise
 
    @param lock An optional lock. If none is provided, the lock will be specific
-   to this [output]. Specifiying a custom lock may be useful to associate one
+   to this [output]. Specifying a custom lock may be useful to associate one
    common lock for several inputs and/or outputs, for instance in the case
    of pipes.
 *)
@@ -952,7 +952,7 @@ module Incubator : sig
       ?sep:string ->
       ?indent:int ->
       (Format.formatter -> 'a -> 'b) -> Format.formatter -> 'a array -> unit
-      (** Print the contents of an array, with [first] preceeding the first item
+      (** Print the contents of an array, with [first] preceding the first item
           (default: ["\[|"]), [last] following the last item (default: ["|\]"])
           and [sep] separating items (default: ["; "]). A printing function must
           be provided to print the items in the array. The [flush] parameter
@@ -973,7 +973,7 @@ module Incubator : sig
       ?sep:string ->
       ?indent:int ->
       (Format.formatter -> 'a -> 'b) -> Format.formatter -> 'a BatEnum.t -> unit
-      (** Print the contents of an enum, with [first] preceeding the first item
+      (** Print the contents of an enum, with [first] preceding the first item
           (default: [""]), [last] following the last item (default: [""])
           and [sep] separating items (default: [" "]). A printing function must
           be provided to print the items in the enum. The [flush] parameter
@@ -993,7 +993,7 @@ module Incubator : sig
       ?sep:string ->
       ?indent:int ->
       (Format.formatter -> 'a -> 'b) -> Format.formatter -> 'a list -> unit
-      (** Print the contents of a list, with [first] preceeding the first item
+      (** Print the contents of a list, with [first] preceding the first item
           (default: ["\["]), [last] following the last item (default: ["\]"])
           and [sep] separating items (default: ["; "]). A printing function must
           be provided to print the items in the list. The [flush] parameter

--- a/src/batInnerIO.mli
+++ b/src/batInnerIO.mli
@@ -57,7 +57,7 @@ val read_all : input -> string
 (** read all the contents of the input until [No_more_input] is raised. *)
 
 val pipe : unit -> input * unit output
-(** Create a pipe between an input and an ouput. Data written from
+(** Create a pipe between an input and an output. Data written from
     the output can be read from the input. *)
 
 val nread : input -> int -> string

--- a/src/batInnerWeaktbl.ml
+++ b/src/batInnerWeaktbl.ml
@@ -45,7 +45,7 @@ module Stack = struct
       let len = length s in
       if len >= s.length / 3 && len < s.length * 2 / 3 then push x s else
         let len' = min (len * 3 / 2 + 2) (Sys.max_array_length -1) in
-        if len' = len then failwith "Weaktbl.Stack.push: stack cannnot grow"
+        if len' = len then failwith "Weaktbl.Stack.push: stack cannot grow"
         else
           let data' = Weak.create len' in
           Weak.blit s.data 0 data' 0 s.cursor;

--- a/src/batInt.mli
+++ b/src/batInt.mli
@@ -262,10 +262,10 @@ module Safe_int : sig
   (** Addition. *)
 
   val sub : t -> t -> t
-  (** Substraction. *)
+  (** Subtraction. *)
 
   val ( - ) : t -> t -> t
-  (** Substraction. *)
+  (** Subtraction. *)
 
   val mul : t -> t -> t
   (** Multiplication. *)
@@ -307,23 +307,23 @@ module Safe_int : sig
   (** [a ** b] computes a{^b}*)
 
   val ( <> ) : t -> t -> bool
-  (** Comparaison: [a <> b] is true if and only if [a] and [b] have
+  (** Comparison: [a <> b] is true if and only if [a] and [b] have
       different values. *)
 
   val ( > )  : t -> t -> bool
-  (** Comparaison: [a > b] is true if and only if [a] is strictly greater than [b].*)
+  (** Comparison: [a > b] is true if and only if [a] is strictly greater than [b].*)
 
   val ( < )  : t -> t -> bool
-  (** Comparaison: [a < b] is true if and only if [a] is strictly smaller than [b].*)
+  (** Comparison: [a < b] is true if and only if [a] is strictly smaller than [b].*)
 
   val ( >= ) : t -> t -> bool
-  (** Comparaison: [a >= b] is true if and only if [a] is greater or equal to [b].*)
+  (** Comparison: [a >= b] is true if and only if [a] is greater or equal to [b].*)
 
   val ( <= ) : t -> t -> bool
-  (** Comparaison: [a <= b] is true if and only if [a] is smaller or equalto [b].*)
+  (** Comparison: [a <= b] is true if and only if [a] is smaller or equalto [b].*)
 
   val ( = )  : t -> t -> bool
-  (** Comparaison: [a = b] if and only if [a] and [b] have the same value.*)
+  (** Comparison: [a = b] if and only if [a] and [b] have the same value.*)
 
   val max_num : t
   (** The greatest representable integer, which is either 2{^30}-1 or 2{^62}-1. *)

--- a/src/batList.mliv
+++ b/src/batList.mliv
@@ -375,7 +375,7 @@ val mem : 'a -> 'a list -> bool
     to an element of [l]. *)
 
 val mem_cmp : ('a -> 'a -> int) -> 'a -> 'a list -> bool
-(** Same as {!List.mem}, but the comparator function is explicitely
+(** Same as {!List.mem}, but the comparator function is explicitly
     provided.
     @since 2.2.0 *)
 
@@ -828,7 +828,7 @@ val merge : ('a -> 'a -> int) -> 'a list -> 'a list -> 'a list
 (** Merge two lists:
     Assuming that [l1] and [l2] are sorted according to the
     comparison function [cmp], [merge cmp l1 l2] will return a
-    sorted list containting all the elements of [l1] and [l2].
+    sorted list containing all the elements of [l1] and [l2].
     If several elements compare equal, the elements of [l1] will be
     before the elements of [l2].
     Not tail-recursive (sum of the lengths of the arguments).

--- a/src/batMap.ml
+++ b/src/batMap.ml
@@ -28,7 +28,7 @@
    operations (both providing their own way to access the ordering
    information, and to possibly pass it along with the result).
 
-   I tried to keep the interface mininal with respect to ordering
+   I tried to keep the interface minimal with respect to ordering
    information : function that do not need the ordering (they do not
    need to find the position of a specific key in the map) do not have
    a 'cmp' parameter.
@@ -408,7 +408,7 @@ module Concrete = struct
     library's version of [Map] easier to track, even if the
     result is a tad slower.*)
   (* [filter{,i,_map} f t cmp] do not use [cmp] on [t], but only to
-     build the result map. The unusual parameter order was choosed to
+     build the result map. The unusual parameter order was chosen to
      reflect this.  *)
   let filterv f t cmp =
     foldi (fun k a acc -> if f a then add k a cmp acc else acc) t empty

--- a/src/batOptParse.mli
+++ b/src/batOptParse.mli
@@ -419,7 +419,7 @@ sig
   (** Add an option to the option parser.
 
       @raise Option_conflict if the short name(s) or long name(s)
-      have alread been used for some other option.
+      have already been used for some other option.
 
       @param help Short help message describing the option (for the usage message).
 

--- a/src/batOrd.mli
+++ b/src/batOrd.mli
@@ -118,7 +118,7 @@ val bin_comp : 'a comp -> 'a -> 'a -> 'b comp -> 'b -> 'b -> int
 val bin_ord : 'a ord -> 'a -> 'a -> 'b ord -> 'b -> 'b -> order
 (** binary lifting of the comparison function, using lexicographic order:
     [bin_ord ord1 v1 v1' ord2 v2 v2'] is [ord2 v2 v2'] if [ord1 v1 v1' = Eq],
-    and [ord1 v1 v1'] otherwhise.
+    and [ord1 v1 v1'] otherwise.
 *)
 val bin_eq : 'a eq -> 'a -> 'a -> 'b eq -> 'b -> 'b -> bool
 

--- a/src/batParserCo.mli
+++ b/src/batParserCo.mli
@@ -42,7 +42,7 @@
 (**The current state of the parser.
 
    The actual set of states is defined by the user. States are
-   typically used to convey informations, such as position in the file
+   typically used to convey information, such as position in the file
    (i.e. line number and character).
 
 *)
@@ -132,7 +132,7 @@ val any: ('a, 'a, _) t
 (**Accept any singleton value.*)
 
 val return: 'b -> (_, 'b, _) t
-(**A parser which always succeds*)
+(**A parser which always succeeds*)
 
 val satisfy: ('a -> bool) -> ('a, 'a, _) t
 (**[satisfy p] accepts one value [p x] such that [p x = true]*)

--- a/src/batPathGen.ml
+++ b/src/batPathGen.ml
@@ -316,7 +316,7 @@ module type PathType = sig
   (** = {!of_string} *)
 
   (** {6 Name related functions}
-      These funtions do not accept empty paths, i.e. [\[\]], [\[""\]] or [\["C:"\]].
+      These functions do not accept empty paths, i.e. [\[\]], [\[""\]] or [\["C:"\]].
   *)
 
   val name : t -> ustring
@@ -547,7 +547,7 @@ module Make = functor (S : StringType) -> struct
     let _, result = List.fold_left fold (S.length ss, []) !rev_separators in
     result
 
-  (* Returns true if windows and the arugment is letter-colon, false otherwise *)
+  (* Returns true if windows and the argument is letter-colon, false otherwise *)
   let is_win_disk_letter =
     if windows then
       let pars = BatParserCo.(>>>) S.Parse.letter (BatParserCo.exactly (S.lift_char ':')) in

--- a/src/batPathGen.mli
+++ b/src/batPathGen.mli
@@ -317,7 +317,7 @@ module type PathType = sig
   (** = {!of_string} *)
 
   (** {6 Name related functions}
-      These funtions do not accept empty paths, i.e. [\[\]], [\[""\]] or [\["C:"\]].
+      These functions do not accept empty paths, i.e. [\[\]], [\[""\]] or [\["C:"\]].
   *)
 
   val name : t -> ustring

--- a/src/batResult.mli
+++ b/src/batResult.mli
@@ -15,12 +15,12 @@ type ('a, 'b) t = ('a, 'b) BatPervasives.result = Ok of 'a | Bad of 'b
 *)
 val catch: ('a -> 'b) -> 'a -> ('b, exn) t
 
-(** As [catch] but two paramaters.  This saves a closure construction
+(** As [catch] but two parameters.  This saves a closure construction
     @since 2.0
 *)
 val catch2: ('a -> 'b -> 'c) -> 'a -> 'b -> ('c, exn) t
 
-(** As [catch] but three paramaters.  This saves a closure construction
+(** As [catch] but three parameters.  This saves a closure construction
     @since 2.0
 *)
 val catch3: ('a -> 'b -> 'c -> 'd) -> 'a -> 'b -> 'c -> ('d, exn) t

--- a/src/batScanf.mli
+++ b/src/batScanf.mli
@@ -79,7 +79,7 @@
     However, it is also largely different, simpler, and yet more powerful:
     the formatted input functions are higher-order functionals and the
     parameter passing mechanism is just the regular function application not
-    the variable assigment based mechanism which is typical for formatted
+    the variable assignment based mechanism which is typical for formatted
     input in imperative languages; the OCaml format strings also feature
     useful additions to easily define complex tokens; as expected within a
     functional programming language, the formatted input functions also
@@ -224,7 +224,7 @@ val bscanf : Scanning.scanbuf -> ('a, 'b, 'c, 'd) scanner;;
 
     Matching {e any} amount of whitespace, a space in the format string
     also matches no amount of whitespace at all; hence, the call [bscanf ib
-    "Price = %d $" (fun p -> p)] succeds and returns [1] when reading an
+    "Price = %d $" (fun p -> p)] succeeds and returns [1] when reading an
     input with various whitespace in it, such as [Price = 1 $],
     [Price  =  1    $], or even [Price=1$]. *)
 
@@ -321,7 +321,7 @@ val bscanf : Scanning.scanbuf -> ('a, 'b, 'c, 'd) scanner;;
 
     Notes:
 
-    - as mentioned above, a [%s] convertion always succeeds, even if there is
+    - as mentioned above, a [%s] conversion always succeeds, even if there is
       nothing to read in the input: it simply returns [""].
 
     - in addition to the relevant digits, ['_'] characters may appear
@@ -415,7 +415,7 @@ val kscanf :
 val bscanf_format :
   Scanning.scanbuf -> ('a, 'b, 'c, 'd, 'e, 'f) format6 ->
   (('a, 'b, 'c, 'd, 'e, 'f) format6 -> 'g) -> 'g;;
-(** [bscanf_format ib fmt f] reads a format string token from the scannning
+(** [bscanf_format ib fmt f] reads a format string token from the scanning
     buffer [ib], according to the given format string [fmt], and applies [f] to
     the resulting format string value.
     @raise Scan_failure if the format string value read does not have the

--- a/src/batSet.ml
+++ b/src/batSet.ml
@@ -648,7 +648,7 @@ struct
   let find x t = Concrete.find Ord.compare x (impl_of_t t)
   let exists f t = Concrete.exists f (impl_of_t t)
   let for_all f t = Concrete.for_all f (impl_of_t t)
-  let paritition f t =
+  let partition f t =
     let l, r = Concrete.partition Ord.compare f (impl_of_t t) in
     (t_of_impl l, t_of_impl r)
 

--- a/src/batStream.mli
+++ b/src/batStream.mli
@@ -117,7 +117,7 @@ val foldr : ('a -> 'b lazy_t -> 'b) -> 'b -> 'a t -> 'b
 (** [foldr f init stream] is a lazy fold_right. Unlike the normal fold_right,
     the accumulation parameter of [f elt accu] is lazy, hence it can decide
     not to force the evaluation of [accu] if the current element [elt] can
-    determin the result by itself. *)
+    determine the result by itself. *)
 
 val fold : ('a -> 'a -> 'a * bool option) -> 'a t -> 'a
 (** [fold] is [foldl] without initialization value, where the first

--- a/src/batString.mliv
+++ b/src/batString.mliv
@@ -260,8 +260,8 @@ val index_after_n :  char -> int -> string -> int
 (** [index_after_n chr n str] returns the index of the character that
     comes immediately after the [n]-th occurrence of [chr] in [str].
 
-    - {b Occurences are numbered from 1}: [n] = 1 returns the index of
-      the character located immediately after the first occurence of
+    - {b Occurrences are numbered from 1}: [n] = 1 returns the index of
+      the character located immediately after the first occurrence of
       [chr].
     - [n] = 0 always returns [0].
     - If the [n]-th occurrence of [chr] is the last character of
@@ -691,7 +691,7 @@ val replace : str:string -> sub:string -> by:string -> bool * string
 (** [replace ~str ~sub ~by] returns a tuple consisting of a boolean
     and a string where the first occurrence of the string [sub]
     within [str] has been replaced by the string [by]. The boolean
-    is true if a subtitution has taken place.
+    is true if a substitution has taken place.
 
     Example: [String.replace "foobarbaz" "bar" "rab" = (true, "foorabbaz")]
 *)
@@ -790,7 +790,7 @@ val cut_on_char : char -> int -> string -> string
    {b Remark:} [cut_on_char] can return the empty string. Examples of this
    behaviour are [cut_on_char ',' 1 "foo,,bar"] and [cut_on_char ',' 0 ",foo"].
 
-   @raise Not_found if there are strictly less than [n] occurences of [chr] in str.
+   @raise Not_found if there are strictly less than [n] occurrences of [chr] in str.
    @raise Invalid_argument if [n < 0].
 
    @since 2.9.0
@@ -1001,7 +1001,7 @@ end (* String.Exceptionless *)
     Read-only strings may then be safely shared and distributed.
 
     @since 2.8.0 the interface and implementation of the Cap
-    module changed to accomodate the -safe-string transition. OCaml
+    module changed to accommodate the -safe-string transition. OCaml
     now uses two distinct types for mutable and immutable string,
     which is a good design but is not as expressive as the present Cap
     interface, and actually makes implementing Cap harder than it

--- a/src/batText.mli
+++ b/src/batText.mli
@@ -123,7 +123,7 @@ val height : t -> int
 val balance : t -> t
 (** [balance r] returns a balanced copy of the [r] rope. Note that ropes are
     automatically rebalanced when their height exceeds a given threshold, but
-    [balance] allows to invoke that operation explicity. *)
+    [balance] allows to invoke that operation explicitly. *)
 
 (** {6 Operations } *)
 

--- a/src/batUChar.mli
+++ b/src/batUChar.mli
@@ -53,7 +53,7 @@ external code : t -> int = "%identity"
 
 (** [chr n] returns the Unicode character with the code number [n].
     If n does not lay in the valid range of Unicode or designates a
-    surrogate charactor, raises Out_of_range *)
+    surrogate character, raises Out_of_range *)
 val chr : int -> t
 
 (** Equality by code point comparison *)

--- a/src/batVect.mli
+++ b/src/batVect.mli
@@ -121,7 +121,7 @@ val length : 'a t -> int
 val balance : 'a t -> 'a t
 (** [balance r] returns a balanced copy of the [r] vect. Note that vects are
     automatically rebalanced when their height exceeds a given threshold, but
-    [balance] allows to invoke that operation explicity. *)
+    [balance] allows to invoke that operation explicitly. *)
 
 val concat : 'a t -> 'a t -> 'a t
 (** [concat r u] concatenates the [r] and [u] vects. In general, it operates
@@ -475,7 +475,7 @@ val length : 'a t -> int
 val balance : 'a t -> 'a t
 (** [balance r] returns a balanced copy of the [r] vect. Note that vects are
     automatically rebalanced when their height exceeds a given threshold, but
-    [balance] allows to invoke that operation explicity. *)
+    [balance] allows to invoke that operation explicitly. *)
 
 val concat : 'a t -> 'a t -> 'a t
 (** [concat r u] concatenates the [r] and [u] vects. In general, it operates

--- a/testsuite/test_print.ml
+++ b/testsuite/test_print.ml
@@ -3,7 +3,7 @@ open Gc
 
 let few_tests = 10
 let many_tests= 100000
-(* (*For comparaison, not part of Batteries.*)
+(* (*For comparison, not part of Batteries.*)
 let run_legacy number_of_runs =
 begin
   Gc.full_major ();

--- a/testsuite/test_uref.ml
+++ b/testsuite/test_uref.ml
@@ -73,7 +73,7 @@ let test_equal () =
 let test_unite_shuffle () =
   (* testing the unification in all possible orders of n urefs
      unfornatunaly, since this is an imperative structure where
-     you can't undo operations, this is slighlty complicated *)
+     you can't undo operations, this is slightly complicated *)
 
   let pick_one n l f =
     assert (n <> 0);


### PR DESCRIPTION
**Note:**

Typos found with https://github.com/codespell-project/codespell

Command line: 
$ codespell -q 2 -S names.txt -L cmo,upto,iff,ba,mut,pres,nd,te,cas,cristal,ith,etst,"o'caml",modul,wont,succint