### PR TITLE
Corrected BatDeque.is_empty documentation.

### DIFF
--- a/src/batDeque.mli
+++ b/src/batDeque.mli
@@ -68,7 +68,7 @@ val rev : 'a dq -> 'a dq
 (** [rev dq] reverses [dq]. O(1) *)
 
 val is_empty : 'a dq -> bool
-(** [is_empty dq] returns [false] iff [dq] has no elements. O(1) *)
+(** [is_empty dq] returns [true] iff [dq] has no elements. O(1) *)
 
 val at : ?backwards:bool -> 'a dq -> int -> 'a option
 (** [at ~backwards dq k] returns the [k]th element of [dq], from


### PR DESCRIPTION
`BatDeque.is_empty`'s documentation states that it returns the opposite of what it actually returns.  This pull request corrects the documentation.  The behavior of the function `is_empty` is correct: `BatDeque.is_empty BatDeque.empty` ⇒ `true` (OCaml 4.07.1, Batteries 2.9.0).