### PR TITLE
Add Legacy.Result for OCaml >= 4.8.0

### DIFF
--- a/src/batteries.mlv
+++ b/src/batteries.mlv
@@ -47,6 +47,7 @@ module Legacy = struct
   module Big_int = Big_int
   module Bigarray = Bigarray
   module Str = Str
+##V>=4.8## module Result = Result
 end
 
 (* stdlib modules *)


### PR DESCRIPTION
So that users can pattern match Result.t returned from some library using
Legacy.Result.Error while Batteries is opened.

Ref #839