### PR TITLE
Make BatSeq.Exceptionless.combine really exceptionless

### DIFF
--- a/src/batSeq.ml
+++ b/src/batSeq.ml
@@ -429,6 +429,7 @@ end
 include Infix
 
 module Exceptionless = struct
+  (*$< Exceptionless *)
   (* This function could be used to eliminate a lot of duplicate code below...
      let exceptionless_arg f s e =
      try Some (f s)
@@ -477,11 +478,18 @@ module Exceptionless = struct
     try Some (min s)
     with Invalid_argument _ -> None
 
-  let combine s1 s2 =
-    try Some (combine s1 s2)
-    with Invalid_argument _ -> None
+  let rec combine s1 s2 () = match s1 (), s2 () with
+  | Nil, Nil ->
+    Nil
+  | Cons(e1, s1), Cons(e2, s2) ->
+    Cons((e1, e2), combine s1 s2)
+  | _ ->
+    Nil
 
   (*$T combine
-    equal (combine (of_list [1;2]) (of_list ["a";"b"])) (of_list [1,"a"; 2,"b"])
+    equal (combine (of_list [1;2]) (of_list ["a";"b"]))     (of_list [1,"a"; 2,"b"])
+    equal (combine (of_list [1;2]) (of_list ["a";"b";"c"])) (of_list [1,"a"; 2,"b"])
+    equal (combine (of_list [1;2;3]) (of_list ["a";"b"]))   (of_list [1,"a"; 2,"b"])
   *)
+  (*$>*)
 end

--- a/src/batSeq.mli
+++ b/src/batSeq.mli
@@ -322,5 +322,5 @@ module Exceptionless : sig
   val reduce : ('a -> 'a -> 'a) -> 'a t -> 'a option
   val max : 'a t -> 'a option
   val min : 'a t -> 'a option
-  val combine : 'a t -> 'b t -> ('a * 'b) t option
+  val combine : 'a t -> 'b t -> ('a * 'b) t
 end


### PR DESCRIPTION
Had to change the signature since it's not possible before consumption
to know if Exceptionless.combine should return Some result or None.
So now BatSeq.Exceptionless.combine returns the longest sequence possible
(stopping when one of the input sequence ends).

BatSeq.combine still raises an exception when the two inputs have
different length though. I would prefer if none of those function ever
throw an exception (as raising an exception from a function after it has
returned brings only misery), but that would be a major overhaul that
this patch has no ambition to.

(Also fixed the unit test that was not testing Exceptionless.combine)

Closes #418