### PR TITLE
BatString.split_on_char and nsplit must never return an empty list

### DIFF
--- a/src/batString.mliv
+++ b/src/batString.mliv
@@ -745,6 +745,7 @@ val split_on_char: char -> string -> string list
       (String.split_on_char sep s) = s]).
     - No string in the result contains the [sep] character.
 
+    Note: prior to NEXT_RELEASE [split_on_char _ ""] used to return an empty list.
     @since 2.5.3
 *)
 
@@ -788,7 +789,8 @@ val rsplit : string -> by:string -> string * string
 val nsplit : string -> by:string -> string list
 (** [nsplit s sep] splits the string [s] into a list of strings
     which are separated by [sep] (excluded).
-    [nsplit "" _] returns the empty list.
+    [nsplit "" _] returns a single empty string.
+    Note: prior to NEXT_RELEASE [nsplit "" _] used to return an empty list.
 
     Example: [String.nsplit "abcabcabc" "bc" = ["a"; "a"; "a"; ""]]
 *)

--- a/src/batString.mlv
+++ b/src/batString.mlv
@@ -383,7 +383,7 @@ let rsplit str ~by:sep =
    of substrings from the end to the beginning, so as to avoid a call to [List.rev].
 *)
 let nsplit str ~by:sep =
-  if str = "" then []
+  if str = "" then [""]
   else if sep = "" then invalid_arg "String.nsplit: empty sep not allowed"
   else
     (* str is non empty *)
@@ -412,7 +412,7 @@ let nsplit str ~by:sep =
 
 (*$T nsplit
   nsplit "a;b;c" ~by:";" = ["a"; "b"; "c"]
-  nsplit "" ~by:"x" = []
+  nsplit "" ~by:"x" = [""]
   try nsplit "abc" ~by:"" = ["a"; "b"; "c"] with Invalid_argument _ -> true
   nsplit "a/b/c" ~by:"/" = ["a"; "b"; "c"]
   nsplit "/a/b/c//" ~by:"/" = [""; "a"; "b"; "c"; ""; ""]
@@ -420,7 +420,7 @@ let nsplit str ~by:sep =
 *)
 
 let split_on_char sep str =
-  if str = "" then []
+  if str = "" then [""]
   else
     (* str is non empty *)
     let rec loop acc ofs limit =
@@ -433,7 +433,7 @@ let split_on_char sep str =
 
 (*$T split_on_char
   split_on_char ';' "a;b;c" = ["a"; "b"; "c"]
-  split_on_char 'x' "" = []
+  split_on_char 'x' "" = [""]
   split_on_char '/' "a/b/c" = ["a"; "b"; "c"]
   split_on_char '/' "/a/b/c//" = [""; "a"; "b"; "c"; ""; ""]
 *)


### PR DESCRIPTION
So that BatString.split_on_char behavior matches the one of
Legacy.String.split_on_char, and that nsplit behavior matches the one
of split_on_char.

Closes #845
Closes #846