### PR TITLE
BatArray: rename v3's split into pivot_split

### DIFF
--- a/src/batArray.mliv
+++ b/src/batArray.mliv
@@ -395,8 +395,8 @@ val bsearch : 'a BatOrd.ord -> 'a array -> 'a ->
     @raise Invalid_argument if the array is found to be unsorted w.r.t [cmp]
     @since 2.2.0 *)
 
-val split : 'a BatOrd.ord -> 'a array -> 'a -> int * int
-(** [split cmp arr x] assumes that [arr] is {b sorted} w.r.t
+val pivot_split : 'a BatOrd.ord -> 'a array -> 'a -> int * int
+(** [pivot_split cmp arr x] assumes that [arr] is {b sorted} w.r.t
     [cmp]. It splits an array [arr] of length [len] into three parts,
     by returning a couple (i,j) such as:
     - all elements with indices 0..i-1 ([sub arr 0 i]) are lower than [x]
@@ -770,6 +770,7 @@ sig
   val of_backwards : 'a BatEnum.t -> ('a, _) t
   val to_list : ('a, [> `Read]) t -> 'a list
   val split : ('a * 'b, [> `Read]) t -> ('a, _) t * ('b, _) t
+  val pivot_split : 'a BatOrd.ord -> ('a, [> `Read]) t -> 'a -> int * int
   val of_list : 'a list -> ('a, _) t
 
   (** {6 Utilities} *)

--- a/src/batArray.mlv
+++ b/src/batArray.mlv
@@ -703,7 +703,7 @@ let bsearch cmp arr x =
   bsearch BatInt.ord [| |] 3 = `Empty
 *)
 
-let split cmp arr x =
+let pivot_split cmp arr x =
   let open BatOrd in
   let n = length arr in
   (* find left edge between i and j *)
@@ -739,14 +739,14 @@ let split cmp arr x =
   in
   (search_left 0 (n-1), search_right 0 (n-1))
 
-(*$T split
-  split BatInt.ord [| |] 1 = (0, 0)
-  split BatInt.ord [|1;2;2;3;3;4;5|] 3 = (3,5)
-  split BatInt.ord [|1;1;1;2;3;3;4;5|] 1 = (0,3)
-  split BatInt.ord [|1;2;2;3;3;4;5|] 10 = (7,7)
-  split BatInt.ord [|1;2;2;3;3;4;5|] 0 = (0,0)
-  split BatInt.ord [|2;2;2|] 2 = (0,3)
-  split BatInt.ord [|1;2;2;4;5|] 3 = (3,3)
+(*$T pivot_split
+  pivot_split BatInt.ord [| |] 1 = (0, 0)
+  pivot_split BatInt.ord [|1;2;2;3;3;4;5|] 3 = (3,5)
+  pivot_split BatInt.ord [|1;1;1;2;3;3;4;5|] 1 = (0,3)
+  pivot_split BatInt.ord [|1;2;2;3;3;4;5|] 10 = (7,7)
+  pivot_split BatInt.ord [|1;2;2;3;3;4;5|] 0 = (0,0)
+  pivot_split BatInt.ord [|2;2;2|] 2 = (0,3)
+  pivot_split BatInt.ord [|1;2;2;4;5|] 3 = (3,3)
 *)
 
 let insert xs x i =
@@ -942,6 +942,7 @@ struct
   let of_backwards = of_backwards
   let to_list      = to_list
   let split        = split
+  let pivot_split  = pivot_split
   let of_list      = of_list
   let sort         = sort
   let stable_sort  = stable_sort


### PR DESCRIPTION
Also add it to the Cap submodule.

Closes #443