### PR TITLE
Build with -strict-sequence

### DIFF
--- a/_tags
+++ b/_tags
@@ -12,4 +12,4 @@ true: package(bytes), warn_-3, bin_annot
 <src/batOpaqueInnerSys.*>: opaque
 true: safe_string
 true: no_alias_deps
-
+true: strict_sequence

--- a/src/batIO.mli
+++ b/src/batIO.mli
@@ -951,7 +951,7 @@ module Incubator : sig
       ?last:string ->
       ?sep:string ->
       ?indent:int ->
-      (Format.formatter -> 'a -> 'b) -> Format.formatter -> 'a array -> unit
+      (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a array -> unit
       (** Print the contents of an array, with [first] preceding the first item
           (default: ["\[|"]), [last] following the last item (default: ["|\]"])
           and [sep] separating items (default: ["; "]). A printing function must
@@ -972,7 +972,7 @@ module Incubator : sig
       ?last:string ->
       ?sep:string ->
       ?indent:int ->
-      (Format.formatter -> 'a -> 'b) -> Format.formatter -> 'a BatEnum.t -> unit
+      (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a BatEnum.t -> unit
       (** Print the contents of an enum, with [first] preceding the first item
           (default: [""]), [last] following the last item (default: [""])
           and [sep] separating items (default: [" "]). A printing function must
@@ -992,7 +992,7 @@ module Incubator : sig
       ?last:string ->
       ?sep:string ->
       ?indent:int ->
-      (Format.formatter -> 'a -> 'b) -> Format.formatter -> 'a list -> unit
+      (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a list -> unit
       (** Print the contents of a list, with [first] preceding the first item
           (default: ["\["]), [last] following the last item (default: ["\]"])
           and [sep] separating items (default: ["; "]). A printing function must

--- a/src/batInnerPervasives.mlv
+++ b/src/batInnerPervasives.mlv
@@ -58,7 +58,7 @@ let ok = function
 
 let wrap f x = try Ok (f x) with ex -> Bad ex
 
-let forever f x = ignore (while true do f x done)
+let forever f x = ignore (while true do ignore (f x) done)
 
 let ignore_exceptions f x = try ignore (f x) with _ -> ()
 

--- a/src/batLazyList.ml
+++ b/src/batLazyList.ml
@@ -106,7 +106,7 @@ let make n x =
 
 let iter f l =
   let rec aux l = match next l with
-    | Cons (x, t) -> (f x; aux t)
+    | Cons (x, t) -> (ignore (f x); aux t)
     | Nil -> ()
   in aux l
 

--- a/src/batRefList.ml
+++ b/src/batRefList.ml
@@ -121,12 +121,12 @@ module Index = struct
 
   let index pred rl =
     let index = ref (-1) in
-    List.find (fun it -> incr index; pred it; ) !rl;
+    ignore (List.find (fun it -> incr index; pred it; ) !rl);
     !index
 
   let index_of rl item =
     let index = ref (-1) in
-    List.find (fun it -> incr index; it = item; ) !rl;
+    ignore (List.find (fun it -> incr index; it = item; ) !rl);
     !index
 
   let at_index rl pos = List.nth !rl pos


### PR DESCRIPTION
This PR enables the `-strict-sequence` flag when building batteries. A few fixes were needed.

- for functions of `BatIO` in an `Incubator` module, I opted to restrict the type in the interface;
- for other functions, I instead inserted calls to `ignore` so as to preserve the library interfaces.