### PR TITLE
Add equality between Stdlib.result and BatInnerPervasives.result

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -46,6 +46,10 @@ Changelog
   are changed. The default value is Pervasives.compare.
   #679
   (Cedric Cellier)
+- BatResult: BatPervasives.result is now equal to Stdlib.result
+  instead of sharing constructors without being the same type
+  #938
+  (Clément Busschaert)
 
 ## v2.11.0 (minor release)
 

--- a/src/batInnerPervasives.mlv
+++ b/src/batInnerPervasives.mlv
@@ -43,7 +43,7 @@ let unique ()     =
    Q.unit (fun () -> unique () <> unique ())
 *)
 
-type ('a, 'b) result =
+type ('a, 'b) result = ('a, 'b) Stdlib.result =
   | Ok  of 'a
   | Error of 'b
 

--- a/src/batteries_compattest.ml
+++ b/src/batteries_compattest.ml
@@ -54,6 +54,7 @@ module Stdlib_verifications = struct
   (*  module Printf = (Printf: module type of Legacy.Printf)*)
   module Queue = (Queue: module type of Legacy.Queue)
   module Random = (Random: module type of Legacy.Random)
+  module Result = (Result: module type of Legacy.Result)
   (*  module Scanf = (Scanf : module type of Legacy.Scanf)*)
   (*  module Set = (Set: module type of Legacy.Set)*)
   (* FAILS BECAUSE OF Stack.Empty not being present because


### PR DESCRIPTION
See #938 

I agreed with the point raised by the issue author. I don't think more changes are needed. If I missed some places to put tests, I'd like to know.