### PR TITLE
Implemented find_opt in Map.S interface

### DIFF
--- a/src/batMap.ml
+++ b/src/batMap.ml
@@ -964,7 +964,6 @@ let add x d m = Concrete.add x d Pervasives.compare m
 let update k1 k2 v2 m = Concrete.update k1 k2 v2 Pervasives.compare m
 
 let find x m = Concrete.find x Pervasives.compare m
-let find_opt x m = Concrete.find_option x Pervasives.compare m
 
 (*$T add; find
   empty |> add 1 true |> add 2 false |> find 1
@@ -973,6 +972,13 @@ let find_opt x m = Concrete.find_option x Pervasives.compare m
   empty |> add 1 true |> add 2 false |> find 2 |> not
   empty |> add 2 'y' |> add 1 'x' |> find 1 = 'x'
   empty |> add 2 'y' |> add 1 'x' |> find 2 = 'y'
+*)
+
+let find_opt x m = Concrete.find_option x Pervasives.compare m
+
+(*$T find_opt
+    find_opt  4 (add 1 2 empty) = None
+    find_opt 1 (add 1 2 empty) = Some 2
 *)
 
 let find_default def x m =

--- a/src/batMap.ml
+++ b/src/batMap.ml
@@ -742,6 +742,7 @@ sig
   val add: key -> 'a -> 'a t -> 'a t
   val update: key -> key -> 'a -> 'a t -> 'a t
   val find: key -> 'a t -> 'a
+  val find_opt: key -> 'a t -> 'a option
   val find_default: 'a -> key -> 'a t -> 'a
   val remove: key -> 'a t -> 'a t
   val modify: key -> ('a -> 'a) -> 'a t -> 'a t
@@ -963,6 +964,7 @@ let add x d m = Concrete.add x d Pervasives.compare m
 let update k1 k2 v2 m = Concrete.update k1 k2 v2 Pervasives.compare m
 
 let find x m = Concrete.find x Pervasives.compare m
+let find_opt x m = Concrete.find_option x Pervasives.compare m
 
 (*$T add; find
   empty |> add 1 true |> add 2 false |> find 1
@@ -1165,6 +1167,9 @@ module PMap = struct (*$< PMap *)
 
   let find x m =
     Concrete.find x m.cmp m.map
+
+  let find_opt x m =
+    Concrete.find_option x m.cmp m.map
 
   let find_default def x m =
     Concrete.find_default def x m.cmp m.map

--- a/src/batMap.mli
+++ b/src/batMap.mli
@@ -102,6 +102,10 @@ sig
   (** [find x m] returns the current binding of [x] in [m],
       or raises [Not_found] if no such binding exists. *)
 
+  val find_opt: key -> 'a t -> 'a option
+  (** [find_opt x m] returns Some b where b is the current binding
+   * of [x] in [m], or None if no such binding exists. *)
+
   val find_default: 'a -> key -> 'a t -> 'a
   (** [find_default d x m] returns the current binding of [x] in [m],
       or the default value [d] if no such binding exists. *)
@@ -429,6 +433,10 @@ val update: 'a -> 'a -> 'b -> ('a, 'b) t -> ('a, 'b) t
 val find : 'a -> ('a, 'b) t -> 'b
 (** [find x m] returns the current binding of [x] in [m],
     or raises [Not_found] if no such binding exists. *)
+
+val find_opt : 'a -> ('a, 'b) t -> 'b option
+(** [find_opt x m] returns Some b where b is the current binding
+ * of [x] in [m], or None if no such binding exists. *)
 
 val find_default : 'b -> 'a -> ('a, 'b) t -> 'b
 (** [find_default d x m] returns the current binding of [x] in [m],

--- a/src/batSplay.ml
+++ b/src/batSplay.ml
@@ -306,6 +306,11 @@ struct
       v
     | _ -> raise Not_found
 
+  let find_opt k m =
+    match find k m with
+    | binding -> Some binding
+    | exception Not_found -> None
+
   let find_default def k m =
     try find k m
     with Not_found -> def
@@ -553,7 +558,7 @@ struct
   end
 
   module Exceptionless = struct
-    let find k m = try Some (find k m) with Not_found -> None
+    let find k m = find_opt k m
     let choose m = try Some (choose m) with Not_found -> None
     let any m = try Some (any m) with Not_found -> None
   end

--- a/src/batSplay.ml
+++ b/src/batSplay.ml
@@ -307,9 +307,8 @@ struct
     | _ -> raise Not_found
 
   let find_opt k m =
-    match find k m with
-    | binding -> Some binding
-    | exception Not_found -> None
+    try Some (find k m)
+    with Not_found -> None
 
   let find_default def k m =
     try find k m

--- a/testsuite/test_map.ml
+++ b/testsuite/test_map.ml
@@ -84,6 +84,7 @@ module TestMap
     val is_empty : _ m -> bool
     val singleton : key -> 'a -> 'a m
     val find : key -> 'a m -> 'a
+    val find_opt : key -> 'a m -> 'a option
     val add : key -> 'a -> 'a m -> 'a m
     val remove : key -> 'a m -> 'a m
     val mem : key -> _ m -> bool
@@ -192,6 +193,19 @@ module TestMap
     "find 3 t = 4" @? (M.find 3 t = 4);
     "find 4 t -> Not_found" @!
       (Not_found, fun () -> M.find 6 t);
+    let test_cardinal k v t =
+      "cardinal (add k v t) = cardinal t + (mem k t ? 0 : 1)" @?
+        (M.cardinal (M.add k v t) =
+            M.cardinal t + if M.mem k t then 0 else 1) in
+    test_cardinal 3 0 t;
+    test_cardinal 57 0 t;
+    ()
+
+  let test_find_opt () =
+    let t = il [(3,4); (5, 6)] in
+    "find_opt 3 t = Some 4" @? (M.find_opt 3 t = Some 4);
+    "find_opt 4 t -> None" @?
+      (M.find_opt 6 t = None);
     let test_cardinal k v t =
       "cardinal (add k v t) = cardinal t + (mem k t ? 0 : 1)" @?
         (M.cardinal (M.add k v t) =

--- a/testsuite/test_map.ml
+++ b/testsuite/test_map.ml
@@ -84,7 +84,6 @@ module TestMap
     val is_empty : _ m -> bool
     val singleton : key -> 'a -> 'a m
     val find : key -> 'a m -> 'a
-    val find_opt : key -> 'a m -> 'a option
     val add : key -> 'a -> 'a m -> 'a m
     val remove : key -> 'a m -> 'a m
     val mem : key -> _ m -> bool
@@ -193,19 +192,6 @@ module TestMap
     "find 3 t = 4" @? (M.find 3 t = 4);
     "find 4 t -> Not_found" @!
       (Not_found, fun () -> M.find 6 t);
-    let test_cardinal k v t =
-      "cardinal (add k v t) = cardinal t + (mem k t ? 0 : 1)" @?
-        (M.cardinal (M.add k v t) =
-            M.cardinal t + if M.mem k t then 0 else 1) in
-    test_cardinal 3 0 t;
-    test_cardinal 57 0 t;
-    ()
-
-  let test_find_opt () =
-    let t = il [(3,4); (5, 6)] in
-    "find_opt 3 t = Some 4" @? (M.find_opt 3 t = Some 4);
-    "find_opt 4 t -> None" @?
-      (M.find_opt 6 t = None);
     let test_cardinal k v t =
       "cardinal (add k v t) = cardinal t + (mem k t ? 0 : 1)" @?
         (M.cardinal (M.add k v t) =


### PR DESCRIPTION
Related to this issue : https://github.com/ocaml-batteries-team/batteries-included/issues/940

This Pull request adds a find_opt function to the Map.S interface. It appears that there was  already a find_option implemented in Map.Concrete so I just used that. Another implementation was needed in BatSplay.ml so I added one. Also note that a function with the same type is implemented in Map.S.Exceptionless. Maybe we should do some factorization, but for now I changed the code as little as possible.
There was a discussion on the issue on which syntax should be used (about whether or not use the match... exception syntax). I'm still not clear on the subject, so I'm waiting for your comments.