### PR TITLE
Fix tests on OCaml 4.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ env:
   - OCAML_VERSION=4.06.0
   - OCAML_VERSION=4.07.0
   - OCAML_VERSION=4.08.0
+  - OCAML_VERSION=4.09.0
+  - OCAML_VERSION=4.10.0+rc2 OCAML_BETA=enable
 
 # notifications:
 #   email:

--- a/src/batList.mliv
+++ b/src/batList.mliv
@@ -441,14 +441,6 @@ val find_opt: ('a -> bool) -> 'a list -> 'a option
     satisfies [p] in the list [l].
     @since 2.7.0 *)
 
-##V>=4.10##val find_map_opt: ('a -> 'b option) -> 'a list -> 'b option
-##V>=4.10##(** [find_map f l] applies [f] to the elements of [l] in order,
-##V>=4.10##    and returns the first result of the form [Some v], or [None]
-##V>=4.10##    if none exist.
-##V>=4.10##
-##V>=4.10##    @since 2.12.0 and OCaml 4.10
-##V>=4.10##*)
-
 val find_exn : ('a -> bool) -> exn -> 'a list -> 'a
 (** [find_exn p e l] returns the first element of [l] such as [p x]
     returns [true] or raises [e] if such an element has not been found. *)
@@ -458,11 +450,10 @@ val findi : (int -> 'a -> bool) -> 'a list -> (int * 'a)
     index [i] such that [p i ai] is true, or @raise Not_found if no
     such element has been found. *)
 
-val find_map : ('a -> 'b option) -> 'a list -> 'b
+val find_map : ('a -> 'b option) -> 'a list -> 'b option
 (** [find_map pred list] finds the first element of [list] for which
-    [pred element] returns [Some r].  It returns [r] immediately
-    once found or @raise Not_found if no element matches the
-    predicate.  See also {!filter_map}. *)
+    [pred element] returns [Some r].  It returns [Some r] once found
+    or [None] if no element matches the predicate.  See also {!filter_map}. *)
 
 ##V>=4.10##val concat_map : ('a -> 'b list) -> 'a list -> 'b list
 ##V>=4.10##(** [List.concat_map f l] gives the same result as
@@ -1012,11 +1003,6 @@ module Exceptionless : sig
   val assq : 'a -> ('a * 'b) list -> 'b option
   (** As {!assoc} but with physical equality. *)
 
-  val find_map : ('a -> 'b option) -> 'a list -> 'b option
-  (** [find_map f xs] returns [Some y] such that [x] is the first
-      element of the list where [f x] returns [Some y].  It returns [None]
-      if no such element exists. *)
-
   val hd : ('a list -> 'a option)
   (** [hd l] returns [Some x] such that [x] is the first element of the given
       list [l].
@@ -1066,7 +1052,6 @@ module Labels : sig
   val subset : cmp:('a -> 'b -> int) -> 'a list -> 'b list -> bool
   val find : f:('a -> bool) -> 'a list -> 'a
   val find_exn : f:('a -> bool) -> exn -> 'a list -> 'a
-##V>=4.10##val find_map_opt: f:('a -> 'b option) -> 'a list -> 'b option
   val findi : f:(int -> 'a -> bool) -> 'a list -> (int * 'a)
   val rfind : f:('a -> bool) -> 'a list -> 'a
   val filter : f:('a -> bool) -> 'a list -> 'a list

--- a/src/batList.mlv
+++ b/src/batList.mlv
@@ -56,7 +56,6 @@ let rev_map2 = List.rev_map2
 ##V>=4.07##let to_seq = List.to_seq
 ##V>=4.07##let of_seq = List.of_seq
 ##V>=4.10##let concat_map = List.concat_map
-##V>=4.10##let find_map_opt = List.find_map
 (* ::VH:: END GLUE *)
 
 let rec compare_lengths la lb = match la, lb with
@@ -566,10 +565,10 @@ let filteri_map f l =
 *)
 
 let rec find_map f = function
-  | [] -> raise Not_found
+  | [] -> None
   | x :: xs ->
     match f x with
-    | Some y -> y
+    | Some y -> Some y
     | None -> find_map f xs
 
 let fold_right_max = 1000
@@ -1540,10 +1539,6 @@ module Exceptionless = struct
     try Some (assoc_inv e l)
     with Not_found -> None
 
-  let find_map f l =
-    try Some(find_map f l)
-    with Not_found -> None
-
   let hd l =
     try Some (hd l)
     with Failure _ -> None
@@ -1572,7 +1567,6 @@ module Labels = struct
   let find ~f l     = find f l
   let findi ~f      = findi f
   let find_exn ~f   = find_exn f
-##V>=4.10##let find_map_opt ~f = find_map_opt f
   let filter_map ~f = filter_map f
   let remove_if ~f  = remove_if f
   let take_while ~f = take_while f

--- a/src/batPrintexc.mliv
+++ b/src/batPrintexc.mliv
@@ -170,6 +170,7 @@ val print : _ BatInnerIO.output -> exn -> unit
 ##V>=4.2##(** {6 Current call stack} *)
 ##V>=4.2##
 ##V>=4.2##val get_callstack: int -> raw_backtrace
+##V>=4.10##external get_callstack : int -> raw_backtrace = "caml_get_current_callstack"
 ##V>=4.2##(** [Printexc.get_callstack n] returns a description of the top of the
 ##V>=4.2##    call stack on the current program point (for the current thread),
 ##V>=4.2##    with at most [n] entries.  (Note: this function is not related to

--- a/src/batSys.mliv
+++ b/src/batSys.mliv
@@ -350,27 +350,4 @@ val files_of: string -> string BatEnum.t
     @since 2.5.0 and OCaml 4.02
  *)
 
-##V>=4.10##module Immediate64 : sig
-##V>=4.10##  (** This module allows to define a type [t] with the [immediate64]
-##V>=4.10##      attribute. This attribute means that the type is immediate on 64
-##V>=4.10##      bit architectures. On other architectures, it might or might not
-##V>=4.10##      be immediate.
-##V>=4.10##
-##V>=4.10##      @since 2.12.0 and OCaml 4.10
-##V>=4.10##  *)
-##V>=4.10##
-##V>=4.10##  module type Non_immediate = sig
-##V>=4.10##    type t
-##V>=4.10##  end
-##V>=4.10##  module type Immediate = sig
-##V>=4.10##    type t [@@immediate]
-##V>=4.10##  end
-##V>=4.10##
-##V>=4.10##  module Make(Immediate : Immediate)(Non_immediate : Non_immediate) : sig
-##V>=4.10##    type t [@@immediate64]
-##V>=4.10##    type 'a repr =
-##V>=4.10##      | Immediate : Immediate.t repr
-##V>=4.10##      | Non_immediate : Non_immediate.t repr
-##V>=4.10##    val repr : t repr
-##V>=4.10##  end
-##V>=4.10##end
+##V>=4.10##module Immediate64 = Sys.Immediate64


### PR DESCRIPTION
Fixes https://github.com/ocaml-batteries-team/batteries-included/pull/936#issuecomment-586996736 and a bunch of failures that came after.

My first PR seemed to have been a bit too rough. To keep compatibility with the standard library I removed `BatList.find_map_opt` in favour of changing the type of `BatList.find_map`. One other solution is to set that in the tests but I figured since it's a major release it might be worth doing it. Otherwise I can always do that instead.