### PR TITLE
BatString: Fix doc section on splitting

### DIFF
--- a/src/batString.mliv
+++ b/src/batString.mliv
@@ -749,21 +749,6 @@ val split_on_char: char -> string -> string list
     @since 2.5.3
 *)
 
-##V>=4.07##(** {1 Iterators} *)
-
-##V>=4.07##val to_seq : t -> char Seq.t
-##V>=4.07##(** Iterate on the string, in increasing index order. Modifications of the
-##V>=4.07##    string during iteration will be reflected in the iterator.
-##V>=4.07##    @since 2.10.0 and OCaml 4.07 *)
-
-##V>=4.07##val to_seqi : t -> (int * char) Seq.t
-##V>=4.07##(** Iterate on the string, in increasing order, yielding indices along chars
-##V>=4.07##    @since 2.10.0 and OCaml 4.07 *)
-
-##V>=4.07##val of_seq : char Seq.t -> t
-##V>=4.07##(** Create a string from the generator
-##V>=4.07##    @since 2.10.0 and OCaml 4.07 *)
-
 val split : string -> by:string -> string * string
 (** [split s sep] splits the string [s] between the first
     occurrence of [sep], and returns the two parts before
@@ -903,6 +888,21 @@ val implode : char list -> string
 
     Example: [String.implode ['b'; 'a'; 'r'] = "bar"]
 *)
+
+##V>=4.07##(** {6 Iterators} *)
+
+##V>=4.07##val to_seq : t -> char Seq.t
+##V>=4.07##(** Iterate on the string, in increasing index order. Modifications of the
+##V>=4.07##    string during iteration will be reflected in the iterator.
+##V>=4.07##    @since 2.10.0 and OCaml 4.07 *)
+
+##V>=4.07##val to_seqi : t -> (int * char) Seq.t
+##V>=4.07##(** Iterate on the string, in increasing order, yielding indices along chars
+##V>=4.07##    @since 2.10.0 and OCaml 4.07 *)
+
+##V>=4.07##val of_seq : char Seq.t -> t
+##V>=4.07##(** Create a string from the generator
+##V>=4.07##    @since 2.10.0 and OCaml 4.07 *)
 
 (** {6 Comparisons}*)
 


### PR DESCRIPTION
itself was split by iterators section.

The whole documentation organisation into sections needs some live, though.