### PR TITLE
Aliases for List.unfold_exc and RefList.find_exc

### DIFF
--- a/src/batList.mliv
+++ b/src/batList.mliv
@@ -201,16 +201,21 @@ val unfold: 'b -> ('b -> ('a * 'b) option) -> 'a list
     @since 2.1
 *)
 
-val unfold_exc : (unit -> 'a) -> 'a list * exn
+val unfold_exn : (unit -> 'a) -> 'a list * exn
 (** Creates a list containing the results of sequential calls
     to [f()]. [f()] is called repeatedly until it throws an exception.
     Both the results list, as well as the exception
     thrown are returned in a [(results_list, exn)] pair.
-    Warning: if calls to [f()] never throw an exception, unfold_exc
+    Warning: if calls to [f()] never throw an exception, unfold_exn
     is an infinite loop.
 
-    @since 2.3.0
+    @since NEXT_RELEASE
 *)
+
+val unfold_exc : (unit -> 'a) -> 'a list * exn
+(** Alias for [unfold_exn].
+    @deprecated use {!unfold_exn}
+    @since 2.3.0 *)
 
 (**{6 Iterators}*)
 

--- a/src/batList.mlv
+++ b/src/batList.mlv
@@ -883,7 +883,7 @@ let init size f =
     loop r 1;
     inj r
 
-let unfold_exc f =
+let unfold_exn f =
   let rec loop dst =
     loop (Acc.accum dst (f ()))
   in
@@ -892,16 +892,18 @@ let unfold_exc f =
     loop acc
   with exn -> (acc.tl, exn)
 
-(*$T unfold_exc
+(*$T unfold_exn
   let exc () = raise End_of_file in \
-  unfold_exc exc = ([], End_of_file)
+  unfold_exn exc = ([], End_of_file)
   let state = ref 0 in \
   let just_zero () = \
     if !state = 1 then raise End_of_file \
     else let _ = incr state in 0 \
   in \
-  unfold_exc just_zero = ([0], End_of_file)
+  unfold_exn just_zero = ([0], End_of_file)
 *)
+
+let unfold_exc = unfold_exn
 
 let make i x =
   if i < 0 then invalid_arg "List.make";

--- a/src/batRefList.ml
+++ b/src/batRefList.ml
@@ -49,7 +49,8 @@ let transform f rl = rl := BatList.map f !rl
 let map_list f rl = BatList.map f !rl
 let find f rl = List.find f !rl
 let rev rl = rl := List.rev !rl
-let find_exc f exn rl = try List.find f !rl with _ -> raise exn
+let find_exn f exn rl = try List.find f !rl with _ -> raise exn
+let find_exc = find_exn
 let exists f rl = List.exists f !rl
 let sort ~cmp rl = rl := List.sort cmp !rl
 

--- a/src/batRefList.mli
+++ b/src/batRefList.mli
@@ -135,9 +135,14 @@ val rfind : ('a -> bool) -> 'a t -> 'a
     the specified predicate
     raise [Not_found] if no element is found *)
 
-val find_exc : ('a -> bool) -> exn -> 'a t -> 'a
+val find_exn : ('a -> bool) -> exn -> 'a t -> 'a
 (** Same as find but takes an exception to be raised when
-    no element is found as additional parameter *)
+    no element is found as additional parameter.
+    @since NEXT_RELEASE *)
+
+val find_exc : ('a -> bool) -> exn -> 'a t -> 'a
+(** Alias for [find_exn].
+    @deprecated use {!find_exn} *)
 
 val exists : ('a -> bool) -> 'a t -> bool
 (** Return [true] if an element matches the specified


### PR DESCRIPTION
The_exn suffix is favored.