### PR TITLE
Removed double cut_on_char that appears twice in the BatString interface

### DIFF
--- a/src/batString.mliv
+++ b/src/batString.mliv
@@ -815,29 +815,6 @@ val cut_on_char : char -> int -> string -> string
    @since 2.9.0
 *)
 
-val cut_on_char : char -> int -> string -> string
-(**
-   Similar to Unix [cut]. [cut_on_char chr n str] returns the substring of
-   [str] located strictly between the [n]-th occurrence of [chr] and
-   the [n+1]-th one.
-
-   - {b Occurrences of [chr] are numbered from 1}.
-   - If [n = 0], returns the substring from the beginning of
-     [str] to the first occurrence of [chr].
-   - If there are exactly [n] occurrences of [chr] in [str], returns the
-     substring between the last occurrence of [chr] and the end of [str].
-   - These behaviours cumulate: if [n] equals [0] and [chr] is
-     absent from [str], returns the full string [str].
-
-   {b Remark:} [cut_on_char] can return the empty string. Examples of this
-   behaviour are [cut_on_char ',' 1 "foo,,bar"] and [cut_on_char ',' 0 ",foo"].
-
-   @raise Not_found if there are strictly less than [n] occurrences of [chr] in str.
-   @raise Invalid_argument if [n < 0].
-
-   @since 2.9.0
-*)
-
 val join : string -> string list -> string
 (** Same as {!concat} *)
 


### PR DESCRIPTION
https://github.com/ocaml-batteries-team/batteries-included/blob/8db9a29365b31d689677565705154dc5b6595020/src/batString.mliv#L795