### PR TITLE
Removed double trim in BatString's interface

### DIFF
--- a/src/batString.mliv
+++ b/src/batString.mliv
@@ -178,10 +178,10 @@ val mapi : (int -> char -> char) -> string -> string
 
 val trim : string -> string
 (** Return a copy of the argument, without leading and trailing
-    whitespace.  The characters regarded as whitespace are: [' '],
-    ['\012'], ['\n'], ['\r'], and ['\t'].  If there is no leading nor
-    trailing whitespace character in the argument, return the original
-    string itself, not a copy.
+    whitespace (according to {!BatChar.is_whitespace}).
+    The characters regarded as whitespace are: [' '], ['\n'], ['\r'], ['\t'],
+    ['\012'] and ['\026'].  If there is no leading nor trailing whitespace
+    character in the argument, return the original string itself, not a copy.
     @since 4.00.0 *)
 
 val escaped : string -> string

--- a/src/batString.mliv
+++ b/src/batString.mliv
@@ -626,13 +626,6 @@ val chop : ?l:int -> ?r:int -> string -> string
     [String.chop ~l:2 ~r:3 "01234567" = "234"]
 *)
 
-val trim : string -> string
-(** Returns the same string but without the leading and trailing
-    whitespaces (according to {!BatChar.is_whitespace}).
-
-    Example: [String.trim " \t foo\n  " = "foo"]
-*)
-
 val quote : string -> string
 (** Add quotes around a string and escape any quote or escape
     appearing in that string.  This function is used typically when


### PR DESCRIPTION
- trim appears twice in batString.mliv
- and added char '\026' in the comments