### PR TITLE
Add support for ocaml-multicore

### DIFF
--- a/src/batGc.mliv
+++ b/src/batGc.mliv
@@ -267,29 +267,29 @@ val allocated_bytes : unit -> float
     started.  It is returned as a [float] to avoid overflow problems
     with [int] on 32-bit machines. *)
 
-##V>=4.3##external get_minor_free : unit -> int = "caml_get_minor_free"
+##V>=4.3####V<multicore##external get_minor_free : unit -> int = "caml_get_minor_free"
 ##V=4.3##          [@@noalloc]
 ##V=4.4##          [@@noalloc]
-(** Return the current size of the free space inside the minor heap.
-    @since 2.5.0 and OCaml 4.03.0 *)
+##V>=4.3####V<multicore##(** Return the current size of the free space inside the minor heap.
+##V>=4.3####V<multicore##    @since 2.5.0 and OCaml 4.03.0 *)
 
-##V>=4.3##external get_bucket : int -> int = "caml_get_major_bucket" [@@noalloc]
-(** [get_bucket n] returns the current size of the [n]-th future bucket
-    of the GC smoothing system. The unit is one millionth of a full GC.
-    Raise [Invalid_argument] if [n] is negative, return 0 if n is larger
-    than the smoothing window.
-    @since 2.5.0 and OCaml 4.03.0 *)
+##V>=4.3####V<multicore##external get_bucket : int -> int = "caml_get_major_bucket" [@@noalloc]
+##V>=4.3####V<multicore##(** [get_bucket n] returns the current size of the [n]-th future bucket
+##V>=4.3####V<multicore##    of the GC smoothing system. The unit is one millionth of a full GC.
+##V>=4.3####V<multicore##    Raise [Invalid_argument] if [n] is negative, return 0 if n is larger
+##V>=4.3####V<multicore##    than the smoothing window.
+##V>=4.3####V<multicore##    @since 2.5.0 and OCaml 4.03.0 *)
 
-##V>=4.3##external get_credit : unit -> int = "caml_get_major_credit" [@@noalloc]
-(** [get_credit ()] returns the current size of the "work done in advance"
-    counter of the GC smoothing system. The unit is one millionth of a
-    full GC.
-    @since 2.5.0 and OCaml 4.03.0 *)
+##V>=4.3####V<multicore##external get_credit : unit -> int = "caml_get_major_credit" [@@noalloc]
+##V>=4.3####V<multicore##(** [get_credit ()] returns the current size of the "work done in advance"
+##V>=4.3####V<multicore##    counter of the GC smoothing system. The unit is one millionth of a
+##V>=4.3####V<multicore##    full GC.
+##V>=4.3####V<multicore##    @since 2.5.0 and OCaml 4.03.0 *)
 
-##V>=4.3##external huge_fallback_count : unit -> int = "caml_gc_huge_fallback_count"
-(** Return the number of times we tried to map huge pages and had to fall
-    back to small pages. This is always 0 if [OCAMLRUNPARAM] contains [H=1].
-    @since 2.5.0 and OCaml 4.03.0 *)
+##V>=4.3####V<multicore##external huge_fallback_count : unit -> int = "caml_gc_huge_fallback_count"
+##V>=4.3####V<multicore##(** Return the number of times we tried to map huge pages and had to fall
+##V>=4.3####V<multicore##    back to small pages. This is always 0 if [OCAMLRUNPARAM] contains [H=1].
+##V>=4.3####V<multicore##    @since 2.5.0 and OCaml 4.03.0 *)
 
 val finalise : ('a -> unit) -> 'a -> unit
 (** [finalise f v] registers [f] as a finalisation function for [v].


### PR DESCRIPTION
ocaml-multicore (OCaml 5.0) changes the interface for the `Gc` module, the interface is not set in stone yet so this PR is not intended to be merged now, only as a way for people testing ocaml-multicore early to be able to use packages that depend on batteries.