### PR TITLE
Little bit faster BatList.cartesian_product

### DIFF
--- a/src/batList.mliv
+++ b/src/batList.mliv
@@ -915,7 +915,9 @@ val cartesian_product_rev : 'a list -> 'b list -> ('a * 'b) list
 (** Same than [cartesian_product], but returns its output in reversed
     order than [cartesian_product].
     If you don't mind about the order of the output list, this function
-    is just a little bit faster while it doesn't reverse the input lists. *)
+    is just a little bit faster while it doesn't reverse the input lists.
+
+    @since NEXT_RELEASE *)
 
 val n_cartesian_product : 'a list list -> 'a list list
 (** Given n lists, return the n-way cartesian product of

--- a/src/batList.mliv
+++ b/src/batList.mliv
@@ -911,6 +911,12 @@ val cartesian_product : 'a list -> 'b list -> ('a * 'b) list
     [(a0,b0);(a0,b1); ...; (a0,bn); (a1,b0); ..; (a1, bn);
     ...; (an,bn)]].  The lists can be of unequal size. *)
 
+val cartesian_product_rev : 'a list -> 'b list -> ('a * 'b) list
+(** Same than [cartesian_product], but returns its output in reversed
+    order than [cartesian_product].
+    If you don't mind about the order of the output list, this function
+    is just a little bit faster while it doesn't reverse the input lists. *)
+
 val n_cartesian_product : 'a list list -> 'a list list
 (** Given n lists, return the n-way cartesian product of
     these lists.  Given [[a;b];[c];[d;e;f]], returns

--- a/src/batList.mlv
+++ b/src/batList.mlv
@@ -1344,7 +1344,14 @@ let group cmp lst =
 *)
 
 let cartesian_product l1 l2 =
-  List.concat (List.map (fun i -> List.map (fun j -> (i,j)) l2) l1)
+  let l1 = List.rev l1 in
+  let l2 = List.rev l2 in
+  List.fold_left
+    (fun acc a ->
+       List.fold_left
+         (fun acc b -> (a, b)::acc)
+         acc l2)
+    [] l1
 
 (*$T cartesian_product as cp
   cp [1;2;3] ['x';'y'] = [1,'x';1,'y';2,'x';2,'y';3,'x';3,'y']

--- a/src/batList.mlv
+++ b/src/batList.mlv
@@ -1357,6 +1357,18 @@ let cartesian_product l1 l2 =
   cp [1;2;3] ['x';'y'] = [1,'x';1,'y';2,'x';2,'y';3,'x';3,'y']
 *)
 
+let cartesian_product_rev l1 l2 =
+  List.fold_left
+    (fun acc a ->
+       List.fold_left
+         (fun acc b -> (a, b)::acc)
+         acc l2)
+    [] l1
+
+(*$T cartesian_product_rev as cp
+  cp [1;2;3] ['x';'y'] = [3,'y';3,'x';2,'y';2,'x';1,'y';1,'x']
+*)
+
 let rec n_cartesian_product = function
   | [] -> [[]]
   | h :: t ->


### PR DESCRIPTION
More details in this issue: #997

Also by avoiding the call to [List.concat](https://caml.inria.fr/pub/docs/manual-ocaml/libref/List.html#VALconcat) seems to make this function tail-rec, while the doc says that [List.concat](https://caml.inria.fr/pub/docs/manual-ocaml/libref/List.html#VALconcat) is not tail-rec.

You can test this PR with:
```
$ ocamlfind ocamlopt -linkpkg -package "unix,num,bigarray,str,bytes" \
        -I _build/src/ batteries.cmxa -o cp.opt cp.ml

$ cat cp.ml

let cartesian_product_orig l1 l2 =
  List.concat (List.map (fun a -> List.map (fun b -> (a, b)) l2) l1)

let cartesian_product = BatList.cartesian_product
let cartesian_product_rev = BatList.cartesian_product_rev

let () =
  let l1 = List.init 2_000 (fun i -> i) in
  let l2 = List.init 4_000 (fun i -> i) in
  let p =
    match Sys.argv.(1) with
    | "concat" -> cartesian_product_orig l1 l2
    | "fold" -> cartesian_product l1 l2
    | "fold_rev" -> cartesian_product_rev l1 l2
    | _ -> raise Exit
  in
  Printf.printf "len: %d\n%!" (List.length p);
;;

$ time ./cp.opt concat
len: 8000000

real	0m2,566s
user	0m2,392s
sys	0m0,172s

$ time ./cp.opt fold
len: 8000000

real	0m2,355s
user	0m2,215s
sys	0m0,139s

$ time ./cp.opt fold_rev
len: 8000000

real	0m2,176s
user	0m2,046s
sys	0m0,128s
```