### PR TITLE
Stdlib compat set

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,13 @@ Changelog
 
 ## NEXT_RELEASE (minor release)
 
+- BatSet: added several missing methods for compatibility with stdlib.
+	The implementation of filter, map and filter_map was adapted from
+	stdlib, authors of the original implementation are Xavier Leroy,
+	Albin Coquereau and Gabriel Scherer
+  #1003 (??)
+  (Jakob Krainz)
+
 - BatMap, BatSplay: find_first, find_first_opt, find_last, find_last_opt
 	for compatibility with stdlib.
 	The implementation in BatMap was adapted from stdlib; authors of the original

--- a/src/batSeq.mlv
+++ b/src/batSeq.mlv
@@ -413,7 +413,7 @@ let of_string ?(first="[") ?(last="]") ?(sep=";") of_str s =
   else
     let body = BatString.chop ~l:prfx_len ~r:sufx_len s in
     let strings = BatString.nsplit ~by:sep body in
-    of_list (BatList.map of_str strings)
+    of_list (List.map of_str strings)
 
 (*$T of_string
   equal (of_string int_of_string "[1;2;3]") (of_list [1;2;3])

--- a/src/batSeq.mlv
+++ b/src/batSeq.mlv
@@ -366,6 +366,9 @@ let to_string ?(first="[") ?(last="]") ?(sep=";") to_str s =
 *)
 
 let of_string ?(first="[") ?(last="]") ?(sep=";") of_str s =
+  let rec map f = function
+  | [] -> []
+  | h :: t -> (f h) :: (map f t) in
   if not (BatString.starts_with s first) then
     raise
       (Invalid_argument
@@ -381,7 +384,7 @@ let of_string ?(first="[") ?(last="]") ?(sep=";") of_str s =
   else
     let body = BatString.chop ~l:prfx_len ~r:sufx_len s in
     let strings = BatString.nsplit ~by:sep body in
-    of_list (BatList.map of_str strings)
+    of_list (map of_str strings)
 
 (*$T of_string
   equal (of_string int_of_string "[1;2;3]") (of_list [1;2;3])

--- a/src/batSeq.mlv
+++ b/src/batSeq.mlv
@@ -366,9 +366,6 @@ let to_string ?(first="[") ?(last="]") ?(sep=";") to_str s =
 *)
 
 let of_string ?(first="[") ?(last="]") ?(sep=";") of_str s =
-  let rec map f = function
-  | [] -> []
-  | h :: t -> (f h) :: (map f t) in
   if not (BatString.starts_with s first) then
     raise
       (Invalid_argument
@@ -384,7 +381,7 @@ let of_string ?(first="[") ?(last="]") ?(sep=";") of_str s =
   else
     let body = BatString.chop ~l:prfx_len ~r:sufx_len s in
     let strings = BatString.nsplit ~by:sep body in
-    of_list (map of_str strings)
+    of_list (BatList.map of_str strings)
 
 (*$T of_string
   equal (of_string int_of_string "[1;2;3]") (of_list [1;2;3])

--- a/src/batSet.ml
+++ b/src/batSet.ml
@@ -494,7 +494,7 @@ module Concrete = struct
 
   let filter_map cmp f e = fold (fun x acc -> match f x with Some v -> add cmp v acc | _ -> acc) e empty
 
-   let choose = min_elt (* I'd rather this chose the root, but okay *)
+  let choose = min_elt (* I'd rather this chose the root, but okay *)
   (*$= choose
     42 (empty |> add 42 |> choose)
     (empty |> add 0 |> add 1 |> choose) (empty |> add 1 |> add 0 |> choose)
@@ -995,7 +995,6 @@ module PSet = struct (*$< PSet *)
     get_cmp (create BatInt.compare) == BatInt.compare
   *)
 
-  (* TODO: ensure phys. equality for add remove update map_stdlib filter filter_map_stdlib *)
   let singleton ?(cmp = compare) x = { cmp = cmp; set = Concrete.singleton x }
   let is_empty s = Concrete.is_empty s.set
   let mem x s = Concrete.mem s.cmp x s.set

--- a/src/batSet.ml
+++ b/src/batSet.ml
@@ -1316,29 +1316,6 @@ let to_seq t =
 let to_seq_from k t =
   Concrete.to_seq_from Pervasives.compare k t
 
-(*$T add_seq
-  equal (of_list [1;2;3;4]) (add_seq (BatSeq.of_list [1;2]) (of_list [3;4]))
-  equal (of_list [3;4]) (add_seq (BatSeq.of_list []) (of_list [3;4]))
-  equal (of_list [1;2]) (add_seq (BatSeq.of_list [1;2]) (of_list []))
- *)
-
-(*$T of_seq
-  equal (of_list [1;2;3;4]) (of_seq (BatSeq.of_list [1;2;4;3]))
-  equal (of_list []) (of_seq (BatSeq.of_list []))
- *)
-
-(*$T to_seq
-  BatSeq.equal (BatSeq.of_list [1;2;3;4]) (to_seq (of_list [4;1;3;2]))
-  BatSeq.equal (BatSeq.of_list []) (to_seq (of_list []))
- *)
-
-(*$T to_seq_from
-  BatSeq.equal (BatSeq.of_list [1;2;3;4]) (to_seq_from 0 (of_list [4;1;3;2]))
-  BatSeq.equal (BatSeq.of_list [3;4]) (to_seq_from 3 (of_list [4;1;3;2]))
-  BatSeq.equal (BatSeq.of_list []) (to_seq_from 5 (of_list [4;1;3;2]))
-  BatSeq.equal (BatSeq.of_list []) (to_seq_from 5 (of_list []))
- *)
-
 (*$T subset
    subset (of_list [1;2;3]) (of_list [1;2;3;4])
    not (subset (of_list [1;2;3;5]) (of_list [1;2;3;4]))

--- a/src/batSet.ml
+++ b/src/batSet.ml
@@ -681,25 +681,27 @@ module Concrete = struct
         subset cmp (Node (Empty, v1, r1, 0)) r2 && subset cmp l1 t2
 
   let add_seq cmp s m =
-    Seq.fold_left (fun m e -> add cmp e m) m s
+    BatSeq.fold_left (fun m e -> add cmp e m) m s
     
   let of_seq cmp s =
     add_seq cmp s empty
     
   let rec to_seq m =
+    fun () ->
     match m with
-    | Empty -> Seq.empty
-    | Node(l, v, r, _) -> 
-       Seq.append (to_seq l) (Seq.cons v (to_seq r))
+    | Empty -> BatSeq.Nil
+    | Node(l, v, r, _) ->
+       BatSeq.append (to_seq l) (fun () -> BatSeq.Cons (v, to_seq r)) ()
     
   let rec to_seq_from cmp k m =
+    fun () ->
     match m with
-    | Empty -> Seq.empty
+    | Empty -> BatSeq.Nil
     | Node(l, v, r, _) ->
        if cmp k v <= 0 then
-         Seq.append (to_seq_from cmp k l) (Seq.cons v (to_seq r))
+         BatSeq.append (to_seq_from cmp k l) (fun () -> BatSeq.Cons (v, to_seq r)) ()
        else
-         to_seq_from cmp k r
+         to_seq_from cmp k r ()
   
 end
 

--- a/src/batSet.ml
+++ b/src/batSet.ml
@@ -699,7 +699,7 @@ module Concrete = struct
        if cmp k v <= 0 then
          Seq.append (to_seq_from cmp k l) (Seq.cons v (to_seq r))
        else
-         to_seq r
+         to_seq_from cmp k r
   
 end
 

--- a/src/batSet.ml
+++ b/src/batSet.ml
@@ -783,10 +783,10 @@ sig
   val of_enum: elt BatEnum.t -> t
   val of_list: elt list -> t
   val of_array: elt array -> t
-  val to_seq : t -> elt Seq.t
-  val to_seq_from :  elt -> t -> elt Seq.t
-  val add_seq : elt Seq.t -> t -> t
-  val of_seq : elt Seq.t -> t
+  val to_seq : t -> elt BatSeq.t
+  val to_seq_from :  elt -> t -> elt BatSeq.t
+  val add_seq : elt BatSeq.t -> t -> t
+  val of_seq : elt BatSeq.t -> t
   val print :  ?first:string -> ?last:string -> ?sep:string ->
     ('a BatInnerIO.output -> elt -> unit) ->
     'a BatInnerIO.output -> t -> unit

--- a/src/batSet.ml
+++ b/src/batSet.ml
@@ -1142,68 +1142,13 @@ let find_last_opt  f s = Concrete.find_last_opt  f s
   try ignore (find (1,2) (singleton (1,1))); false with Not_found -> true
  *)
 
-(*$T find_opt
-  (find_opt 1 (of_list [1;2;3;4;5;6;7;8])) = Some 1
-  (find_opt 8 (of_list [1;2;3;4;5;6;7;8])) = Some 8
-  (find_opt (1,2) (singleton (1,1))) = None
-*)
-
-(*$T find_first
-            (empty |> add 1 |> add 2 |> add 3 |> find_first (fun x -> x >= 0)) = 1
-            (empty |> add 1 |> add 2 |> add 3 |> find_first (fun x -> x >= 1)) = 1
-            (empty |> add 1 |> add 2 |> add 3 |> find_first (fun x -> x >= 2)) = 2
-            (empty |> add 1 |> add 2 |> add 3 |> find_first (fun x -> x >= 3)) = 3
-  try ignore(empty |> add 1 |> add 2 |> add 3 |> find_first (fun x -> x >= 4)); false with Not_found -> true
-  try ignore(empty |>                            find_first (fun x -> x >= 3)); false with Not_found -> true
-*)
-
-(*$T find_first_opt
-  (empty |> add 1 |> add 2 |> add 3 |> find_first_opt (fun x -> x >= 0)) = (Some 1)
-  (empty |> add 1 |> add 2 |> add 3 |> find_first_opt (fun x -> x >= 1)) = (Some 1)
-  (empty |> add 1 |> add 2 |> add 3 |> find_first_opt (fun x -> x >= 2)) = (Some 2)
-  (empty |> add 1 |> add 2 |> add 3 |> find_first_opt (fun x -> x >= 3)) = (Some 3)
-  (empty |> add 1 |> add 2 |> add 3 |> find_first_opt (fun x -> x >= 4)) = (None)
-  (empty |>                            find_first_opt (fun x -> x >= 3)) = (None)
-*)
-
-(*$T find_last
-            (empty |> add 1 |> add 2 |> add 3 |> find_last (fun x -> x <= 1)) = 1
-            (empty |> add 1 |> add 2 |> add 3 |> find_last (fun x -> x <= 2)) = 2
-            (empty |> add 1 |> add 2 |> add 3 |> find_last (fun x -> x <= 3)) = 3
-            (empty |> add 1 |> add 2 |> add 3 |> find_last (fun x -> x <= 4)) = 3
-  try ignore(empty |> add 1 |> add 2 |> add 3 |> find_last (fun x -> x <= 0)); false with Not_found -> true
-  try ignore(empty |>                            find_last (fun x -> x <= 3)); false with Not_found -> true
-*)
-
-(*$T find_last_opt
-  (empty |> add 1 |> add 2 |> add 3 |> find_last_opt (fun x -> x <= 0)) = None
-  (empty |> add 1 |> add 2 |> add 3 |> find_last_opt (fun x -> x <= 1)) = Some 1
-  (empty |> add 1 |> add 2 |> add 3 |> find_last_opt (fun x -> x <= 2)) = Some 2
-  (empty |> add 1 |> add 2 |> add 3 |> find_last_opt (fun x -> x <= 3)) = Some 3
-  (empty |> add 1 |> add 2 |> add 3 |> find_last_opt (fun x -> x <= 4)) = Some 3
-  (empty |>                            find_last_opt (fun x -> x <= 3)) = None
-*)
-
 let add x s  = Concrete.add Pervasives.compare x s
 
-(*$T add
-  let s = of_list [1;2;3] in s == (add 2 s) 
- *)
-
 let remove x s = Concrete.remove Pervasives.compare x s
-
-(*$T remove
-  let s = of_list [1;2;3] in s == (remove 4 s) 
-  let s = empty in s == (remove 4 s) 
- *)
 
 let remove_exn x s = Concrete.remove_exn Pervasives.compare x s
 
 let update x y s = Concrete.update Pervasives.compare x y s
-
-(*$T update
-  let s = of_list [1;2;3] in s == (update 2 2 s) 
- *)
 
 let iter f s = Concrete.iter f s
 

--- a/src/batSet.mli
+++ b/src/batSet.mli
@@ -380,23 +380,23 @@ sig
    *)
 
 
-  val to_seq : t -> elt Seq.t
+  val to_seq : t -> elt BatSeq.t
   (** Iterate on the whole set, in ascending order.
 
       @since NEXT_RELEASE  *)
     
-  val to_seq_from :  elt -> t -> elt Seq.t
+  val to_seq_from :  elt -> t -> elt BatSeq.t
   (** [to_seq_from x s] iterates on a subset of the elements in [s], 
       namely those greater or equal to [x], in ascending order.
     
       @since NEXT_RELEASE *)
     
-  val add_seq : elt Seq.t -> t -> t
+  val add_seq : elt BatSeq.t -> t -> t
   (** add the given elements to the set, in order. 
     
       @since NEXT_RELEASE  *)
     
-  val of_seq : elt Seq.t -> t
+  val of_seq : elt BatSeq.t -> t
   (** build a set from the given elements 
     
       @since NEXT_RELEASE *)
@@ -866,23 +866,23 @@ val of_array: 'a array -> 'a t
     function *)
 
   
-val to_seq : 'a t -> 'a Seq.t
+val to_seq : 'a t -> 'a BatSeq.t
 (** Iterate on the whole set, in ascending order.
 
     @since NEXT_RELEASE  *)
   
-val to_seq_from :  'a -> 'a t -> 'a Seq.t
+val to_seq_from :  'a -> 'a t -> 'a BatSeq.t
 (** [to_seq_from x s] iterates on a subset of the elements in [s], 
     namely those greater or equal to [x], in ascending order.
   
     @since NEXT_RELEASE *)
   
-val add_seq : 'a Seq.t -> 'a t -> 'a t
+val add_seq : 'a BatSeq.t -> 'a t -> 'a t
 (** add the given elements to the set, in order. 
   
     @since NEXT_RELEASE  *)
   
-val of_seq : 'a Seq.t -> 'a t
+val of_seq : 'a BatSeq.t -> 'a t
 (** build a set from the given elements 
   
     @since NEXT_RELEASE *)
@@ -1271,23 +1271,23 @@ module PSet : sig
   (** builds a set from the given array and comparison function *)
 
       
-  val to_seq : 'a t -> 'a Seq.t
+  val to_seq : 'a t -> 'a BatSeq.t
   (** Iterate on the whole set, in ascending order.
   
       @since NEXT_RELEASE  *)
     
-  val to_seq_from :  'a -> 'a t -> 'a Seq.t
+  val to_seq_from :  'a -> 'a t -> 'a BatSeq.t
   (** [to_seq_from x s] iterates on a subset of the elements in [s], 
       namely those greater or equal to [x], in ascending order.
     
       @since NEXT_RELEASE *)
     
-  val add_seq : 'a Seq.t -> 'a t -> 'a t
+  val add_seq : 'a BatSeq.t -> 'a t -> 'a t
   (** add the given elements to the set, in order. 
     
       @since NEXT_RELEASE  *)
     
-  val of_seq : ?cmp:('a -> 'a -> int) -> 'a Seq.t -> 'a t
+  val of_seq : ?cmp:('a -> 'a -> int) -> 'a BatSeq.t -> 'a t
   (** build a set from the given elements 
     
       @since NEXT_RELEASE *)

--- a/src/batSet.mli
+++ b/src/batSet.mli
@@ -76,7 +76,7 @@ sig
   *)
 
   val find_opt : elt -> t -> elt option
-  (** [find x s] returns [Some k] for the element [k] in [s] that
+  (** [find_opt x s] returns [Some k] for the element [k] in [s] that
       tests equal to [x] under its comparison function.
       If no element is equal, return [None]
 
@@ -534,7 +534,7 @@ val find: 'a -> 'a t -> 'a
 *)
 
 val find_opt : 'a -> 'a t -> 'a option
-(** [find x s] returns [Some k] for the element [k] in [s] that
+(** [find_opt x s] returns [Some k] for the element [k] in [s] that
     tests equal to [x] under its comparison function.
     If no element is equal, return [None]
 
@@ -956,7 +956,7 @@ module PSet : sig
   *)
 
   val find_opt : 'a -> 'a t -> 'a option
-  (** [find x s] returns [Some k] for the element [k] in [s] that
+  (** [find_opt x s] returns [Some k] for the element [k] in [s] that
       tests equal to [x] under its comparison function.
       If no element is equal, return [None]
 

--- a/src/batSet.mli
+++ b/src/batSet.mli
@@ -75,6 +75,45 @@ sig
       @raise Not_found if no element is equal
   *)
 
+  val find_opt : elt -> t -> elt option
+  (** [find x s] returns [Some k] for the element [k] in [s] that
+      tests equal to [x] under its comparison function.
+      If no element is equal, return [None]
+
+      @since NEXT_RELEASE *)
+
+  val find_first : (elt -> bool) -> t -> elt
+  (** [find_first f m] returns the first element [e] for which [f e] is true
+      or raises [Not_found] if there is no such element.
+      [f] must be monotonically increasing,
+      i.e. if [k1 < k2 && f k1] is true then [f k2] must also be true. 
+    
+      @since NEXT_RELEASE *)
+    
+  val find_first_opt : (elt -> bool) -> t -> elt option
+  (** [find_first_opt f m] returns [Some e] for the first element [e]
+      for which [f e] is true or returns [None] if there is no such element.
+      [f] must be monotonically increasing,
+      i.e. if [k1 < k2 && f k1] is true then [f k2] must also be true. 
+    
+      @since NEXT_RELEASE *)
+
+  val find_last : (elt -> bool) -> t -> elt
+  (** [find_last f m] returns the last element [e] for which [f e] is true
+    or raises [Not_found] if there is no such element.
+    [f] must be monotonically decreasing,
+    i.e. if [k1 < k2 && f k2] is true then [f k1] must also be true. 
+    
+    @since NEXT_RELEASE *)
+    
+  val find_last_opt : (elt -> bool) -> t -> elt option
+  (** [find_last_opt f m] returns [Some e] for the last element [e]
+    for which [f e] is true or returns [None] if there is no such element.
+    [f] must be monotonically decreasing,
+    i.e. if [k1 < k2 && f k2] is true then [f k1] must also be true. 
+    
+    @since NEXT_RELEASE *)
+
   val add: elt -> t -> t
   (** [add x s] returns a set containing all elements of [s],
       plus [x]. If [x] was already in [s], [s] is returned unchanged. *)
@@ -231,6 +270,13 @@ sig
 
     @raise Not_found if the set is empty. *)
 
+  val min_elt_opt : t -> elt option
+  (** Return [Some e] for the smallest element [e] of the given set
+      (with respect to the [Ord.compare] ordering).
+      Return None if the set is empty. 
+   
+      @since NEXT_RELEASE *)
+
   val pop_min: t -> elt * t
   (** Returns the smallest element of the given set
       along with the rest of the set.
@@ -254,12 +300,26 @@ sig
   val max_elt: t -> elt
   (** Same as {!Set.S.min_elt}, but returns the largest element of the
       given set. *)
+    
+  val max_elt_opt : t -> elt option
+  (** Same as {!Set.S.min_elt_opt}, but for the largest element of the
+      given set.
+
+      @since NEXT_RELEASE *)
 
   val choose: t -> elt
   (** Return one element of the given set.
       Which element is chosen is unspecified, but equal elements will be
       chosen for equal sets.
       @raise Not_found if the set is empty. *)
+
+  val choose_opt : t -> elt option
+  (** Return [Some e] for one element [e] of the given set.
+      Which element is chosen is unspecified, but equal elements will be
+      chosen for equal sets.
+      Return [None] if the set is empty.
+
+      @since NEXT_RELEASE *)
 
   val any: t -> elt
   (** Return one element of the given set.
@@ -296,7 +356,31 @@ sig
   (** builds a set from the given array.
 
       @since 2.4
-  *)
+   *)
+
+
+  val to_seq : t -> elt Seq.t
+  (** Iterate on the whole set, in ascending order.
+
+      @since NEXT_RELEASE  *)
+    
+  val to_seq_from :  elt -> t -> elt Seq.t
+  (** [to_seq_from x s] iterates on a subset of the elements in [s], 
+      namely those greater or equal to [x], in ascending order.
+    
+      @since NEXT_RELEASE *)
+    
+  val add_seq : elt Seq.t -> t -> t
+  (** add the given elements to the set, in order. 
+    
+      @since NEXT_RELEASE  *)
+    
+  val of_seq : elt Seq.t -> t
+  (** build a set from the given elements 
+    
+      @since NEXT_RELEASE *)
+     
+
 
 
   (** {6 Boilerplate code}*)
@@ -428,6 +512,45 @@ val find: 'a -> 'a t -> 'a
     @since 2.1
 *)
 
+val find_opt : 'a -> 'a t -> 'a option
+(** [find x s] returns [Some k] for the element [k] in [s] that
+    tests equal to [x] under its comparison function.
+    If no element is equal, return [None]
+
+    @since NEXT_RELEASE *)
+
+val find_first : ('a -> bool) -> 'a t -> 'a
+(** [find_first f m] returns the first element [e] for which [f e] is true
+    or raises [Not_found] if there is no such element.
+    [f] must be monotonically increasing,
+    i.e. if [k1 < k2 && f k1] is true then [f k2] must also be true. 
+  
+    @since NEXT_RELEASE *)
+  
+val find_first_opt : ('a -> bool) -> 'a t -> 'a option
+(** [find_first_opt f m] returns [Some e] for the first element [e]
+    for which [f e] is true or returns [None] if there is no such element.
+    [f] must be monotonically increasing,
+    i.e. if [k1 < k2 && f k1] is true then [f k2] must also be true. 
+  
+    @since NEXT_RELEASE *)
+
+val find_last : ('a -> bool) -> 'a t -> 'a
+(** [find_last f m] returns the last element [e] for which [f e] is true
+  or raises [Not_found] if there is no such element.
+  [f] must be monotonically decreasing,
+  i.e. if [k1 < k2 && f k2] is true then [f k1] must also be true. 
+  
+  @since NEXT_RELEASE *)
+  
+val find_last_opt : ('a -> bool) -> 'a t -> 'a option
+(** [find_last_opt f m] returns [Some e] for the last element [e]
+  for which [f e] is true or returns [None] if there is no such element.
+  [f] must be monotonically decreasing,
+  i.e. if [k1 < k2 && f k2] is true then [f k1] must also be true. 
+  
+  @since NEXT_RELEASE *)
+
 val add: 'a -> 'a t -> 'a t
 (** [add x s] returns a set containing all elements of [s],
     plus [x]. If [x] was already in [s], [s] is returned unchanged. *)
@@ -510,6 +633,21 @@ val map: ('a -> 'b) -> 'a t -> 'b t
     [Incubator.op_map] may be more efficient.
 *)
 
+val map_stdlib: ('a -> 'a) -> 'a t -> 'a t
+(** [map f x] creates a new set with elements [f a0],
+    [f a1]... [f aN], where [a0], [a1], ..., [aN] are the
+    elements of [x].
+
+    This function places no restriction on [f]; it can map multiple
+    input values to the same output value, in which case the
+    resulting set will have smaller cardinality than the input.  [f]
+    does not need to be order preserving, although if it is, then
+    [Incubator.op_map] may be more efficient.
+
+    This version of map will result in a physically equal map if [f]
+    returns physically equal keys.
+*)
+
 val filter: ('a -> bool) -> 'a t -> 'a t
 (** [filter p s] returns the set of all elements in [s]
     that satisfy predicate [p]. *)
@@ -524,6 +662,20 @@ val filter_map: ('a -> 'b option) -> 'a t -> 'b t
 
     The resulting map uses the polymorphic [compare] function to
     order elements.
+*)
+
+val filter_map_stdlib: ('a -> 'a option) -> 'a t -> 'a t
+(** [filter_map f m] combines the features of [filter] and
+    [map].  It calls calls [f a0], [f a1], [f aN] where [a0,a1..an]
+    are the elements of [m] and returns the set of pairs [bi]
+    such as [f ai = Some bi] (when [f] returns [None], the
+    corresponding element of [m] is discarded).
+
+    The resulting map uses the polymorphic [compare] function to
+    order elements.
+
+    if the filter function [f] returns [true] for all elements in [m],
+    the resulting map is physically equal to [m].
 *)
 
 val fold: ('a -> 'b -> 'b) -> 'a t -> 'b -> 'b
@@ -593,6 +745,13 @@ val min_elt : 'a t -> 'a
 (** returns the smallest element of the set.
     @raise Not_found if given an empty set. *)
 
+val min_elt_opt : 'a t -> 'a option
+(** Return [Some e] for the smallest element [e] of the given set
+    (with respect to the [Ord.compare] ordering).
+    Return None if the set is empty. 
+ 
+    @since NEXT_RELEASE *)
+
 val pop_min: 'a t -> 'a * 'a t
 (** Returns the smallest element of the given set
     along with the rest of the set.
@@ -617,9 +776,23 @@ val max_elt : 'a t -> 'a
 (** returns the largest element of the set.
     @raise Not_found if given an empty set.*)
 
+val max_elt_opt : 'a t -> 'a option
+(** Same as {!Set.S.min_elt_opt}, but for the largest element of the
+    given set.
+
+    @since NEXT_RELEASE *)
+
 val choose : 'a t -> 'a
 (** returns an arbitrary (but deterministic) element of the given set.
     @raise Not_found if given an empty set. *)
+
+val choose_opt : 'a t -> 'a option
+(** Return [Some e] for one element [e] of the given set.
+    Which element is chosen is unspecified, but equal elements will be
+    chosen for equal sets.
+    Return [None] if the set is empty.
+
+    @since NEXT_RELEASE *)
 
 val any: 'a t -> 'a
 (** Return one element of the given set.
@@ -657,6 +830,28 @@ val of_array: 'a array -> 'a t
 (** builds a set from the given array, using the default comparison
     function *)
 
+  
+val to_seq : 'a t -> 'a Seq.t
+(** Iterate on the whole set, in ascending order.
+
+    @since NEXT_RELEASE  *)
+  
+val to_seq_from :  'a -> 'a t -> 'a Seq.t
+(** [to_seq_from x s] iterates on a subset of the elements in [s], 
+    namely those greater or equal to [x], in ascending order.
+  
+    @since NEXT_RELEASE *)
+  
+val add_seq : 'a Seq.t -> 'a t -> 'a t
+(** add the given elements to the set, in order. 
+  
+    @since NEXT_RELEASE  *)
+  
+val of_seq : 'a Seq.t -> 'a t
+(** build a set from the given elements 
+  
+    @since NEXT_RELEASE *)
+   
 (** {6 Boilerplate code}*)
 
 
@@ -724,6 +919,45 @@ module PSet : sig
   (** [find x s] returns the element in s that tests equal to [x] under its comparison function.
       @raise Not_found if no element is equal
   *)
+
+  val find_opt : 'a -> 'a t -> 'a option
+  (** [find x s] returns [Some k] for the element [k] in [s] that
+      tests equal to [x] under its comparison function.
+      If no element is equal, return [None]
+
+      @since NEXT_RELEASE *)
+
+  val find_first : ('a -> bool) -> 'a t -> 'a
+  (** [find_first f m] returns the first element [e] for which [f e] is true
+      or raises [Not_found] if there is no such element.
+      [f] must be monotonically increasing,
+      i.e. if [k1 < k2 && f k1] is true then [f k2] must also be true. 
+    
+      @since NEXT_RELEASE *)
+    
+  val find_first_opt : ('a -> bool) -> 'a t -> 'a option
+  (** [find_first_opt f m] returns [Some e] for the first element [e]
+      for which [f e] is true or returns [None] if there is no such element.
+      [f] must be monotonically increasing,
+      i.e. if [k1 < k2 && f k1] is true then [f k2] must also be true. 
+    
+      @since NEXT_RELEASE *)
+
+  val find_last : ('a -> bool) -> 'a t -> 'a
+  (** [find_last f m] returns the last element [e] for which [f e] is true
+    or raises [Not_found] if there is no such element.
+    [f] must be monotonically decreasing,
+    i.e. if [k1 < k2 && f k2] is true then [f k1] must also be true. 
+    
+    @since NEXT_RELEASE *)
+    
+  val find_last_opt : ('a -> bool) -> 'a t -> 'a option
+  (** [find_last_opt f m] returns [Some e] for the last element [e]
+    for which [f e] is true or returns [None] if there is no such element.
+    [f] must be monotonically decreasing,
+    i.e. if [k1 < k2 && f k2] is true then [f k1] must also be true. 
+    
+    @since NEXT_RELEASE *)
 
   val add: 'a -> 'a t -> 'a t
   (** [add x s] returns a set containing all elements of [s],
@@ -805,6 +1039,18 @@ module PSet : sig
       order elements.
   *)
 
+  val map_stdlib: ('a -> 'a) -> 'a t -> 'a t
+  (** [map f x] creates a new set with elements [f a0],
+      [f a1]... [f aN], where [a0], [a1], ..., [aN] are the
+      values contained in [x]
+
+      The resulting map uses the same [compare] function to
+      order elements as [m] does.
+
+      If [f] returns physically equal values for all elements 
+      in [m] then the resulting map will be physically equal to [m].
+  *)
+
   val filter: ('a -> bool) -> 'a t -> 'a t
   (** [filter p s] returns the set of all elements in [s]
       that satisfy predicate [p]. *)
@@ -819,6 +1065,20 @@ module PSet : sig
 
       The resulting map uses the polymorphic [compare] function to
       order elements.
+  *)
+
+  val filter_map_stdlib: ('a -> 'a option) -> 'a t -> 'a t
+  (** [filter_map f m] combines the features of [filter] and
+      [map].  It calls calls [f a0], [f a1], [f aN] where [a0,a1..an]
+      are the elements of [m] and returns the set of pairs [bi]
+      such as [f ai = Some bi] (when [f] returns [None], the
+      corresponding element of [m] is discarded).
+  
+      The resulting map uses the polymorphic [compare] function to
+      order elements.
+  
+      if the filter function [f] returns [true] for all elements in [m],
+      the resulting map is physically equal to [m].
   *)
 
   val fold: ('a -> 'b -> 'b) -> 'a t -> 'b -> 'b
@@ -884,6 +1144,13 @@ module PSet : sig
   (** returns the smallest element of the set.
       @raise Not_found if given an empty set. *)
 
+  val min_elt_opt : 'a t -> 'a option
+  (** Return [Some e] for the smallest element [e] of the given set
+      (with respect to the [Ord.compare] ordering).
+      Return None if the set is empty. 
+   
+      @since NEXT_RELEASE *)
+
   val pop_min: 'a t -> 'a * 'a t
   (** Returns the smallest element of the given set
       along with the rest of the set.
@@ -908,10 +1175,24 @@ module PSet : sig
   (** returns the largest element of the set.
       @raise Not_found if given an empty set.*)
 
+  val max_elt_opt : 'a t -> 'a option
+  (** Same as {!Set.S.min_elt_opt}, but for the largest element of the
+      given set.
+  
+      @since NEXT_RELEASE *)
+  
   val choose : 'a t -> 'a
   (** returns an arbitrary (but deterministic) element of the given set.
       @raise Not_found if given an empty set. *)
 
+  val choose_opt : 'a t -> 'a option
+  (** Return [Some e] for one element [e] of the given set.
+      Which element is chosen is unspecified, but equal elements will be
+      chosen for equal sets.
+      Return [None] if the set is empty.
+  
+      @since NEXT_RELEASE *)
+  
   val any: 'a t -> 'a
   (** Return one element of the given set.
       The difference with choose is that there is no guarantee that equals
@@ -940,6 +1221,28 @@ module PSet : sig
   val of_array: ?cmp:('a -> 'a -> int) -> 'a array -> 'a t
   (** builds a set from the given array and comparison function *)
 
+      
+  val to_seq : 'a t -> 'a Seq.t
+  (** Iterate on the whole set, in ascending order.
+  
+      @since NEXT_RELEASE  *)
+    
+  val to_seq_from :  'a -> 'a t -> 'a Seq.t
+  (** [to_seq_from x s] iterates on a subset of the elements in [s], 
+      namely those greater or equal to [x], in ascending order.
+    
+      @since NEXT_RELEASE *)
+    
+  val add_seq : 'a Seq.t -> 'a t -> 'a t
+  (** add the given elements to the set, in order. 
+    
+      @since NEXT_RELEASE  *)
+    
+  val of_seq : ?cmp:('a -> 'a -> int) -> 'a Seq.t -> 'a t
+  (** build a set from the given elements 
+    
+      @since NEXT_RELEASE *)
+     
   (** {6 Boilerplate code}*)
 
 

--- a/src/batSet.mli
+++ b/src/batSet.mli
@@ -664,16 +664,17 @@ val map: ('a -> 'b) -> 'a t -> 'b t
     [Incubator.op_map] may be more efficient.
 *)
 
-val map_stdlib: ('a -> 'a) -> 'a t -> 'a t
-(** [map f x] creates a new set with elements [f a0],
+val map_endo: ('a -> 'a) -> 'a t -> 'a t
+(** [map_endo f x] creates a new set with elements [f a0],
     [f a1]... [f aN], where [a0], [a1], ..., [aN] are the
     elements of [x].
 
-    This function places no restriction on [f]; it can map multiple
-    input values to the same output value, in which case the
-    resulting set will have smaller cardinality than the input.  [f]
-    does not need to be order preserving, although if it is, then
-    [Incubator.op_map] may be more efficient.
+    This function places no restriction on [f] (beyond the type 
+    signature being more restricted than for [map] above); it can
+    map multiple input values to the same output value, in which
+    case the resulting set will have smaller cardinality than the
+    input.  [f]  does not need to be order preserving, although if
+    it is, then [Incubator.op_map] may be more efficient.
 
     This version of map will result in a physically equal map if [f]
     returns physically equal keys.
@@ -699,8 +700,8 @@ val filter_map: ('a -> 'b option) -> 'a t -> 'b t
     order elements.
 *)
 
-val filter_map_stdlib: ('a -> 'a option) -> 'a t -> 'a t
-(** [filter_map f m] combines the features of [filter] and
+val filter_map_endo: ('a -> 'a option) -> 'a t -> 'a t
+(** [filter_map_endo f m] combines the features of [filter] and
     [map].  It calls calls [f a0], [f a1], [f aN] where [a0,a1..an]
     are the elements of [m] and returns the set of pairs [bi]
     such as [f ai = Some bi] (when [f] returns [None], the
@@ -709,9 +710,8 @@ val filter_map_stdlib: ('a -> 'a option) -> 'a t -> 'a t
     The resulting map uses the polymorphic [compare] function to
     order elements.
 
-    if the filter function [f] returns [true] for all elements in [m],
-    the resulting map is physically equal to [m].
-*)
+    If the filter function [f] returns [true] for all elements in [m],
+    the resulting map is physically equal to [m]. *)
 
 val fold: ('a -> 'b -> 'b) -> 'a t -> 'b -> 'b
 (** [fold f s a] computes [(f xN ... (f x1 (f x0 a))...)],
@@ -1082,7 +1082,7 @@ module PSet : sig
       order elements.
   *)
 
-  val map_stdlib: ('a -> 'a) -> 'a t -> 'a t
+  val map_endo: ('a -> 'a) -> 'a t -> 'a t
   (** [map f x] creates a new set with elements [f a0],
       [f a1]... [f aN], where [a0], [a1], ..., [aN] are the
       values contained in [x]
@@ -1115,15 +1115,15 @@ module PSet : sig
       order elements.
   *)
 
-  val filter_map_stdlib: ('a -> 'a option) -> 'a t -> 'a t
-  (** [filter_map f m] combines the features of [filter] and
+  val filter_map_endo: ('a -> 'a option) -> 'a t -> 'a t
+  (** [filter_map_endo f m] combines the features of [filter] and
       [map].  It calls calls [f a0], [f a1], [f aN] where [a0,a1..an]
       are the elements of [m] and returns the set of pairs [bi]
       such as [f ai = Some bi] (when [f] returns [None], the
       corresponding element of [m] is discarded).
   
-      The resulting map uses the polymorphic [compare] function to
-      order elements.
+      The resulting map uses the same [compare] function to
+      order elements as used for [m].
   
       if the filter function [f] returns [true] for all elements in [m],
       the resulting map is physically equal to [m].

--- a/src/batSet.mli
+++ b/src/batSet.mli
@@ -116,11 +116,17 @@ sig
 
   val add: elt -> t -> t
   (** [add x s] returns a set containing all elements of [s],
-      plus [x]. If [x] was already in [s], [s] is returned unchanged. *)
+      plus [x]. If [x] was already in [s], [s] is returned unchanged.
+
+      @before NEXT_RELEASE Physical equality was not ensured.
+      *)
 
   val remove: elt -> t -> t
   (** [remove x s] returns a set containing all elements of [s],
-      except [x]. If [x] was not in [s], [s] is returned unchanged. *)
+      except [x]. If [x] was not in [s], [s] is returned unchanged.
+
+      @before NEXT_RELEASE Physical equality was not ensured.
+   *)
 
   val remove_exn: elt -> t -> t
   (** [remove_exn x s] behaves like [remove x s] except that it raises
@@ -132,7 +138,10 @@ sig
   (** [update x y s] replace [x] by [y] in [s].
       [update] is faster when [x] compares equal to [y] according
       to the comparison function used by your set.
+      When [x] and [y] are physically equal, [m] is returned unchanged.
       @raise Not_found if [x] is not in [s].
+
+      @before NEXT_RELEASE Physical equality was not ensured.
       @since 2.4 *)
 
   val union: t -> t -> t
@@ -184,18 +193,30 @@ sig
   val map: (elt -> elt) -> t -> t
   (** [map f x] creates a new set with elements [f a0],
       [f a1]... [f aN], where [a0],[a1]..[aN] are the
-      values contained in [x]*)
+      values contained in [x]
+
+      if [f] returns all elements unmodified then [x] is returned unmodified.
+      @before NEXT_RELEASE Physical equality was not ensured.
+*)
 
   val filter: (elt -> bool) -> t -> t
   (** [filter p s] returns the set of all elements in [s]
-      that satisfy predicate [p]. *)
+      that satisfy predicate [p]. 
+
+      if [p] returns [true] for all elements then [s] is returned unmodified.
+      @before NEXT_RELEASE Physical equality was not ensured.
+   *)
 
   val filter_map: (elt -> elt option) -> t -> t
   (** [filter_map f m] combines the features of [filter] and
-      [map].  It calls calls [f a0], [f a1], [f aN] where [a0],[a1]..[aN]
-      are the elements of [m] and returns the set of pairs [bi]
+      [map].  It calls [f a0], [f a1], [f aN] where [a0],[a1]..[aN]
+      are the elements of [m] and returns the set of elements [bi]
       such as [f ai = Some bi] (when [f] returns [None], the
-      corresponding element of [m] is discarded). *)
+      corresponding element of [m] is discarded).
+
+      if [f] returns [true] for all elements then [s] is returned unmodified.
+      @before NEXT_RELEASE Physical equality was not ensured.
+ *)
 
   val fold: (elt -> 'a -> 'a) -> t -> 'a -> 'a
   (** [fold f s a] computes [(f xN ... (f x1 (f x0 a))...)],
@@ -553,11 +574,17 @@ val find_last_opt : ('a -> bool) -> 'a t -> 'a option
 
 val add: 'a -> 'a t -> 'a t
 (** [add x s] returns a set containing all elements of [s],
-    plus [x]. If [x] was already in [s], [s] is returned unchanged. *)
+    plus [x]. If [x] was already in [s], [s] is returned unchanged.
+
+    @before NEXT_RELEASE Physical equality was not ensured.
+ *)
 
 val remove: 'a -> 'a t -> 'a t
 (** [remove x s] returns a set containing all elements of [s],
-    except [x]. If [x] was not in [s], [s] is returned unchanged. *)
+    except [x]. If [x] was not in [s], [s] is returned unchanged. 
+
+    @before NEXT_RELEASE Physical equality was not ensured.
+*)
 
 val remove_exn: 'a -> 'a t -> 'a t
 (** [remove_exn x s] behaves like [remove x s] except that it raises
@@ -569,8 +596,12 @@ val update: 'a -> 'a -> 'a t -> 'a t
 (** [update x y s] replace [x] by [y] in [s].
     [update] is faster when [x] compares equal to [y] according
     to the comparison function used by your set.
+    When [x] and [y] are physically equal, [m] is returned unchanged.
     @raise Not_found if [x] is not in [s].
-    @since 2.4 *)
+    @since 2.4 
+
+    @before NEXT_RELEASE Physical equality was not ensured.
+*)
 
 val union: 'a t -> 'a t -> 'a t
 (** [union s t] returns the union of [s] and [t] - the set containing
@@ -650,7 +681,11 @@ val map_stdlib: ('a -> 'a) -> 'a t -> 'a t
 
 val filter: ('a -> bool) -> 'a t -> 'a t
 (** [filter p s] returns the set of all elements in [s]
-    that satisfy predicate [p]. *)
+    that satisfy predicate [p]. 
+
+    if [p] returns [true] for all elements then [s] is returned unmodified.
+    @before NEXT_RELEASE Physical equality was not ensured.
+ *)
 
 (* as under-specified as 'map' *)
 val filter_map: ('a -> 'b option) -> 'a t -> 'b t
@@ -961,11 +996,17 @@ module PSet : sig
 
   val add: 'a -> 'a t -> 'a t
   (** [add x s] returns a set containing all elements of [s],
-      plus [x]. If [x] was already in [s], [s] is returned unchanged. *)
+      plus [x]. If [x] was already in [s], [s] is returned unchanged. 
+
+      @before NEXT_RELEASE Physical equality was not ensured.
+   *)
 
   val remove: 'a -> 'a t -> 'a t
   (** [remove x s] returns a set containing all elements of [s],
-      except [x]. If [x] was not in [s], [s] is returned unchanged. *)
+      except [x]. If [x] was not in [s], [s] is returned unchanged.
+
+      @before NEXT_RELEASE Physical equality was not ensured.
+   *)
 
   val remove_exn: 'a -> 'a t -> 'a t
   (** [remove_exn x s] behaves like [remove x s] except that it raises
@@ -977,7 +1018,9 @@ module PSet : sig
   (** [update x y s] replace [x] by [y] in [s].
       [update] is faster when [x] compares equal to [y] according
       to the comparison function used by your set.
+      When [x] and [y] are physically equal, [m] is returned unchanged.
       @raise Not_found if [x] is not in [s].
+      @before NEXT_RELEASE Physical equality was not ensured.
       @since 2.4 *)
 
   val union: 'a t -> 'a t -> 'a t
@@ -1049,11 +1092,16 @@ module PSet : sig
 
       If [f] returns physically equal values for all elements 
       in [m] then the resulting map will be physically equal to [m].
+      @since NEXT_RELEASE
   *)
 
   val filter: ('a -> bool) -> 'a t -> 'a t
   (** [filter p s] returns the set of all elements in [s]
-      that satisfy predicate [p]. *)
+      that satisfy predicate [p]. 
+
+      if [p] returns [true] for all elements then [s] is returned unmodified.
+      @before NEXT_RELEASE Physical equality was not ensured.
+   *)
 
   (* as under-specified as 'map' *)
   val filter_map: ('a -> 'b option) -> 'a t -> 'b t
@@ -1079,6 +1127,7 @@ module PSet : sig
   
       if the filter function [f] returns [true] for all elements in [m],
       the resulting map is physically equal to [m].
+      @since NEXT_RELEASE
   *)
 
   val fold: ('a -> 'b -> 'b) -> 'a t -> 'b -> 'b

--- a/src/batteries_compattest.mlv
+++ b/src/batteries_compattest.mlv
@@ -60,7 +60,6 @@ module Stdlib_verifications = struct
   module Random = (Random: module type of Legacy.Random)
 ##V>=4.8## module Result = (Result: module type of Legacy.Result)
   (*  module Scanf = (Scanf : module type of Legacy.Scanf)*)
-  (*  module Set = (Set: module type of Legacy.Set)*)
   (* FAILS BECAUSE OF Stack.Empty not being present because
      module Stack = (Stack : module type of Legacy.Stack)
   *)
@@ -109,4 +108,12 @@ module Stdlib_verifications = struct
   module Big_int = (Big_int : module type of Legacy.Big_int)
   (* FIXME: This does not pass for some reason:
   module Bigarray = (Bigarray : module type of Legacy.Bigarray)*)
+
+  (* test compatibility of BatSet.S with Legacy.Set.S *)
+  let sort (type s) (module Set : Legacy.Set.S with type elt = s) l =
+      Set.elements (List.fold_right Set.add l Set.empty)
+  module IntSet = struct
+      include BatSet.Int
+  end 
+  let _ = assert ([1;2;3] = (sort (module IntSet) [3; 1; 2;]))
 end


### PR DESCRIPTION
BatSet is missing several methods from Stdlib.Set.
Also, several existing methods in Stdlib.Set guarantee physical equality of resulting sets if possible.
This PR introduces the missing methods into BatSet, and adds the physical equality guarantees.
It also adds BatSet to the compattest.