### PR TITLE
add version guards to definition of Legacy.Seq and to compattest for seq

### DIFF
--- a/src/batteries.mlv
+++ b/src/batteries.mlv
@@ -34,7 +34,7 @@ module Legacy = struct
   module Random = Random
   module Scanf = Scanf
   module Set = Set
-  module Seq = Seq
+##V>=4.7##  module Seq = Seq
 ##V<4.8## module Sort = Sort
   module Stack = Stack
   module StdLabels = StdLabels

--- a/src/batteries_compattest.mlv
+++ b/src/batteries_compattest.mlv
@@ -41,7 +41,7 @@ module Stdlib_verifications = struct
        val find_map : ('a -> 'b option) -> 'a list -> 'b
      end)
   (*  module Map = (Map : module type of Legacy.Map)*)
-  module Seq = (Seq : module type of Legacy.Seq)
+##V>=4.7## module Seq = (Seq : module type of Legacy.Seq)
   module Marshal =
     (Marshal: sig
        include module type of Legacy.Marshal


### PR DESCRIPTION
I forgot to make sure that Batteries depends on the presence of Stdlib.Seq only on >= 4.07.

This has been tested with 4.11 and 4.05.