### PR TITLE
increase compatibility between BatMap, BatSplay and stdlib.Map

### DIFF
--- a/src/batMap.ml
+++ b/src/batMap.ml
@@ -108,9 +108,10 @@ module Concrete = struct
     | Node (l, _, _, _, _) -> min_binding l
     | Empty -> raise Not_found
 
-  let min_binding_opt m =
-    try Some (min_binding m)
-    with Not_found -> None
+  let rec min_binding_opt = function
+    | Node (Empty, k, v, _, _) -> Some (k, v)
+    | Node (l, _, _, _, _) -> min_binding_opt l
+    | Empty -> None
 
   let get_root = function
     | Empty -> raise Not_found
@@ -131,9 +132,10 @@ module Concrete = struct
     | Node (_, _, _, r, _) -> max_binding r
     | Empty -> raise Not_found
 
-  let max_binding_opt m =
-    try Some (max_binding m)
-    with Not_found -> None
+  let rec max_binding_opt = function
+    | Node (_, k, v, Empty, _) -> Some (k, v)
+    | Node (_, _, _, r, _) -> max_binding_opt r
+    | Empty -> None
 
   let pop_max_binding s =
     let maxi = ref (get_root s) in

--- a/src/batMap.ml
+++ b/src/batMap.ml
@@ -913,12 +913,11 @@ module Concrete = struct
   let union_stdlib cmp f m1 m2 =
     foldi
       (fun k v m ->
-        match find_option k cmp m with
-        | Some v1 ->
-           (match f k v v1 with
-            | Some vmerged -> add k vmerged cmp m
-            | None -> remove k cmp m)
-        | None -> add k v cmp m)
+        update_stdlib k
+          (fun v2opt ->
+            match v2opt with
+            | Some v2 -> f k v v2
+            | None -> Some v) cmp m)
       m1
       m2
     

--- a/src/batMap.ml
+++ b/src/batMap.ml
@@ -120,7 +120,7 @@ module Concrete = struct
   let pop_min_binding s =
     let mini = ref (get_root s) in
     let rec loop = function
-      | Empty -> raise Not_found
+      | Empty -> assert(false)  (* get_root already raises Not_found on empty map *)
       | Node(Empty, k, v, r, _) -> mini := (k, v); r
       | Node(l, k, v, r, _) -> bal (loop l) k v r
     in
@@ -140,7 +140,7 @@ module Concrete = struct
   let pop_max_binding s =
     let maxi = ref (get_root s) in
     let rec loop = function
-      | Empty -> raise Not_found
+      | Empty ->  assert(false)  (* get_root already raises Not_found on empty map *)
       | Node (l, k, v, Empty, _) -> maxi := (k, v); l
       | Node (l, k, v, r, _) -> bal l k v (loop r)
     in

--- a/src/batMap.ml
+++ b/src/batMap.ml
@@ -917,7 +917,7 @@ module Concrete = struct
         | Some v1 ->
            (match f k v v1 with
             | Some vmerged -> add k vmerged cmp m
-            | None -> m)
+            | None -> remove k cmp m)
         | None -> add k v cmp m)
       m1
       m2

--- a/src/batMap.ml
+++ b/src/batMap.ml
@@ -990,10 +990,10 @@ sig
     (key -> 'a option -> 'b option -> 'c option) -> 'a t -> 'b t -> 'c t
   val union:
     (key -> 'a -> 'a -> 'a option) -> 'a t -> 'a t -> 'a t
-  val to_seq : 'a t -> (key * 'a) Seq.t
-  val to_seq_from :  key -> 'a t -> (key * 'a) Seq.t
-  val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
-  val of_seq : (key * 'a) Seq.t -> 'a t
+  val to_seq : 'a t -> (key * 'a) BatSeq.t
+  val to_seq_from :  key -> 'a t -> (key * 'a) BatSeq.t
+  val add_seq : (key * 'a) BatSeq.t -> 'a t -> 'a t
+  val of_seq : (key * 'a) BatSeq.t -> 'a t
   (** {6 Boilerplate code}*)
   (** {7 Printing}*)
   val print :  ?first:string -> ?last:string -> ?sep:string -> ?kvsep:string ->
@@ -1101,6 +1101,9 @@ struct
     let maxi, rest = Concrete.pop_max_binding (impl_of_t t) in
     (maxi, t_of_impl rest)
 
+  let max_binding_opt t = Concrete.max_binding_opt (impl_of_t t)
+  let min_binding_opt t = Concrete.min_binding_opt (impl_of_t t)
+
   let choose t = Concrete.choose (impl_of_t t)
   let choose_opt t = Concrete.choose_opt (impl_of_t t)
   let any t = Concrete.any (impl_of_t t)
@@ -1140,6 +1143,11 @@ struct
 
   let merge f t1 t2 =
     t_of_impl (Concrete.merge f Ord.compare (impl_of_t t1) (impl_of_t t2))
+
+  let of_seq s = t_of_impl (Concrete.of_seq Ord.compare s)
+  let add_seq s m = t_of_impl (Concrete.add_seq Ord.compare s (impl_of_t m))
+  let to_seq m = Concrete.to_seq (impl_of_t m)
+  let to_seq_from k m = Concrete.to_seq_from Ord.compare k (impl_of_t m)
 
   module Exceptionless =
   struct

--- a/src/batMap.ml
+++ b/src/batMap.ml
@@ -906,7 +906,7 @@ module Concrete = struct
     | Empty -> BatSeq.Nil
     | Node(l, k2, v, r, _) ->
        if cmp k k2 <= 0 then
-         BatSeq.append (to_seq_from cmp k l) (fun () -> BatSeq.Cons ((k,v), to_seq r)) ()
+         BatSeq.append (to_seq_from cmp k l) (fun () -> BatSeq.Cons ((k2,v), to_seq r)) ()
        else
          to_seq_from cmp k r ()
     

--- a/src/batMap.mli
+++ b/src/batMap.mli
@@ -119,7 +119,7 @@ sig
       be physically equal to [m]
       @raise Not_found if [k1] is not bound in [m].
       @since 2.4.0 
-      @before NEXT_RELEASE physical equality was nor ensured.  *)
+      @before NEXT_RELEASE physical equality was not ensured.  *)
     
   val find: key -> 'a t -> 'a
   (** [find x m] returns the current binding of [x] in [m],
@@ -289,7 +289,7 @@ sig
 
   val min_binding : 'a t -> (key * 'a)
   (** Return the [(key, value)] pair with the smallest key.
-      Raises Not_found if the map is empty.  *)
+      @raise Not_found if the map is empty.  *)
     
   val min_binding_opt : 'a t -> (key * 'a) option
   (** Return [Some (key, value)] for the [key, value] pair with 
@@ -560,7 +560,7 @@ val update: 'a -> 'a -> 'b -> ('a, 'b) t -> ('a, 'b) t
     be physically equal to [m]
     @raise Not_found if [k1] is not bound in [m].
     @since 2.4.0 
-    @before NEXT_RELEASE physical equality was nor ensured. *)
+    @before NEXT_RELEASE physical equality was not ensured. *)
 
 val update_stdlib : 'a -> ('b option -> 'b option) -> ('a, 'b) t -> ('a, 'b) t
 (** [update_stdlib k f m] returns a map containing the same bindings as [m],
@@ -1001,7 +1001,7 @@ module PMap : sig
       be physically equal to [m]
       @raise Not_found if [k1] is not bound in [m].
       @since 2.4.0 
-      @before NEXT_RELEASE physical equality was nor ensured.  *)
+      @before NEXT_RELEASE physical equality was not ensured.  *)
 
   val update_stdlib : 'a -> ('b option -> 'b option) -> ('a, 'b) t -> ('a, 'b) t
   (** [update_stdlib k f m] returns a map containing the same bindings as [m],

--- a/src/batMap.mli
+++ b/src/batMap.mli
@@ -416,23 +416,23 @@ sig
     
       @since NEXT_RELEASE *)
 
-  val to_seq : 'a t -> (key * 'a) Seq.t
+  val to_seq : 'a t -> (key * 'a) BatSeq.t
   (** Iterate on the whole map, in ascending order of keys.
 
       @since NEXT_RELEASE  *)
     
-  val to_seq_from :  key -> 'a t -> (key * 'a) Seq.t
+  val to_seq_from :  key -> 'a t -> (key * 'a) BatSeq.t
   (** [to_seq_from k m] iterates on a subset of the bindings in [m], 
       namely those bindings greater or equal to [k], in ascending order. 
     
       @since NEXT_RELEASE *)
     
-  val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
+  val add_seq : (key * 'a) BatSeq.t -> 'a t -> 'a t
   (** add the given bindings to the map, in order. 
     
       @since NEXT_RELEASE  *)
     
-  val of_seq : (key * 'a) Seq.t -> 'a t
+  val of_seq : (key * 'a) BatSeq.t -> 'a t
   (** build a map from the given bindings 
     
       @since NEXT_RELEASE *)
@@ -846,23 +846,23 @@ val union_stdlib:
     
     @since NEXT_RELEASE *)
 
-val to_seq : ('key, 'a) t -> ('key * 'a) Seq.t
+val to_seq : ('key, 'a) t -> ('key * 'a) BatSeq.t
 (** Iterate on the whole map, in ascending order of keys.
     
     @since NEXT_RELEASE  *)
   
-val to_seq_from :  'key -> ('key, 'a) t -> ('key * 'a) Seq.t
+val to_seq_from :  'key -> ('key, 'a) t -> ('key * 'a) BatSeq.t
 (** [to_seq_from k m] iterates on a subset of the bindings in [m], 
     namely those bindings greater or equal to [k], in ascending order. 
     
     @since NEXT_RELEASE *)
   
-val add_seq : ('key * 'a) Seq.t -> ('key, 'a) t -> ('key, 'a) t
+val add_seq : ('key * 'a) BatSeq.t -> ('key, 'a) t -> ('key, 'a) t
 (** add the given bindings to the map, in order. 
     
     @since NEXT_RELEASE  *)
   
-val of_seq : ('key * 'a) Seq.t -> ('key, 'a) t
+val of_seq : ('key * 'a) BatSeq.t -> ('key, 'a) t
 (** build a map from the given bindings 
     
     @since NEXT_RELEASE *)
@@ -1307,23 +1307,23 @@ module PMap : sig
 
       @since NEXT_RELEASE *)
 
-  val to_seq : ('key, 'a) t -> ('key * 'a) Seq.t
+  val to_seq : ('key, 'a) t -> ('key * 'a) BatSeq.t
   (** Iterate on the whole map, in ascending order of keys.
 
       @since NEXT_RELEASE  *)
     
-  val to_seq_from : 'key -> ('key, 'a) t -> ('key * 'a) Seq.t
+  val to_seq_from : 'key -> ('key, 'a) t -> ('key * 'a) BatSeq.t
   (** [to_seq_from k m] iterates on a subset of the bindings in [m], 
       namely those bindings greater or equal to [k], in ascending order. 
     
       @since NEXT_RELEASE *)
     
-  val add_seq : ('key * 'a) Seq.t -> ('key, 'a) t -> ('key, 'a) t
+  val add_seq : ('key * 'a) BatSeq.t -> ('key, 'a) t -> ('key, 'a) t
   (** add the given bindings to the map, in order. 
     
       @since NEXT_RELEASE  *)
     
-  val of_seq : ?cmp:('key -> 'key -> int) -> ('key * 'a) Seq.t -> ('key, 'a) t
+  val of_seq : ?cmp:('key -> 'key -> int) -> ('key * 'a) BatSeq.t -> ('key, 'a) t
   (** build a map from the given bindings 
     
       @since NEXT_RELEASE *)

--- a/src/batMap.mli
+++ b/src/batMap.mli
@@ -88,7 +88,11 @@ sig
   val add: key -> 'a -> 'a t -> 'a t
   (** [add x y m] returns a map containing the same bindings as
       [m], plus a binding of [x] to [y]. If [x] was already bound
-      in [m], its previous binding disappears. *)
+      in [m], its previous binding disappears. 
+      If [x] was already bound to some [z] that is physically equal
+      to [y], then the returned map is physically equal to [m].
+
+      @before NEXT_RELEASE physical equality was not ensured. *)
 
   val update_stdlib : key -> ('a option -> 'a option) -> 'a t -> 'a t
   (** [update_stdlib k f m] returns a map containing the same bindings as [m],
@@ -96,6 +100,8 @@ sig
       First, calculate [y] as [f (find_opt k m)].
       If [y = Some v] then [k] will be bound to [v] in the resulting map.
       Else [k] will not be bound in the resulting map.
+      If [v] is physically equal to the value of the previous binding of [k] in [m],
+      then the returned map will be physically equal to [m].
 
       This function does the same thing as [update] in the stdlib, but has a
       different name for backwards compatibility reasons.
@@ -108,8 +114,12 @@ sig
       [k2] associated to [v2].
       This is equivalent to [add k2 v2 (remove k1) m], but more efficient
       in the case where [k1] and [k2] have the same key ordering.
+      If [k1] and [k2] have the same key ordering and [v2] is physically
+      equal to the value [k1] is bound to in [m] then the returned map will
+      be physically equal to [m]
       @raise Not_found if [k1] is not bound in [m].
-      @since 2.4.0 *)
+      @since 2.4.0 
+      @before NEXT_RELEASE physical equality was nor ensured.  *)
     
   val find: key -> 'a t -> 'a
   (** [find x m] returns the current binding of [x] in [m],
@@ -158,8 +168,10 @@ sig
   val remove: key -> 'a t -> 'a t
   (** [remove x m] returns a map containing the same bindings as
       [m], except for [x] which is unbound in the returned map.
-      The returned map compares equal to the passed one if [x] was
-      already unbound. *)
+      The returned map is physically equal  to the passed one if [x] was
+      already unbound. 
+  
+      @before  NEXT_RELEASE physical equality was not ensured *)
 
   val remove_exn: key -> 'a t -> 'a t
   (** [remove_exn x m] behaves like [remove x m] except that it raises
@@ -243,7 +255,11 @@ sig
   (** [filter f m] returns a map where only the [(key, value)] pairs of [m]
       such that [f key value = true] remain. The bindings are passed to
       [f] in increasing order with respect to the ordering over the type
-      of the keys. *)
+      of the keys. 
+      If [f] returns [true] for all bindings of [m] the returned map is physically 
+      equal to [m].
+      
+      @before NEXT_RELEASE physical equality was not ensured. *)
 
   val filter_map: (key -> 'a -> 'b option) -> 'a t -> 'b t
   (** [filter_map f m] combines the features of [filter] and
@@ -528,15 +544,23 @@ val cardinal: ('a, 'b) t -> int
 val add : 'a -> 'b -> ('a, 'b) t -> ('a, 'b) t
 (** [add x y m] returns a map containing the same bindings as
     [m], plus a binding of [x] to [y]. If [x] was already bound
-    in [m], its previous binding disappears. *)
+    in [m], its previous binding disappears. 
+    If [x] was already bound to some [z] that is physically equal
+    to [y], then the returned map is physically equal to [m].
+
+    @before NEXT_RELEASE physical equality was not ensured. *)
 
 val update: 'a -> 'a -> 'b -> ('a, 'b) t -> ('a, 'b) t
 (** [update k1 k2 v2 m] replace the previous binding of [k1] in [m] by
     [k2] associated to [v2].
     This is equivalent to [add k2 v2 (remove k1) m], but more efficient
     in the case where [k1] and [k2] have the same key ordering.
+    If [k1] and [k2] have the same key ordering and [v2] is physically
+    equal to the value [k1] is bound to in [m] then the returned map will
+    be physically equal to [m]
     @raise Not_found if [k1] is not bound in [m].
-    @since 2.4.0 *)
+    @since 2.4.0 
+    @before NEXT_RELEASE physical equality was nor ensured. *)
 
 val update_stdlib : 'a -> ('b option -> 'b option) -> ('a, 'b) t -> ('a, 'b) t
 (** [update_stdlib k f m] returns a map containing the same bindings as [m],
@@ -545,6 +569,11 @@ val update_stdlib : 'a -> ('b option -> 'b option) -> ('a, 'b) t -> ('a, 'b) t
     If [y = Some v] then [k] will be bound to [v] in the resulting map.
     Else [k] will not be bound in the resulting map.
 
+    If [v] is physically equal to the value of the previous binding of [k] in [m],
+    then the returned map will be physically equal to [m].
+
+    This function does the same thing as [update] in the stdlib, but has a
+    different name for backwards compatibility reasons.
     @since NEXT_RELEASE *)
 
 val find : 'a -> ('a, 'b) t -> 'b
@@ -594,8 +623,10 @@ val find_last_opt: ('a -> bool) -> ('a, 'b) t -> ('a * 'b) option
 val remove : 'a -> ('a, 'b) t -> ('a, 'b) t
 (** [remove x m] returns a map containing the same bindings as
     [m], except for [x] which is unbound in the returned map.
-    The returned map compares equal to the passed one if [x] was
-    already unbound. *)
+    The returned map is physically equal  to the passed one if [x] was
+    already unbound. 
+
+    @before  NEXT_RELEASE physical equality was not ensured *)
 
 val remove_exn: 'a -> ('a, 'b) t -> ('a, 'b) t
 (** [remove_exn x m] behaves like [remove x m] except that it raises
@@ -653,10 +684,14 @@ val filterv: ('a -> bool) -> ('key, 'a) t -> ('key, 'a) t
    type of the keys. *)
 
 val filter: ('key -> 'a -> bool) -> ('key, 'a) t -> ('key, 'a) t
-(**[filter f m] returns a map where only the [(key, value)] pairs
-   [key], [a] of [m] such that [f key a = true] remain. The
-   bindings are passed to [f] in increasing order with respect
-   to the ordering over the type of the keys. *)
+(** [filter f m] returns a map where only the [(key, value)] pairs of [m]
+    such that [f key value = true] remain. The bindings are passed to
+    [f] in increasing order with respect to the ordering over the type
+    of the keys. 
+    If [f] returns [true] for all bindings of [m] the returned map is physically 
+    equal to [m].
+    
+    @before NEXT_RELEASE physical equality was not ensured. *)
 
 val filter_map: ('key -> 'a -> 'b option) -> ('key, 'a) t -> ('key, 'b) t
 (** [filter_map f m] combines the features of [filter] and
@@ -949,15 +984,24 @@ module PMap : sig
   val add : 'a -> 'b -> ('a, 'b) t -> ('a, 'b) t
   (** [add x y m] returns a map containing the same bindings as
       [m], plus a binding of [x] to [y]. If [x] was already bound
-      in [m], its previous binding disappears. *)
+      in [m], its previous binding disappears. 
+      
+      If [x] was already bound to some [z] that is physically equal
+      to [y], then the returned map is physically equal to [m].
+
+      @before NEXT_RELEASE physical equality was not ensured. *)
 
   val update : 'a -> 'a -> 'b -> ('a, 'b) t -> ('a, 'b) t
   (** [update k1 k2 v2 m] replace the previous binding of [k1] in [m] by
       [k2] associated to [v2].
       This is equivalent to [add k2 v2 (remove k1) m], but more efficient
       in the case where [k1] and [k2] have the same key ordering.
+      If [k1] and [k2] have the same key ordering and [v2] is physically
+      equal to the value [k1] is bound to in [m] then the returned map will
+      be physically equal to [m]
       @raise Not_found if [k1] is not bound in [m].
-      @since 2.4.0 *)
+      @since 2.4.0 
+      @before NEXT_RELEASE physical equality was nor ensured.  *)
 
   val update_stdlib : 'a -> ('b option -> 'b option) -> ('a, 'b) t -> ('a, 'b) t
   (** [update_stdlib k f m] returns a map containing the same bindings as [m],
@@ -965,7 +1009,12 @@ module PMap : sig
       First, calculate [y] as [f (find_opt k m)].
       If [y = Some v] then [k] will be bound to [v] in the resulting map.
       Else [k] will not be bound in the resulting map.
-  
+      If [v] is physically equal to the value of the previous binding of [k] in [m],
+      then the returned map will be physically equal to [m].
+
+      This function does the same thing as [update] in the stdlib, but has a
+      different name for backwards compatibility reasons.
+
       @since NEXT_RELEASE *)
   
   val find : 'a -> ('a, 'b) t -> 'b
@@ -1010,7 +1059,11 @@ module PMap : sig
 
   val remove : 'a -> ('a, 'b) t -> ('a, 'b) t
   (** [remove x m] returns a map containing the same bindings as
-      [m], except for [x] which is unbound in the returned map. *)
+      [m], except for [x] which is unbound in the returned map.
+      The returned map is physically equal  to the passed one if [x] was
+      already unbound. 
+  
+      @before  NEXT_RELEASE physical equality was not ensured *)
 
   val remove_exn : 'a -> ('a, 'b) t -> ('a, 'b) t
   (** [remove_exn x m] behaves like [remove x m] except that it raises
@@ -1068,10 +1121,14 @@ module PMap : sig
      type of the keys. *)
 
   val filter: ('key -> 'a -> bool) -> ('key, 'a) t -> ('key, 'a) t
-  (**[filter f m] returns a map where only the [(key, value)] pairs
-     [key], [a] of [m] such that [f key a = true] remain. The
-     bindings are passed to [f] in increasing order with respect
-     to the ordering over the type of the keys. *)
+  (** [filter f m] returns a map where only the [(key, value)] pairs of [m]
+      such that [f key value = true] remain. The bindings are passed to
+      [f] in increasing order with respect to the ordering over the type
+      of the keys. 
+      If [f] returns [true] for all bindings of [m] the returned map is physically 
+      equal to [m].
+      
+      @before NEXT_RELEASE physical equality was not ensured. *)
 
   val filter_map: ('key -> 'a -> 'b option) -> ('key, 'a) t -> ('key, 'b) t
   (** [filter_map f m] combines the features of [filter] and

--- a/src/batSet.ml
+++ b/src/batSet.ml
@@ -704,24 +704,26 @@ module Concrete = struct
     
   let of_seq cmp s =
     add_seq cmp s empty
-    
-  let rec to_seq m =
-    fun () ->
+
+  let rec to_seq_hlp m =
     match m with
-    | Empty -> BatSeq.Nil
-    | Node(l, v, r, _) ->
-       BatSeq.append (to_seq l) (fun () -> BatSeq.Cons (v, to_seq r)) ()
-    
-  let rec to_seq_from cmp k m =
-    fun () ->
-    match m with
-    | Empty -> BatSeq.Nil
-    | Node(l, v, r, _) ->
-       if cmp k v <= 0 then
-         BatSeq.append (to_seq_from cmp k l) (fun () -> BatSeq.Cons (v, to_seq r)) ()
-       else
-         to_seq_from cmp k r ()
-  
+    | E -> BatSeq.Nil
+    | C(k, r, e) ->
+       BatSeq.Cons (k, fun () -> to_seq_hlp (cons_iter r e))
+      
+  let to_seq m () =
+    to_seq_hlp (cons_iter m E)
+
+  let to_seq_from cmp k m () =
+    let rec cons_enum_from k2 m e =
+      match m with
+      | Empty -> e
+      | Node (l, k, r, _) ->
+         if cmp k2 k <= 0
+         then cons_enum_from k2 l (C (k, r, e))
+         else cons_enum_from k2 r e in
+    to_seq_hlp (cons_enum_from k m E)
+
 end
 
 module type S =

--- a/src/batSet.ml
+++ b/src/batSet.ml
@@ -451,6 +451,14 @@ module Concrete = struct
       Empty -> t
     | Node (l, e, r, _) -> rev_cons_iter r (C (e, l, t))
 
+  let rec cons_iter_from cmp k2 m e =
+    match m with
+    | Empty -> e
+    | Node (l, k, r, _) ->
+       if cmp k2 k <= 0
+       then cons_iter_from cmp k2 l (C (k, r, e))
+       else cons_iter_from cmp k2 r e
+
   let enum_next l () = match !l with
       E -> raise BatEnum.No_more_elements
     | C (e, s, t) -> l := cons_iter s t; e
@@ -705,24 +713,17 @@ module Concrete = struct
   let of_seq cmp s =
     add_seq cmp s empty
 
-  let rec to_seq_hlp m =
+  let rec seq_of_iter m () =
     match m with
     | E -> BatSeq.Nil
     | C(k, r, e) ->
-       BatSeq.Cons (k, fun () -> to_seq_hlp (cons_iter r e))
+       BatSeq.Cons (k, seq_of_iter (cons_iter r e))
       
-  let to_seq m () =
-    to_seq_hlp (cons_iter m E)
+  let to_seq m =
+    seq_of_iter (cons_iter m E)
 
-  let to_seq_from cmp k m () =
-    let rec cons_enum_from k2 m e =
-      match m with
-      | Empty -> e
-      | Node (l, k, r, _) ->
-         if cmp k2 k <= 0
-         then cons_enum_from k2 l (C (k, r, e))
-         else cons_enum_from k2 r e in
-    to_seq_hlp (cons_enum_from k m E)
+  let to_seq_from cmp k m =
+    seq_of_iter (cons_iter_from cmp k m E)
 
 end
 

--- a/src/batSplay.ml
+++ b/src/batSplay.ml
@@ -820,7 +820,7 @@ struct
         | Some v1 ->
            (match f k v v1 with
             | Some vmerged -> add k vmerged m
-            | None -> m)
+            | None -> remove k m)
         | None -> add k v m)
       m1
       m2

--- a/src/batSplay.ml
+++ b/src/batSplay.ml
@@ -441,7 +441,12 @@ struct
           | C (cx, Node (l, _kv, r)) -> C (cx, Node (l, (k2, v2), r))
           | C (cx, Empty) -> raise Not_found
         end
-      end
+        end
+
+  let update_stdlib k f m =
+    match f (find_opt k m) with
+    | Some x -> add k x m
+    | None -> remove k m
 
   let mem k m =
     try ignore (find k m) ; true with Not_found -> false
@@ -477,6 +482,11 @@ struct
     in
     bfind tr
 
+  let min_binding_opt tr =
+    try Some(min_binding tr)
+    with Not_found -> None
+        
+
   let choose = min_binding
   (*$= choose
     (empty |> add 0 1 |> add 1 1 |> choose) \
@@ -485,7 +495,8 @@ struct
   (*$T choose
     try ignore (choose empty) ; false with Not_found -> true
   *)
-
+  let choose_opt  = min_binding_opt
+                  
   let any tr = match sget tr with
     | Empty -> raise Not_found
     | Node (_, kv, _) -> kv
@@ -511,6 +522,10 @@ struct
     in
     bfind tr
 
+  let max_binding_opt tr =
+    try Some(max_binding tr)
+    with Not_found -> None
+        
   let pop_max_binding tr =
     let maxi = ref (choose tr) in
     let rec bfind = function
@@ -769,6 +784,12 @@ struct
     | Empty -> raise Not_found
     | Node (l, kv, r) -> kv, sref (bst_append l r)
 
+  let to_seq _ = failwith "unimplemented"
+  let of_seq _ = failwith "unimplemented"
+  let add_seq _ = failwith "unimplemented"
+  let to_seq_from _ _ = failwith "unimplemented"
+  let union _f _m1 _m2 = failwith "unimplemented"
+                       
   let extract k tr =
     let tr = sget tr in
     (* the reference here is a tad ugly but allows to reuse `cfind`
@@ -787,3 +808,5 @@ struct
     | Some v -> v, sref tr
   (*$>*)
 end
+  
+

--- a/src/batSplay.ml
+++ b/src/batSplay.ml
@@ -483,8 +483,13 @@ struct
     bfind tr
 
   let min_binding_opt tr =
-    try Some(min_binding tr)
-    with Not_found -> None
+    let tr = sget tr in
+    let rec bfind = function
+      | Node (Empty, kv, _) -> Some kv
+      | Node (l, _, _) -> bfind l
+      | Empty -> None
+    in
+    bfind tr
         
 
   let choose = min_binding
@@ -509,7 +514,7 @@ struct
     let rec bfind = function
       | Node (Empty, kv, r) -> mini := kv; r
       | Node (l, kv, r) -> Node (bfind l, kv, r)
-      | Empty -> assert(false)
+      | Empty -> raise Not_found
     in
     (!mini, sref (bfind (sget tr)))
 
@@ -523,15 +528,20 @@ struct
     bfind tr
 
   let max_binding_opt tr =
-    try Some(max_binding tr)
-    with Not_found -> None
+    let tr = sget tr in
+    let rec bfind = function
+      | Node (_, kv, Empty) -> Some kv
+      | Node (_, _, r) -> bfind r
+      | Empty -> None
+    in
+    bfind tr
         
   let pop_max_binding tr =
     let maxi = ref (choose tr) in
     let rec bfind = function
       | Node (l, kv, Empty) -> maxi := kv; l
       | Node (l, kv, r) -> Node (l, kv, bfind r)
-      | Empty -> assert(false)
+      | Empty -> raise Not_found
     in
     (!maxi, sref (bfind (sget tr)))
 
@@ -803,7 +813,7 @@ struct
     fun () ->
     BatSeq.filter (fun (k2, _) -> Ord.compare k k2 <= 0) (to_seq m) ()
     
-  let union_stdlib f m1 m2 =
+  let union f m1 m2 =
     fold
      (fun k v m ->
         match find_opt k m with

--- a/src/batSplay.ml
+++ b/src/batSplay.ml
@@ -609,6 +609,14 @@ struct
     | Node (l, (k, v), r) ->
       rev_cons_enum r (More (k, v, l, e))
 
+  let rec cons_enum_from k2 m e =
+    match m with
+    | Empty -> e
+    | Node (l, (k, v), r) ->
+       if Ord.compare k2 k <= 0
+       then cons_enum_from k2 l (More (k, v, r, e))
+       else cons_enum_from k2 r e
+
   let compare cmp tr1 tr2 =
     let tr1, tr2 = sget tr1, sget tr2 in
     let rec aux e1 e2 = match (e1, e2) with
@@ -804,24 +812,17 @@ struct
   let of_seq s =
     add_seq s empty
 
-  let rec to_seq_hlp m =
+  let rec seq_of_iter m () =
     match m with
     | End -> BatSeq.Nil
     | More(k, v, r, e) ->
-       BatSeq.Cons ((k, v), fun () -> to_seq_hlp (cons_enum r e))
+       BatSeq.Cons ((k, v), seq_of_iter (cons_enum r e))
       
-  let to_seq m () =
-    to_seq_hlp (cons_enum (sget m) End)
+  let to_seq m =
+    seq_of_iter (cons_enum (sget m) End)
 
-  let to_seq_from k m () =
-    let rec cons_enum_from k2 m e =
-      match m with
-      | Empty -> e
-      | Node (l, (k, v), r) ->
-         if Ord.compare k2 k <= 0
-         then cons_enum_from k2 l (More (k, v, r, e))
-         else cons_enum_from k2 r e in
-    to_seq_hlp (cons_enum_from k (sget m) End)
+  let to_seq_from k m =
+    seq_of_iter (cons_enum_from k (sget m) End)
    
   let union f m1 m2 =
     fold

--- a/src/batSplay.ml
+++ b/src/batSplay.ml
@@ -514,7 +514,7 @@ struct
     let rec bfind = function
       | Node (Empty, kv, r) -> mini := kv; r
       | Node (l, kv, r) -> Node (bfind l, kv, r)
-      | Empty -> raise Not_found
+      | Empty ->  assert(false)  (* choose already raises Not_found on empty map *)
     in
     (!mini, sref (bfind (sget tr)))
 
@@ -541,7 +541,7 @@ struct
     let rec bfind = function
       | Node (l, kv, Empty) -> maxi := kv; l
       | Node (l, kv, r) -> Node (l, kv, bfind r)
-      | Empty -> raise Not_found
+      | Empty ->  assert(false)  (* choose already raises Not_found on empty map *)
     in
     (!maxi, sref (bfind (sget tr)))
 

--- a/src/batSplay.ml
+++ b/src/batSplay.ml
@@ -441,7 +441,7 @@ struct
           | C (cx, Node (l, _kv, r)) -> C (cx, Node (l, (k2, v2), r))
           | C (cx, Empty) -> raise Not_found
         end
-        end
+      end
 
   let update_stdlib k f m =
     match f (find_opt k m) with

--- a/src/batSplay.mli
+++ b/src/batSplay.mli
@@ -18,7 +18,16 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *)
 
-(** Maps and sets based on splay trees *)
+(** Maps over ordered types based on splay trees.
+
+    Splay trees are ordered binary trees that have the 
+    most recently used element as the root of the tree.
+    If another element is accessed (even read-only), 
+    the tree will be rearranged internally.
+    
+    Not threadsafe; even read-only functions will rearrange
+    the tree, even though its contents will remain unchanged.
+ *)
 
 module Map (Ord : BatInterfaces.OrderedType)
   : sig

--- a/src/batteries_compattest.mlv
+++ b/src/batteries_compattest.mlv
@@ -40,7 +40,6 @@ module Stdlib_verifications = struct
        include module type of Legacy.List
        val find_map : ('a -> 'b option) -> 'a list -> 'b
      end)
-  (*  module Map = (Map : module type of Legacy.Map)*)
   module Seq = (Seq : module type of Legacy.Seq)
   module Marshal =
     (Marshal: sig
@@ -110,4 +109,14 @@ module Stdlib_verifications = struct
   module Big_int = (Big_int : module type of Legacy.Big_int)
   (* FIXME: This does not pass for some reason:
   module Bigarray = (Bigarray : module type of Legacy.Bigarray)*)
+   
+  (* test compatibility of BatMap.S with Legacy.Map.S *)
+  let sort_map (type s) (module Map : Legacy.Map.S with type key = s) l =
+      Map.bindings (List.fold_right (fun x m -> Map.add x x m) l Map.empty)
+  module IntMap = struct
+     include BatMap.Int
+     let update = update_stdlib
+  end 
+  let _ = assert ([1,1;2,2;3,3;] = (sort_map (module IntMap) [3; 1; 2;]))
+ 
 end

--- a/src/batteries_compattest.mlv
+++ b/src/batteries_compattest.mlv
@@ -40,7 +40,6 @@ module Stdlib_verifications = struct
        include module type of Legacy.List
        val find_map : ('a -> 'b option) -> 'a list -> 'b
      end)
-  (*  module Map = (Map : module type of Legacy.Map)*)
 ##V>=4.7## module Seq = (Seq : module type of Legacy.Seq)
   module Marshal =
     (Marshal: sig
@@ -116,8 +115,14 @@ module Stdlib_verifications = struct
   module IntMap = struct
      include BatMap.Int
      let update = update_stdlib
-  end 
+  end
   let _ = assert ([1,1;2,2;3,3;] = (sort_map (module IntMap) [3; 1; 2;]))
+  (* test compat of BatSplay.S with Legacy.Map.S *)
+  module IntSplayMap = struct
+     include BatSplay.Map (BatInt)
+     let update = update_stdlib
+  end
+  let _ = assert ([1,1;2,2;3,3;] = (sort_map (module IntSplayMap) [3; 1; 2;]))
  
   (* test compatibility of BatSet.S with Legacy.Set.S *)
   let sort (type s) (module Set : Legacy.Set.S with type elt = s) l =

--- a/testsuite/test_map.ml
+++ b/testsuite/test_map.ml
@@ -130,6 +130,11 @@ module TestMap
     val choose : 'a m -> (key * 'a)
     val split : key -> 'a m -> ('a m * 'a option * 'a m)
 
+    val add_seq : (key * 'a) BatSeq.t -> 'a m  -> 'a m
+    val of_seq : (key * 'a) BatSeq.t -> 'a m
+    val to_seq : 'a m -> (key * 'a) BatSeq.t
+    val to_seq_from : key -> 'a m -> (key * 'a) BatSeq.t
+
     val merge :
       (key -> 'a option -> 'b option -> 'c option)
       -> 'a m -> 'b m -> 'c m
@@ -315,19 +320,28 @@ module TestMap
     BatSeq.fold_right (fun x l -> x :: l) s []
 
   let test_add_seq () =
-    (* TODO write some tests *)
+    "add_seq [1,1;2,2;3,3] [3,3;4,4]" @= (il [1,1;2,2;3,3;4,4], M.add_seq (BatSeq.of_list [1,1;2,2;3,3]) (il [3,3;4,4]));
+    "add_seq [1,1;2,2]     [3,3;4,4]" @= (il [1,1;2,2;3,3;4,4], M.add_seq (BatSeq.of_list [1,1;2,2])     (il [3,3;4,4]));
+    "add_seq []            [3,3;4,4]" @= (il [3,3;4,4],         M.add_seq (BatSeq.of_list [])            (il [3,3;4,4]));
+    "add_seq [1,1;2,2]     []       " @= (il [1,1;2,2],         M.add_seq (BatSeq.of_list [1,1;2,2])     (il []));
+    "add_seq []            []       " @= (il [],                M.add_seq (BatSeq.of_list [])            (il []));
     ()
 
   let test_of_seq () =
-    (* TODO write some tests *)
+    "of_seq [1,1;2,2;3,3;4,4]" @= (il [1,1;2,2;3,3;4,4], M.of_seq (BatSeq.of_list [1,1;2,2;4,4;3,3]));
+    "of_seq []"                @= (il [               ], M.of_seq (BatSeq.of_list [               ]));
     ()
 
-  let test_to_seq () =
-    (* TODO write some tests *)
+  let test_to_seq () = 
+    "to_seq [1,1;2,2;3,3;4,4]" @? (BatSeq.equal (BatSeq.of_list [1,1;2,2;3,3;4,4]) (M.to_seq (il [4,4;1,1;3,3;2,2])));
+    "to_seq []"                @? (BatSeq.equal (BatSeq.of_list [               ]) (M.to_seq (il [               ])));
     ()
-
+ 
   let test_to_seq_from () =
-    (* TODO write some tests *)
+    "to_seq_from 5 []"                @? (BatSeq.equal (BatSeq.of_list [               ]) (M.to_seq_from 5 (il [               ])));
+    "to_seq_from 5 [1,1;2,2;3,3;4,4]" @? (BatSeq.equal (BatSeq.of_list [               ]) (M.to_seq_from 5 (il [4,4;1,1;3,3;2,2])));
+    "to_seq_from 3 [1,1;2,2;3,3;4,4]" @? (BatSeq.equal (BatSeq.of_list [3,3;4,4        ]) (M.to_seq_from 3 (il [4,4;1,1;3,3;2,2])));
+    "to_seq_from 0 [1,1;2,2;3,3;4,4]" @? (BatSeq.equal (BatSeq.of_list [1,1;2,2;3,3;4,4]) (M.to_seq_from 0 (il [4,4;1,1;3,3;2,2])));
     ()
 
 

--- a/testsuite/test_map.ml
+++ b/testsuite/test_map.ml
@@ -79,6 +79,9 @@ module TestMap
 
     val equal : ('a -> 'a -> bool) -> 'a m -> 'a m -> bool
 
+    (* true if add, remove, update_stdlib and filter support physical equality *)
+    val supports_phys_equality : bool
+
     (* tested functions *)
     val empty : 'a m
     val is_empty : _ m -> bool
@@ -90,6 +93,10 @@ module TestMap
     val cardinal : _ m -> int
     val min_binding : 'a m -> (key * 'a)
     val max_binding : 'a m -> (key * 'a)
+    val pop_min_binding : 'a m -> (key * 'a) * 'a m
+    val pop_max_binding : 'a m -> (key * 'a) * 'a m
+    val min_binding_opt : 'a m -> (key * 'a) option
+    val max_binding_opt : 'a m -> (key * 'a) option
     val modify : key -> ('a -> 'a) -> 'a m -> 'a m
     val modify_def : 'a -> key -> ('a -> 'a) -> 'a m -> 'a m
     val modify_opt : key -> ('a option -> 'a option) -> 'a m -> 'a m
@@ -171,7 +178,11 @@ module TestMap
     "add k v (add k v' t) = add k v t" @=
       (M.add k v (M.add k v' t), M.add k v t);
     "add 4 8 [3,4; 5,6] = [3,4; 4,8; 5,6]" @=
-        (M.add 4 8 t, il [(3,4); (4,8); (5,6)]);
+      (M.add 4 8 t, il [(3,4); (4,8); (5,6)]);
+    if M.supports_phys_equality then begin
+        "add 3,4 [3,4; 5,6] == [3,4; 5,6]" @?
+          (t == M.add 3 4 t);        
+      end;
     ()
 
   let test_cardinal () =
@@ -212,7 +223,98 @@ module TestMap
             M.cardinal t - if M.mem k t then 1 else 0) in
     test_cardinal 3 t;
     test_cardinal 57 t;
+    if M.supports_phys_equality then begin
+        "remove 12 [3,4; 5,6] == [3,4; 5,6]" @?
+          (t == M.remove 12 t);
+        "remove 12 [] == []" @?
+          (M.empty == M.remove 12 M.empty);
+      end;
     ()
+
+  let test_update () =
+    (* TODO write some tests *)
+    (*
+   let of_list l = of_enum (BatList.enum l) and cmp = Pervasives.( = ) in \
+  equal cmp (update_stdlib 1 (fun x -> assert(x = Some 1); Some 3) (of_list [1,1; 2,2]))    (of_list [1,3;2,2])
+  let of_list l = of_enum (BatList.enum l) and cmp = Pervasives.( = ) in \
+  equal cmp (update_stdlib 3 (fun x -> assert(x = None);   Some 3) (of_list [1,1; 2,2]))    (of_list [1,1;2,2;3,3])
+  let of_list l = of_enum (BatList.enum l) and cmp = Pervasives.( = ) in \
+  equal cmp (update_stdlib 1 (fun x -> assert(x = Some 1); None)   (of_list [1,1; 2,2]))    (of_list [2,2])
+  let of_list l = of_enum (BatList.enum l) in \
+  let s = (of_list [1,1; 2,2]) in (update_stdlib 3 (fun x -> assert(x = None  ); None  ) s) == s
+  let of_list l = of_enum (BatList.enum l) in \
+  let s = (of_list [1,1; 2,2]) in (update_stdlib 1 (fun x -> assert(x = Some 1); Some 1) s) == s
+
+    let t = il [(3,4); (5, 6)] in*)
+    ();
+    if M.supports_phys_equality then begin
+        ()
+      end;
+    ()
+
+  let test_update_stdlib () =
+    (* TODO write some tests *)
+   (*   let of_list l = of_enum (BatList.enum l) and cmp = Pervasives.( = ) in \
+  equal cmp (update_stdlib 1 (fun x -> assert(x = Some 1); Some 3) (of_list [1,1; 2,2]))    (of_list [1,3;2,2])
+  let of_list l = of_enum (BatList.enum l) and cmp = Pervasives.( = ) in \
+  equal cmp (update_stdlib 3 (fun x -> assert(x = None);   Some 3) (of_list [1,1; 2,2]))    (of_list [1,1;2,2;3,3])
+  let of_list l = of_enum (BatList.enum l) and cmp = Pervasives.( = ) in \
+  equal cmp (update_stdlib 1 (fun x -> assert(x = Some 1); None)   (of_list [1,1; 2,2]))    (of_list [2,2])
+  let of_list l = of_enum (BatList.enum l) in \
+  let s = (of_list [1,1; 2,2]) in (update_stdlib 3 (fun x -> assert(x = None  ); None  ) s) == s
+  let of_list l = of_enum (BatList.enum l) in \
+  let s = (of_list [1,1; 2,2]) in (update_stdlib 1 (fun x -> assert(x = Some 1); Some 1) s) == s
+    *)
+    let t = il [(3,4); (5, 6)] in
+    ();
+    if M.supports_phys_equality then begin
+        ()
+      end;
+    ()
+
+  let test_filter () =
+    (* TODO write some tests *)
+    let t = il [(3,4); (5, 6)] in
+    ();
+    if M.supports_phys_equality then begin
+        (*
+          let s = empty |> add 1 1 |> add 2 2 in \
+  s == (filter (fun _ _ -> true) s)
+         *)
+        ()
+      end;
+    ()
+
+  let test_union_stdlib () =
+    (* TODO write some tests *)
+    (*$T union_stdlib
+  let cmp = Pervasives.( = ) in \
+  equal cmp (union_stdlib (fun _ -> failwith "must not be called") empty empty) empty
+  let of_list l = of_enum (BatList.enum l) and cmp = Pervasives.( = ) in \
+  equal cmp (union_stdlib (fun _ -> failwith "must not be called") (of_list [1,1;2,2]) empty) (of_list [1,1;2,2])
+  let of_list l = of_enum (BatList.enum l) and cmp = Pervasives.( = ) in \
+  equal cmp (union_stdlib (fun _ -> failwith "must not be called") empty (of_list [1,1;2,2])) (of_list [1,1;2,2])
+  let of_list l = of_enum (BatList.enum l) and cmp = Pervasives.( = ) in \
+  equal cmp (union_stdlib (fun _ -> failwith "must not be called") (of_list [3,3;4,4]) (of_list [1,1;2,2])) (of_list [1,1;2,2;3,3;4,4])
+ *)
+    ()
+
+  let test_add_seq () =
+    (* TODO write some tests *)
+    ()
+
+  let test_of_seq () =
+    (* TODO write some tests *)
+    ()
+
+  let test_to_seq () =
+    (* TODO write some tests *)
+    ()
+
+  let test_to_seq_from () =
+    (* TODO write some tests *)
+    ()
+
 
   let test_mem () =
     let k, k', v = 1, 2, () in
@@ -224,14 +326,52 @@ module TestMap
     let t = il [(2, 0); (1,2); (3, 4); (2, 0)] in
     "min_binding [(2, 0); (1,2); (3, 4); (2, 0)] = (1, 2)" @?
       (M.min_binding t = (1, 2));
+    "min_binding [] -> Not_found" @?
+      (try ignore(M.min_binding M.empty); false with Not_found -> true);
     ()
 
   let test_max_binding () =
     let t = il [(2, 0); (1,2); (3, 4); (2, 0)] in
     "max_binding [(2, 0); (1,2); (3, 4); (2, 0)] = (3, 4)" @?
       (M.max_binding t = (3, 4));
+    "max_binding [] -> Not_found" @?
+      (try ignore(M.max_binding M.empty); false with Not_found -> true);
     ()
 
+  let test_min_binding_opt () =
+    let t = il [(2, 0); (1,2); (3, 4); (2, 0)] in
+    "min_binding_opt [(2, 0); (1,2); (3, 4); (2, 0)] = (1, 2)" @?
+      (M.min_binding_opt t = Some (1, 2));
+    "min_binding_opt [] = None" @?
+      (M.min_binding_opt t = None);
+    ()
+
+  let test_max_binding_opt () =
+    let t = il [(2, 0); (1,2); (3, 4); (2, 0)] in
+    "max_binding_opt [(2, 0); (1,2); (3, 4); (2, 0)] = (3, 4)" @?
+      (M.max_binding_opt t = Some (3, 4));
+    "max_binding_opt [] = None" @?
+      (M.max_binding_opt t = None);
+    ()
+
+  let test_pop_min_binding () =
+    let t = il [(2, 0); (1,2); (3, 4); (2, 0)] in
+    let t2 = il [(2, 0); (3, 4); (2, 0)] in
+    "pop_min_binding [(2, 0); (1,2); (3, 4); (2, 0)] = (1, 2), ..." @?
+      (M.pop_min_binding t = ((1, 2), t2));
+    "pop_min_binding [] -> Not_found" @?
+      (try ignore(M.pop_min_binding M.empty); false with Not_found -> true);
+    ()
+
+  let test_pop_max_binding () =
+    let t = il [(2, 0); (1,2); (3, 4); (2, 0)] in
+    let t2 = il [1,2; (2, 0)] in
+    "pop_max_binding [(2, 0); (1,2); (3, 4); (2, 0)] = (1, 2), ..." @?
+      (M.pop_max_binding t = ((3, 4), t2));
+    "pop_max_binding [] -> Not_found" @?
+      (try ignore(M.pop_max_binding M.empty); false with Not_found -> true);
+    ()
+    
   let test_modify () =
     let k, k', f, t = 1, 2, ((+) 1), il [(1,2); (3, 4)] in
     "mem k t => find k (modify k f t) = f (find k t)" @?
@@ -579,7 +719,18 @@ module TestMap
     "test_iterators" >:: test_iterators;
     "test_pop" >:: test_pop;
     "test_extract" >:: test_extract;
-  ]
+    "test_update" >:: test_update;
+    "test_update_stdlib" >:: test_update_stdlib;
+    "test_filter" >:: test_filter;
+    "test_add_seq" >:: test_add_seq;
+    "test_of_seq" >:: test_of_seq;
+    "test_to_seq" >:: test_to_seq;
+    "test_to_seq_from" >:: test_to_seq_from;
+    "test_min_binding_opt" >:: test_min_binding_opt;
+    "test_max_binding_opt" >:: test_max_binding_opt;
+    "test_pop_min_binding" >:: test_pop_min_binding;
+    "test_pop_max_binding" >:: test_pop_max_binding;
+    ]
 end
 
 module M = struct
@@ -594,6 +745,8 @@ module M = struct
   let iteri = M.iter
 
   let filterv_map f = M.filter_map (fun _ -> f)
+
+  let supports_phys_equality = true
 end
 
 module P = struct
@@ -607,6 +760,7 @@ module P = struct
   let iteri = M.iter
 
   let filterv_map f = M.filter_map (fun _ -> f)
+  let supports_phys_equality = true
 end
 
 module S = struct
@@ -621,6 +775,7 @@ module S = struct
 
   let fold f = M.fold (fun _ -> f)
   let foldi = M.fold
+  let supports_phys_equality = false
 end
 
 module TM = TestMap(M)

--- a/testsuite/test_map.ml
+++ b/testsuite/test_map.ml
@@ -308,12 +308,12 @@ module TestMap
       (M.union_stdlib (fun _ -> failwith "must not be called") M.empty (il [1,1;2,2]), il [1,1;2,2]);
     "union_stdlib [1,1;2,2] [3,3;4,4]" @=
       (M.union_stdlib (fun _ -> failwith "must not be called") (il [3,3;4,4]) (il [1,1;2,2]), il [1,1;2,2;3,3;4,4]);
-    "union_stdlib [1,1;2,2;3,10] [3,6;4,4]" @=
+    "union_stdlib [1,1;2,2;3,10] [3,6;4,4] keep sum on conflict" @=
       (M.union_stdlib (fun _k a b -> Some (a+b)) (il [3,6;4,4]) (il [1,1;2,2;3,10]), il [1,1;2,2;3,16;4,4]);
-    "union_stdlib [1,1;2,2;3,10] [3,6;4,4]" @=
-      (M.union_stdlib (fun _k a b -> None) (il [3,6;4,4]) (il [1,1;2,2;3,10]), il [1,1;2,2;4,4]);    
-    "union_stdlib [1,1;4,2;3,10] [3,6;4,4]" @=
-      (M.union_stdlib (fun k a b -> if k = 3 then Some (a+b) else None) (il [3,6;4,4]) (il [1,1;4,2;3,10]), il [1,1;2,2;3,16]);
+    "union_stdlib [1,1;2,2;3,10] [3,6;4,4] drop on conflict" @=
+      (M.union_stdlib (fun _k a b -> None)       (il [3,6;4,4]) (il [1,1;2,2;3,10]), il [1,1;2,2;4,4]);    
+    "union_stdlib [1,1;4,2;3,10] [3,6;4,4] keep 3 w sum, drop 4" @=
+      (M.union_stdlib (fun k a b -> if k = 3 then Some (a+b) else None) (il [2,2;3,6;4,4]) (il [1,1;4,2;3,10]), il [1,1;2,2;3,16]);
     ()
 
   let list_of_seq s =
@@ -765,6 +765,7 @@ module TestMap
     "test_max_binding_opt" >:: test_max_binding_opt;
     "test_pop_min_binding" >:: test_pop_min_binding;
     "test_pop_max_binding" >:: test_pop_max_binding;
+    "test_union_stdlib" >:: test_union_stdlib;
     ]
 end
 

--- a/testsuite/test_map.ml
+++ b/testsuite/test_map.ml
@@ -341,7 +341,17 @@ module TestMap
     "to_seq_from 5 []"                @? (BatSeq.equal (BatSeq.of_list [               ]) (M.to_seq_from 5 (il [               ])));
     "to_seq_from 5 [1,1;2,2;3,3;4,4]" @? (BatSeq.equal (BatSeq.of_list [               ]) (M.to_seq_from 5 (il [4,4;1,1;3,3;2,2])));
     "to_seq_from 3 [1,1;2,2;3,3;4,4]" @? (BatSeq.equal (BatSeq.of_list [3,3;4,4        ]) (M.to_seq_from 3 (il [4,4;1,1;3,3;2,2])));
-    "to_seq_from 0 [1,1;2,2;3,3;4,4]" @? (BatSeq.equal (BatSeq.of_list [1,1;2,2;3,3;4,4]) (M.to_seq_from 0 (il [4,4;1,1;3,3;2,2])));
+    "to_seq_from 5 [1,1;2,2;3,3;4,4]" @? (BatSeq.equal (BatSeq.of_list [1,1;2,2;3,3;4,4]) (M.to_seq_from 0 (il [4,4;1,1;3,3;2,2])));
+    let l =  [0,0;1,1;2,2;3,3;4,4;5,5;6,6;7,7;8,8;9,9]
+    and l2 = [5,5;6,6;7,7;8,8;9,9] in
+    "to_seq_from 5 [1,1 -- 9,9]" @? (BatSeq.equal (BatSeq.of_list l2) (M.to_seq_from 5 (il l)));
+    "to_seq_from 0 [1,1 -- 9,9]" @? (BatSeq.equal (BatSeq.of_list l) (M.to_seq_from 0 (il l)));
+    let max = 40 in
+    let l = BatList.init max (fun i -> (i, i)) in
+    for i = 0 to max do
+      let subl = BatList.filter (fun (x, _) -> x >= i) l in
+      "to_seq_from N [1,1 -- M,M]" @? (BatSeq.equal (BatSeq.of_list subl) (M.to_seq_from i (il l)));
+    done;
     ()
 
 


### PR DESCRIPTION
There were several functions added to stdlib.Map, which are added in this PR.
Unfortunately, stdlib also added an update function with an incompatible type signature, 
which is why this PR adds an update_stdlib function.

For 100% compatibility, something like `  module IntMap = struct
     include BatMap.Int
     let update = update_stdlib
  end
  ` is necessary, see also the extended batteries_compattest.

Also, for several functions the exception raised on empty maps was changed to `Not_found` to increase consistency and compatibility with stdlib; the exception raised was unspecified by the documentation for these functions anyways.