### PR TITLE
Remove `-rectypes` from BatFingerTree, simplify the implementation

### DIFF
--- a/benchsuite/bench_finger_tree_enum.ml
+++ b/benchsuite/bench_finger_tree_enum.ml
@@ -1,0 +1,27 @@
+(* cd .. && ocamlbuild -use-ocamlfind benchsuite/bench_finger_tree_enum.native && _build/benchsuite/bench_finger_tree_enum.native *)
+
+module Fg = BatFingerTree
+
+let test_input =
+  let s = ref Fg.empty in
+  for i = 0 to 999_999 do
+    s := Fg.snoc !s i;
+  done;
+  !s
+
+let () =
+  assert (BatList.of_enum (Fg.enum test_input) = Fg.to_list test_input);
+  assert (BatList.of_enum (Fg.backwards test_input) = Fg.to_list_backwards test_input);
+  assert (BatList.of_enum (Fg.backwards test_input) = List.rev (Fg.to_list test_input));
+  ()
+
+let test to_enum n =
+  for i = 1 to n do
+    let enum = to_enum test_input in
+    BatEnum.iter ignore enum
+  done
+
+let () =
+  Bench.bench_n [
+      "implemented", test Fg.enum;
+    ] |>  Bench.run_outputs

--- a/src/_tags
+++ b/src/_tags
@@ -1,7 +1,6 @@
 true: debug
 <{batMutex,batRMutex}.{ml,mli}>: threads
 <batteriesThread.*>: threads
-<batFingerTree.ml>: rectypes
 <{batMap,batVect,batFile,batPervasives,batParserCo,batSet,batLogger,batPathGen,batSplay}.ml>: warn_z
 <{batPervasives,batIMap,batLog}.ml>: warn_-9
 <batteriesHelp.*>: compiler-libs

--- a/src/batFingerTree.ml
+++ b/src/batFingerTree.ml
@@ -898,9 +898,26 @@ struct
     BatEnum.print ?first ?last ?sep f oc (enum x)
 
   let compare cmp t1 t2 =
-    BatEnum.compare cmp (enum t1) (enum t2)
+    let rec loop cmp iter1 iter2 =
+      match iter_next iter1, iter_next iter2 with
+      | None, None -> 0
+      | Some _, None -> 1
+      | None, Some _ -> -1
+      | Some (e1, iter1), Some (e2, iter2) ->
+         let c = cmp e1 e2 in
+         if c <> 0 then c
+         else loop cmp iter1 iter2
+    in loop cmp (to_iter t1 End) (to_iter t2 End)
+
   let equal eq t1 t2 =
-    BatEnum.equal eq (enum t1) (enum t2)
+    let rec loop eq iter1 iter2 =
+      match iter_next iter1, iter_next iter2 with
+      | None, None -> true
+      | Some _, None -> false
+      | None, Some _ -> false
+      | Some (e1, iter1), Some (e2, iter2) ->
+         eq e1 e2 && loop eq iter1 iter2
+    in loop eq (to_iter t1 End) (to_iter t2 End)
 
   (* this function does as of_list, but, by using concatenation,
    * it generates trees with some Node2 (which are never generated

--- a/src/batFingerTree.ml
+++ b/src/batFingerTree.ml
@@ -804,91 +804,60 @@ struct
   (*---------------------------------*)
   (*          enumerations           *)
   (*---------------------------------*)
-  (* Here enumerations are implemented by iterating over the structure in cps
-   * Each time an element is found, a pair consisting of this element and the
-   * current continuation is returned.
-  *)
-  let enum_digit enum_a d k =
-    match d with
-    | One (_, a) ->
-      enum_a a k
-    | Two (_, a, b) ->
-      enum_a a (fun () -> enum_a b k)
-    | Three (_, a, b, c) ->
-      enum_a a (fun () -> enum_a b (fun () -> enum_a c k))
-    | Four (_, a, b, c, d) ->
-      enum_a a (fun () -> enum_a b (fun () -> enum_a c (fun () -> enum_a d k)))
-  let enum_digit_backwards enum_a d k =
-    match d with
-    | One (_, a) ->
-      enum_a a k
-    | Two (_, a, b) ->
-      enum_a b (fun () -> enum_a a k)
-    | Three (_, a, b, c) ->
-      enum_a c (fun () -> enum_a b (fun () -> enum_a a k))
-    | Four (_, a, b, c, d) ->
-      enum_a d (fun () -> enum_a c (fun () -> enum_a b (fun () -> enum_a a k)))
 
-  let enum_node enum_a n k =
-    match n with
-    | Node2 (_, a, b) ->
-      enum_a a (fun () -> enum_a b k)
-    | Node3 (_, a, b, c) ->
-      enum_a a (fun () -> enum_a b (fun () -> enum_a c k))
-  let enum_node_backwards enum_a n k =
-    match n with
-    | Node2 (_, a, b) ->
-      enum_a b (fun () -> enum_a a k)
-    | Node3 (_, a, b, c) ->
-      enum_a c (fun () -> enum_a b (fun () -> enum_a a k))
+  type ('a, 'm) iter =
+    | End
+    | Next of 'a * ('a, 'm) iter
+    | Digit of ('a, 'm) digit * ('a, 'm) iter
+    | Fg of (('a, 'm) node, 'm) iter * ('a, 'm) iter
 
-  type 'a iter = unit -> 'a ret
-  and 'a ret = Next of 'a * 'a iter
-  type ('input, 'output) iter_into = 'input -> 'output iter -> 'output ret
-
-  let enum_base a k = Next (a, k)
-
-  let rec enum_aux : 'v 'a 'm. ('a, 'v) iter_into -> (('a, 'm) fg, 'v) iter_into =
-    fun enum_a t k ->
+  let rec to_iter : 'a. ('a, 'm) fg -> ('a, 'm) iter -> ('a, 'm) iter =
+    fun t k ->
       match t with
-      | Nil -> k ()
-      | Single a -> enum_a a k
-      | Deep (_, pr, m, sf) ->
-        enum_digit enum_a pr (fun () ->
-          enum_aux (enum_node enum_a) m (fun () ->
-            enum_digit enum_a sf k
-          )
-        )
-  let enum_cps t = enum_aux enum_base t (fun () -> raise BatEnum.No_more_elements)
+      | Nil -> k
+      | Single a -> Next (a, k)
+      | Deep (_, pr, m, sf) -> Digit (pr, Fg (to_iter m End, Digit (sf, k)))
 
-  let rec enum_aux_backwards : 'v 'a 'm. ('a, 'v) iter_into -> (('a, 'm) fg, 'v) iter_into =
-    fun enum_a t k ->
+  let rec to_iter_backwards : 'a. ('a, 'm) fg -> ('a, 'm) iter -> ('a, 'm) iter =
+    fun t k ->
       match t with
-      | Nil -> k ()
-      | Single a -> enum_a a k
-      | Deep (_, pr, m, sf) ->
-        enum_digit_backwards enum_a sf (fun () ->
-          enum_aux_backwards (enum_node_backwards enum_a) m (fun () ->
-            enum_digit_backwards enum_a pr k
-          )
-        )
-  let enum_cps_backwards t = enum_aux_backwards enum_base t (fun () -> raise BatEnum.No_more_elements)
+      | Nil -> k
+      | Single a -> Next (a, k)
+      | Deep (_, pr, m, sf) -> Digit (sf, Fg (to_iter_backwards m End, Digit (pr, k)))
 
   (*---------------------------------*)
   (*           conversion            *)
   (*---------------------------------*)
+  let rec iter_next : 'a . ('a, 'm) iter -> ('a * ('a, 'm) iter) option = function
+    | End -> None
+    | Next (v, k) -> Some (v, k)
+    | Digit (One (_, a), k) -> Some (a, k)
+    | Digit (Two (_, a, b), k) -> Some (a, Next (b, k))
+    | Digit (Three (_, a, b, c), k) -> Some (a, Next (b, Next (c, k)))
+    | Digit (Four (_, a, b, c, d), k) -> Some (a, Next (b, Next (c, Next (d, k))))
+    | Fg (node_iter, k) ->
+       match iter_next node_iter with
+       | None -> iter_next k
+       | Some (Node2 (_, a, b), k_node) -> Some (a, Next (b, Fg (k_node, k)))
+       | Some (Node3 (_, a, b, c), k_node) -> Some (a, Next (b, Next (c, Fg (k_node, k))))
+
+  let rec iter_next_backwards : 'a . ('a, 'm) iter -> ('a * ('a, 'm) iter) option = function
+    | End -> None
+    | Next (v, k) -> Some (v, k)
+    | Digit (One (_, a), k) -> Some (a, k)
+    | Digit (Two (_, a, b), k) -> Some (b, Next (a, k))
+    | Digit (Three (_, a, b, c), k) -> Some (c, Next (b, Next (a, k)))
+    | Digit (Four (_, a, b, c, d), k) -> Some (d, Next (c, Next (b, Next (a, k))))
+    | Fg (node_iter, k) ->
+       match iter_next_backwards node_iter with
+       | None -> iter_next k
+       | Some (Node2 (_, a, b), k_node) -> Some (b, Next (a, Fg (k_node, k)))
+       | Some (Node3 (_, a, b, c), k_node) -> Some (c, Next (b, Next (a, Fg (k_node, k))))
+
   let enum t =
-    BatEnum.from_loop
-      (fun () -> enum_cps t)
-      (fun k ->
-        match k () with
-        | Next (v, k) -> (v, k))
+    BatEnum.unfold (to_iter t End) iter_next
   let backwards t =
-    BatEnum.from_loop
-      (fun () -> enum_cps_backwards t)
-      (fun k ->
-        match k () with
-        | Next (v, k) -> (v, k))
+    BatEnum.unfold  (to_iter_backwards t End) iter_next_backwards
 
   let of_enum ~monoid ~measure enum =
     BatEnum.fold (fun t elt -> snoc ~monoid ~measure t elt) empty enum


### PR DESCRIPTION
The option `-rectypes` has a non-obvious impact on the type theory of OCaml, it is better to not require it for some modules. `-rectypes` was used in the implementation of enumeration of finger trees, to implement a specific form of continuation-passing-style. The new implementation uses plain old datatypes, so it is simpler (and shorter). Benchmarking suggests that there are no performance differences.