### PR TITLE
Dune preliminaries: fix Dune warnings over the Batteries codebase

### DIFF
--- a/build/prefilter.ml
+++ b/build/prefilter.ml
@@ -23,11 +23,11 @@ let version_re =
  *)
 let mark_loc_stale = function
   | None -> ()
-  | Some (file, count, stale) -> stale := true
+  | Some (_file, _count, stale) -> stale := true
 
 let incr_loc = function
   | None -> ()
-  | Some (file, count, stale) -> incr count
+  | Some (_file, count, _stale) -> incr count
 
 let print_loc = function
   | None -> ()

--- a/src/batBitSet.ml
+++ b/src/batBitSet.ml
@@ -27,7 +27,7 @@ let print_array =
   let print_bchar c =
     let rc = ref c in
     Buffer.clear buf;
-    for i = 1 to 8 do
+    for _i = 1 to 8 do
       Buffer.add_char buf
         (if !rc land 1 == 1 then '1' else '0');
       rc := !rc lsr 1

--- a/src/batCache.ml
+++ b/src/batCache.ml
@@ -62,7 +62,7 @@ let lru_cache ~gen ~cap =
     incr len;
     let n = BatDllist.create (k, v) in BatHashtbl.add auxentries k n; n
   in
-  let entry_find k dll =
+  let entry_find k _dll =
     try let n = BatHashtbl.find auxentries k in BatDllist.remove n; n
     with Not_found -> entry_gen k (gen k)
   in

--- a/src/batConcreteQueue_402.ml
+++ b/src/batConcreteQueue_402.ml
@@ -26,10 +26,10 @@ and 'a t = {
 external of_abstr : 'a Queue.t -> 'a t = "%identity"
 external to_abstr : 'a t -> 'a Queue.t = "%identity"
 
-let filter_inplace f ({tail} as queue) =
+let filter_inplace f ({tail; _} as queue) =
   if not (Queue.is_empty (to_abstr queue)) then
     let rec filter'
-        ({ next = { content; next} as current } as prev)
+        ({ next = { content; next } as current; _ } as prev)
       =
       if f content
       then

--- a/src/batEnum.ml
+++ b/src/batEnum.ml
@@ -265,7 +265,7 @@ let take n e =
   let r = ref [] in
   begin
     try
-      for i = 1 to n do
+      for _i = 1 to n do
         r := e.next () :: !r
       done
     with No_more_elements -> ()
@@ -740,7 +740,7 @@ let range ?until x =
 *)
 
 let drop n e =
-  for i = 1 to n do
+  for _i = 1 to n do
     junk e
   done
 
@@ -987,7 +987,7 @@ let clump clump_size add get e = (* convert a uchar enum into a ustring enum *)
       add x;
       junk e; (* don't get [x] twice *)
       (try
-        for i = 2 to clump_size do
+        for _i = 2 to clump_size do
           add (e.next ())
         done
       with No_more_elements -> ());

--- a/src/batFile.ml
+++ b/src/batFile.ml
@@ -145,7 +145,7 @@ let open_in ?mode ?(perm=default_permission) name =
       ~read:(fun () ->
         if !pos >= len then raise No_more_input
         else Array1.get array (BatRef.post_incr pos))
-      ~input:(fun sout p l ->
+      ~input:(fun sout _p l ->
         if !pos >= len then raise No_more_input;
         let n = (if !pos + l > len then len - !pos else l) in
         for i = 0 to n - 1 do

--- a/src/batIMap.ml
+++ b/src/batIMap.ml
@@ -313,7 +313,7 @@ let singleton ~eq x y = {m = Core.singleton x y; eq}
   try ignore(find 0 (singleton ~eq:(=) 1 'x')); false with Not_found -> true
 *)
 
-let is_empty {m} = Core.is_empty m
+let is_empty {m; _} = Core.is_empty m
 let add x y {m;eq} = {m=Core.add ~eq x y m; eq}
 
 (*$= add as a & ~cmp:(List.eq (Tuple3.eq Int.equal Int.equal Int.equal)) ~printer:(List.print (Tuple3.print Int.print Int.print Int.print) |> IO.to_string)
@@ -326,7 +326,7 @@ let add x y {m;eq} = {m=Core.add ~eq x y m; eq}
 
 
 let add_range lo hi y {m;eq} = {m=Core.add_range ~eq lo hi y m; eq}
-let find x {m} = Core.find x m
+let find x {m; _} = Core.find x m
 let modify x f {m;eq} = {m=Core.modify ~eq x f m; eq}
 
 (*$T modify
@@ -369,23 +369,23 @@ let from x {m;eq} = {m=Core.from x m; eq}
 let after x {m;eq} = {m=Core.after x m; eq}
 let until x {m;eq} = {m=Core.until x m; eq}
 let before x {m;eq} = {m=Core.before x m; eq}
-let mem x {m} = Core.mem x m
-let iter f {m} = Core.iter f m
-let iter_range f {m} = Core.iter_range f m
-let map ?(eq=(=)) f {m} = {m=Core.map ~eq f m; eq}
-let mapi ?(eq=(=)) f {m} = {m=Core.mapi ~eq f m; eq}
-let map_range ?(eq=(=)) f {m} = {m = Core.map_range ~eq f m; eq}
-let fold f {m} x0 = Core.fold f m x0
-let fold_range f {m} x0 = Core.fold_range f m x0
+let mem x {m; _} = Core.mem x m
+let iter f {m; _} = Core.iter f m
+let iter_range f {m; _} = Core.iter_range f m
+let map ?(eq=(=)) f {m; _} = {m=Core.map ~eq f m; eq}
+let mapi ?(eq=(=)) f {m; _} = {m=Core.mapi ~eq f m; eq}
+let map_range ?(eq=(=)) f {m; _} = {m = Core.map_range ~eq f m; eq}
+let fold f {m; _} x0 = Core.fold f m x0
+let fold_range f {m; _} x0 = Core.fold_range f m x0
 let set_to_map ?(eq=(=)) s x = {m = Core.set_to_map s x; eq}
-let domain {m} = Core.domain m
-let map_to_set f {m} = Core.map_to_set f m
-let enum {m} = Core.enum m
-let fold2_range f {m=m1} {m=m2} x0 = Core.fold2_range f m1 m2 x0
-let union f {m=m1;eq} {m=m2} = {m=Core.union ~eq f m1 m2; eq}
-let merge ?(eq=(=)) f {m=m1} {m=m2} = {m=Core.merge ~eq f m1 m2; eq}
-let forall2_range f {m=m1} {m=m2} = Core.forall2_range f m1 m2
-let get_dec_eq {eq} = eq
+let domain {m; _} = Core.domain m
+let map_to_set f {m; _} = Core.map_to_set f m
+let enum {m; _} = Core.enum m
+let fold2_range f {m=m1; _} {m=m2; _} x0 = Core.fold2_range f m1 m2 x0
+let union f {m=m1;eq} {m=m2; _} = {m=Core.union ~eq f m1 m2; eq}
+let merge ?(eq=(=)) f {m=m1; _} {m=m2; _} = {m=Core.merge ~eq f m1 m2; eq}
+let forall2_range f {m=m1; _} {m=m2; _} = Core.forall2_range f m1 m2
+let get_dec_eq {eq; _} = eq
 
 (*$T get_dec_eq
   get_dec_eq (empty Int.equal) == Int.equal
@@ -395,6 +395,6 @@ let of_enum ~eq e =
   BatEnum.fold (fun t (n1, n2, v) -> add_range n1 n2 v t) (empty ~eq) e
 
 module Infix = struct
-  let (-->) {m} k = Core.find k m
+  let (-->) {m; _} k = Core.find k m
   let (<--) m (k,v) = add k v m
 end

--- a/src/batList.mlv
+++ b/src/batList.mlv
@@ -391,7 +391,7 @@ let nsplit p = function
       let r = Acc.accum dst ok in
       match rest with
         | [] -> ()
-        | x :: xs -> loop r xs
+        | _x :: xs -> loop r xs
     in
     let dummy = Acc.dummy () in
     loop dummy li;
@@ -817,7 +817,7 @@ let count_matching p l =
 ##V<4.11##  let rec aux i = function
 ##V<4.11##    | [] -> []
 ##V<4.11##    | x::xs when f i x -> x :: aux (succ i) xs
-##V<4.11##    | x::xs -> aux (succ i) xs
+##V<4.11##    | _x::xs -> aux (succ i) xs
 ##V<4.11##  in
 ##V<4.11##  aux 0
 (*$T filteri

--- a/src/batLog.ml
+++ b/src/batLog.ml
@@ -34,10 +34,10 @@ let flags = ref [`Date; `Time]
 
 let print_flag ?fp t oc = function
   | `Date ->
-    let {Unix.tm_year=y; tm_mon=m; tm_mday=d} = Lazy.force t in
+    let {Unix.tm_year=y; tm_mon=m; tm_mday=d; _} = Lazy.force t in
     BatPrintf.fprintf oc "%4d/%02d/%02d" (y + 1900) (m + 1) d
   | `Time ->
-    let {Unix.tm_hour=h; tm_min=m; tm_sec=s} = Lazy.force t in
+    let {Unix.tm_hour=h; tm_min=m; tm_sec=s; _} = Lazy.force t in
     BatPrintf.fprintf oc "%2d:%02d:%02d" h m s
   | `Filepos ->
     BatOption.may (nwrite oc) fp

--- a/src/batLogger.ml
+++ b/src/batLogger.ml
@@ -118,14 +118,14 @@ let make_std_formatter oc lm lev (event_name, event_args) timestamp =
 
 let stderr_formatter = make_std_formatter BatIO.stderr
 
-let null_formatter lm lev event timestamp = ()
+let null_formatter _lm _lev _event _timestamp = ()
 
 let format_indent oc depth =
   for _i = 0 to depth do
     fprintf oc "| "
   done
 
-let make_dbg_formatter oc lm lev (event_name, event_args) timestamp =
+let make_dbg_formatter oc lm lev (event_name, event_args) _timestamp =
   let indent = try int_of_string (List.assoc "I" event_args) with _ -> 0 in
   let args = List.remove_assoc "I" event_args in
   fprintf oc "### %a%s.%s %a [%s]\n%!" format_indent indent
@@ -142,7 +142,7 @@ let log lm lev event_fun =
     let time = Unix.gettimeofday () in
     let event_name, event_args = event_fun () in
     let event = event_name, ("I", string_of_int !depth) :: event_args in
-    List.iter (fun (name, fmt) -> fmt lm lev event time) !formatters
+    List.iter (fun (_name, fmt) -> fmt lm lev event time) !formatters
 
 let with_log lm lev event_fun ?result body =
   if log_enabled lm lev then begin
@@ -186,7 +186,7 @@ let init_from_string name_level_string formatter =
     with Not_found -> try
       let level = level_of_name (BatSubstring.to_string ss) in
       default_level := int_of_level level;
-      Hashtbl.iter (fun name lm -> log_enable lm level) logs
+      Hashtbl.iter (fun _name lm -> log_enable lm level) logs
     with Failure _ ->
       failwith ("invalid log initialization: " ^ BatSubstring.to_string ss)
   in

--- a/src/batMap.ml
+++ b/src/batMap.ml
@@ -842,7 +842,7 @@ module Concrete = struct
   (* Maps are considered compatible by their comparison function when either:
      - cmp1 and cmp2 are the *same* function (physical equality)
      - cmp1 is a correct ordering on m2 (see comment in [ordered]) *)
-  let compatible_cmp cmp1 m1 cmp2 m2 =
+  let compatible_cmp cmp1 _m1 cmp2 m2 =
     cmp1 == cmp2 || ordered cmp1 m2
 
   (* We first try to see if the comparison functions are compatible.
@@ -1512,7 +1512,7 @@ module PMap = struct (*$< PMap *)
     }
 
   let create cmp = { cmp = cmp; map = Concrete.empty }
-  let get_cmp {cmp} = cmp
+  let get_cmp {cmp; _} = cmp
 
   (*$T get_cmp
     get_cmp (create BatInt.compare) == BatInt.compare

--- a/src/batParserCo.ml
+++ b/src/batParserCo.ml
@@ -35,7 +35,7 @@ struct
   open Lexing
 
   (**TODO: Handle EOF !*)
-  let of_lexer l = assert false
+  let of_lexer _l = assert false
   (**    LazyList.of_enum (BatEnum.from (fun () ->
 
              l.refill_buff l;
@@ -80,11 +80,11 @@ let apply p e = p e(**To improve reusability*)
 
    These errors are caused by [must].*)
 
-let fail        e     = Setback (Report [])
+let fail        _e     = Setback (Report [])
 let succeed     v e   = Success (v, e)
 let backtracked v r e = Backtrack (v, r, e)
 let return            = succeed
-let fatal       e     = Failure (Report [])
+let fatal       _e     = Failure (Report [])
 (* Primitives *)
 
 
@@ -98,9 +98,9 @@ let label s p e =
   if BatString.is_empty s then
     match apply p e with
     | Success _ as x      -> x
-    | Setback c           -> Setback (Report [])
-    | Failure c           -> Failure (Report [])
-    | Backtrack (b, c, t) -> Backtrack (b, Report [], t)
+    | Setback _c           -> Setback (Report [])
+    | Failure _c           -> Failure (Report [])
+    | Backtrack (b, _c, t) -> Backtrack (b, Report [], t)
   else
     let make_report c = Report [get_state e, s, c] in
     if !debug_mode then
@@ -230,13 +230,13 @@ let ignore_zero_plus ?sep p e =
     | Some s -> s >>> p
   in
   let rec aux l = match apply p' l with
-    | Success   (x, rest)              -> aux rest
-    | Backtrack (result, report, rest) -> backtracked () report rest
+    | Success   (_x, rest)              -> aux rest
+    | Backtrack (_result, report, rest) -> backtracked () report rest
     | Setback   report                 -> backtracked () report l
     | Failure _ as result              -> result
   in match apply p e with
   | Success   (_, rest)              -> aux rest
-  | Backtrack (result, report, rest) -> backtracked () report rest
+  | Backtrack (_result, report, rest) -> backtracked () report rest
   | Setback   report                 -> backtracked () report e
   | Failure _ as result              -> result
 
@@ -263,8 +263,8 @@ let prefix suffix l =
 let scan p e =
   let just_prefix rest = List.map fst (prefix rest e) in
   match apply p e with (*First proceed with parsing*)
-  | Success (result, rest)           -> succeed (just_prefix rest) rest
-  | Backtrack (result, report, rest) -> backtracked (just_prefix rest) report rest
+  | Success (_result, rest)           -> succeed (just_prefix rest) rest
+  | Backtrack (_result, report, rest) -> backtracked (just_prefix rest) report rest
   | Setback _ | Failure _ as result  -> result
 
 let lookahead p e = match apply p e with

--- a/src/batPathGen.ml
+++ b/src/batPathGen.ml
@@ -632,13 +632,13 @@ module Make = functor (S : StringType) -> struct
       | 0,  [] -> []
       | nn, [] -> !!".." :: (doit (nn - 1) [])
       | 0,  [rt] when isroot rt -> path
-      | nn, [rt] when isroot rt -> raise Malformed_path
+      | _nn, [rt] when isroot rt -> raise Malformed_path
       | _,  dotdot :: rest  when can_dotdot && isdotdot dotdot -> doit (cback + 1) rest
       | 0,  [dot;nu] when windows && (isdot dot) && (isnul nu) -> path
-      | nn, [dot;nu] when windows && (isdot dot) && (isnul nu) -> raise Malformed_path
+      | _nn, [dot;nu] when windows && (isdot dot) && (isnul nu) -> raise Malformed_path
       | _,  dot :: rest when isdot dot -> doit cback rest
       | 0,  name :: rest -> name :: (doit 0 rest)
-      | nn, name :: rest -> doit (nn - 1) rest
+      | nn, _name :: rest -> doit (nn - 1) rest
     in
     doit 0 path
 
@@ -662,14 +662,14 @@ module Make = functor (S : StringType) -> struct
     let rec fold rbase rsub =
       match rbase, rsub with
       | bname::brest, sname::srest when bname = sname -> fold brest srest
-      | _::brest, _ -> false
+      | _::_brest, _ -> false
       | [], _ -> true
     in
     let rbase = List.rev base in
     let rsub = List.rev sub in
     match rbase, rsub with
     | hb::_, hs::_ when hb = hs -> fold rbase rsub
-    | hb::_, hs::_ -> false
+    | _hb::_, _hs::_ -> false
     | rt::_, _ when isroot rt -> invalid_arg "PathGen.belongs"
     | _, rt::_ when isroot rt -> invalid_arg "PathGen.belongs"
     | _, _ -> fold rbase rsub

--- a/src/batSet.ml
+++ b/src/batSet.ml
@@ -82,13 +82,13 @@ module Concrete = struct
   (* Smallest and greatest element of a set *)
   let rec min_elt = function
       Empty -> raise Not_found
-    | Node(Empty, v, r, _) -> v
-    | Node(l, v, r, _) -> min_elt l
+    | Node(Empty, v, _r, _) -> v
+    | Node(l, _v, _r, _) -> min_elt l
 
   let rec min_elt_opt = function
       Empty -> None
-    | Node(Empty, v, r, _) -> Some v
-    | Node(l, v, r, _) -> min_elt_opt l
+    | Node(Empty, v, _r, _) -> Some v
+    | Node(l, _v, _r, _) -> min_elt_opt l
 
   let get_root = function
     | Empty -> raise Not_found
@@ -116,18 +116,18 @@ module Concrete = struct
 
   let rec max_elt = function
       Empty -> raise Not_found
-    | Node(l, v, Empty, _) -> v
-    | Node(l, v, r, _) -> max_elt r
+    | Node(_l, v, Empty, _) -> v
+    | Node(_l, _v, r, _) -> max_elt r
 
   let rec max_elt_opt = function
       Empty -> None
-    | Node(l, v, Empty, _) -> Some v
-    | Node(l, v, r, _) -> max_elt_opt r
+    | Node(_l, v, Empty, _) -> Some v
+    | Node(_l, _v, r, _) -> max_elt_opt r
 
   (* Remove the smallest element of the given set *)
   let rec remove_min_elt = function
       Empty -> invalid_arg "Set.remove_min_elt"
-    | Node(Empty, v, r, _) -> r
+    | Node(Empty, _v, r, _) -> r
     | Node(l, v, r, _) -> bal (remove_min_elt l) v r
 
   (* Merge two trees l and r into one.
@@ -324,12 +324,12 @@ module Concrete = struct
 
   let rec add_min v = function
     | Empty -> singleton v
-    | Node (l, x, r, h) ->
+    | Node (l, x, r, _h) ->
       bal (add_min v l) x r
 
   let rec add_max v = function
     | Empty -> singleton v
-    | Node (l, x, r, h) ->
+    | Node (l, x, r, _h) ->
       bal l x (add_max v r)
 
   (* Same as create and bal, but no assumptions are made on the
@@ -425,7 +425,7 @@ module Concrete = struct
 
   let rec cardinal = function
       Empty -> 0
-    | Node(l, v, r, _) -> cardinal l + 1 + cardinal r
+    | Node(l, _v, r, _) -> cardinal l + 1 + cardinal r
 
   let rec elements_aux accu = function
       Empty -> accu
@@ -470,7 +470,7 @@ module Concrete = struct
   let enum_count l () =
     let rec aux n = function
         E -> n
-      | C (e, s, t) -> aux (n + 1 + cardinal s) t
+      | C (_e, s, t) -> aux (n + 1 + cardinal s) t
     in aux 0 !l
 
   let enum t =
@@ -646,8 +646,8 @@ module Concrete = struct
 
   let rec inter cmp12 s1 s2 =
     match (s1, s2) with
-      (Empty, t2) -> Empty
-    | (t1, Empty) -> Empty
+      (Empty, _t2) -> Empty
+    | (_t1, Empty) -> Empty
     | (Node(l1, v1, r1, _), t2) ->
       match split cmp12 v1 t2 with
         (l2, false, r2) ->
@@ -657,7 +657,7 @@ module Concrete = struct
 
   let rec diff cmp12 s1 s2 =
     match (s1, s2) with
-      (Empty, t2) -> Empty
+      (Empty, _t2) -> Empty
     | (t1, Empty) -> t1
     | (Node(l1, v1, r1, _), t2) ->
       match split cmp12 v1 t2 with
@@ -674,7 +674,7 @@ module Concrete = struct
       match split cmp12 v1 t2 with
         (l2, false, r2) ->
         disjoint cmp12 l1 l2 && disjoint cmp12 r1 r2
-      | (l2, true, r2) -> false
+      | (_l2, true, _r2) -> false
 
   let compare cmp s1 s2 =
     let rec compare_aux t1' t2' =
@@ -923,8 +923,8 @@ struct
   let rec compare_subset s1 s2 =
     match (s1, impl_of_t s2) with
       (Concrete.Empty, Concrete.Empty) -> 0
-    | (Concrete.Empty, t2) -> -1
-    | (t1, Concrete.Empty) -> 1
+    | (Concrete.Empty, _t2) -> -1
+    | (_t1, Concrete.Empty) -> 1
     | (Concrete.Node(l1, v1, r1, _), t2) ->
       match split v1 (t_of_impl t2) with
         (l2, true, r2) -> (* v1 in both s1 and s2 *)
@@ -1013,7 +1013,7 @@ module PSet = struct (*$< PSet *)
 
   let empty    = { cmp = compare; set = Concrete.empty }
   let create cmp  = { cmp = cmp; set = Concrete.empty }
-  let get_cmp {cmp} = cmp
+  let get_cmp {cmp; _} = cmp
 
   (*$T get_cmp
     get_cmp (create BatInt.compare) == BatInt.compare

--- a/src/batSplay.ml
+++ b/src/batSplay.ml
@@ -263,7 +263,7 @@ struct
       csplay begin
         match cfind ~sel:(ksel k) tr with
         | C (cx, Node (l, (k, v), r)) -> C (cx, Node (l, (k, fn v), r))
-        | C (cx, Empty) -> raise Not_found
+        | C (_cx, Empty) -> raise Not_found
       end
     end
 
@@ -439,7 +439,7 @@ struct
         csplay begin
           match cfind ~sel:(ksel k1) tr with
           | C (cx, Node (l, _kv, r)) -> C (cx, Node (l, (k2, v2), r))
-          | C (cx, Empty) -> raise Not_found
+          | C (_cx, Empty) -> raise Not_found
         end
       end
 

--- a/src/batString.mlv
+++ b/src/batString.mlv
@@ -918,7 +918,7 @@ let in_place_mirror = rev_in_place
 
 let repeat s n =
   let buf = Buffer.create ( n * (String.length s) ) in
-  for i = 1 to n do Buffer.add_string buf s done;
+  for _i = 1 to n do Buffer.add_string buf s done;
   Buffer.contents buf
 (*$T repeat
    repeat "fo" 4 = "fofofofo"

--- a/src/batText.ml
+++ b/src/batText.ml
@@ -216,7 +216,7 @@ let get r i =
     | Leaf (lens, s) ->
       if i >= 0 && i < lens then UTF8.get s i
       else raise Out_of_bounds
-    | Concat (l, cl, r, cr, _) ->
+    | Concat (l, cl, r, _cr, _) ->
       if i < cl then aux i l
       else aux (i - cl) r
   in
@@ -237,7 +237,7 @@ let set r i v =
         let s = copy_set s i v in
         Leaf (lens, s)
       else raise Out_of_bounds
-    | Concat(l, cl, r, cr, _) ->
+    | Concat(l, cl, r, _cr, _) ->
       if i < cl then append (aux i l) r
       else append l (aux (i - cl) r)
   in
@@ -270,9 +270,9 @@ module Iter = struct
   let rec next_leaf = function
     | Empty :: l ->
       next_leaf l
-    | Leaf(len, str) :: l ->
+    | Leaf(_len, str) :: l ->
       Some(str, l)
-    | Concat(left, left_len, right, right_len, height) :: l ->
+    | Concat(left, _left_len, right, _right_len, _height) :: l ->
       next_leaf (left :: right :: l)
     | [] ->
       None
@@ -320,9 +320,9 @@ module Iter = struct
   let rec prev_leaf = function
     | Empty :: l ->
       prev_leaf l
-    | Leaf(len, str) :: l ->
+    | Leaf(_len, str) :: l ->
       Some(str, l)
-    | Concat(left, left_len, right, right_len, height) :: l ->
+    | Concat(left, _left_len, right, _right_len, _height) :: l ->
       prev_leaf (right :: left :: l)
     | [] ->
       None
@@ -493,7 +493,7 @@ let rec iteri ?(base=0) f = function
 
 let rec bulk_iteri_backwards ~top f = function
   | Empty -> ()
-  | Leaf (lens,s) -> f top s
+  | Leaf (_lens,s) -> f top s
   | Concat(l,_,r,cr,_) ->
     bulk_iteri_backwards ~top f r;
     bulk_iteri_backwards ~top:(top-cr) f l
@@ -635,7 +635,7 @@ let backwards r =
 let of_enum e =
   let size = BatEnum.count e in
   init size
-    (fun i ->
+    (fun _i ->
        try BatEnum.get_exn e
        with BatEnum.No_more_elements -> assert false)
 
@@ -846,7 +846,7 @@ let of_list l =
     Return.label
       (fun label ->
         let b = Buffer.create 256 in
-        for i = 1 to 256 do
+        for _i = 1 to 256 do
           match !e with
             []   -> Return.return label (false, UTF8.of_string_unsafe (Buffer.contents b))
           | c :: rest  -> Buffer.add_string b (UTF8.to_string_unsafe (UTF8.of_char c)); e := rest

--- a/src/batUTF8.ml
+++ b/src/batUTF8.ml
@@ -298,7 +298,7 @@ end = struct
   let move us bi n = (* faster moving positive than negative n *)
     let bi = ref bi in
     let step = if n > 0 then next else prev in
-    for j = 1 to abs n do bi := step us !bi done;
+    for _j = 1 to abs n do bi := step us !bi done;
     !bi
   let of_char_idx us ci = move us first ci
 end

--- a/src/batVect.ml
+++ b/src/batVect.ml
@@ -226,7 +226,7 @@ let rec get t i =
   | Leaf s ->
     if i >= 0 && i < STRING.length s then STRING.unsafe_get s i
     else raise Out_of_bounds
-  | Concat (l, cl, r, cr, _) ->
+  | Concat (l, cl, r, _cr, _) ->
     if i < cl then get l i
     else get r (i - cl)
 
@@ -240,7 +240,7 @@ let rec set t i x =
       STRING.unsafe_set s i x;
       Leaf s
     ) else raise Out_of_bounds
-  | Concat (l, cl, r, cr, _) ->
+  | Concat (l, cl, r, _cr, _) ->
     if i < cl then concat (set l i x) r
     else concat l (set r (i - cl) x)
 
@@ -256,7 +256,7 @@ let rec modify t i f =
       STRING.unsafe_set s i (f (STRING.unsafe_get s i));
       Leaf s
     ) else raise Out_of_bounds
-  | Concat (l, cl, r, cr, _) ->
+  | Concat (l, cl, r, _cr, _) ->
     if i < cl then concat (modify l i f) r
     else concat l (modify r (i - cl) f)
 
@@ -398,7 +398,7 @@ let enum_count l () =
 let rev_enum_count l () =
   let rec aux n = function
     | E -> n
-    | C (s, p, m, t) -> aux (n + (p + 1) + length m) t
+    | C (_s, p, m, t) -> aux (n + (p + 1) + length m) t
   in aux 0 !l
 
 let enum t =
@@ -614,7 +614,7 @@ let destructive_set v i x =
       if i >= 0 && i < STRING.length s then
         STRING.unsafe_set s i x
       else raise Out_of_bounds
-    | Concat (l, cl, r, cr, _) ->
+    | Concat (l, cl, r, _cr, _) ->
       if i < cl then aux i l
       else aux (i - cl) r in
   aux i v
@@ -904,7 +904,7 @@ struct
     | Leaf s ->
       if i >= 0 && i < STRING.length s then STRING.unsafe_get s i
       else raise Out_of_bounds
-    | Concat (l, cl, r, cr, _) ->
+    | Concat (l, cl, r, _cr, _) ->
       if i < cl then get l i
       else get r (i - cl)
 
@@ -918,7 +918,7 @@ struct
         STRING.unsafe_set s i x;
         Leaf s
       ) else raise Out_of_bounds
-    | Concat (l, cl, r, cr, _) ->
+    | Concat (l, cl, r, _cr, _) ->
       if i < cl then concat (set l i x) r
       else concat l (set r (i - cl) x)
 
@@ -934,7 +934,7 @@ struct
         STRING.unsafe_set s i (f (STRING.unsafe_get s i));
         Leaf s
       ) else raise Out_of_bounds
-    | Concat (l, cl, r, cr, _) ->
+    | Concat (l, cl, r, _cr, _) ->
       if i < cl then concat (modify l i f) r
       else concat l (modify r (i - cl) f)
 
@@ -1054,7 +1054,7 @@ struct
   let rev_enum_count l () =
     let rec aux n = function
       | E -> n
-      | C (s, p, m, t) -> aux (n + (p + 1) + length m) t
+      | C (_s, p, m, t) -> aux (n + (p + 1) + length m) t
     in aux 0 !l
 
   let enum t =
@@ -1276,7 +1276,7 @@ struct
         if i >= 0 && i < STRING.length s then
           STRING.unsafe_set s i x
         else raise Out_of_bounds
-      | Concat (l, cl, r, cr, _) ->
+      | Concat (l, cl, r, _cr, _) ->
         if i < cl then aux i l
         else aux (i - cl) r in
     aux i v

--- a/testsuite/test_file.ml
+++ b/testsuite/test_file.ml
@@ -56,7 +56,7 @@ let test_open_files_not_autoclosed () =
 
 let test_open_close_many () =
   try
-    for i = 0 to 10000 do
+    for _i = 0 to 10000 do
       Unix.unlink (write buffer)
     done;
     (* pass *)
@@ -65,7 +65,7 @@ let test_open_close_many () =
 
 let test_open_close_many_pervasives () =
   try
-    for i = 0 to 10000 do
+    for _i = 0 to 10000 do
       let temp = temp_file "batteries" "test" in
       let oc   = open_out temp                         in
       output_string oc "test";

--- a/testsuite/test_map.ml
+++ b/testsuite/test_map.ml
@@ -311,7 +311,7 @@ module TestMap
     "union_stdlib [1,1;2,2;3,10] [3,6;4,4] keep sum on conflict" @=
       (M.union_stdlib (fun _k a b -> Some (a+b)) (il [3,6;4,4]) (il [1,1;2,2;3,10]), il [1,1;2,2;3,16;4,4]);
     "union_stdlib [1,1;2,2;3,10] [3,6;4,4] drop on conflict" @=
-      (M.union_stdlib (fun _k a b -> None)       (il [3,6;4,4]) (il [1,1;2,2;3,10]), il [1,1;2,2;4,4]);    
+      (M.union_stdlib (fun _k _a _b -> None)       (il [3,6;4,4]) (il [1,1;2,2;3,10]), il [1,1;2,2;4,4]);
     "union_stdlib [1,1;4,2;3,10] [3,6;4,4] keep 3 w sum, drop 4" @=
       (M.union_stdlib (fun k a b -> if k = 3 then Some (a+b) else None) (il [2,2;3,6;4,4]) (il [1,1;4,2;3,10]), il [1,1;2,2;3,16]);
     ()

--- a/testsuite/test_pervasives.ml
+++ b/testsuite/test_pervasives.ml
@@ -81,7 +81,7 @@ let test_dump () =
   let test_float x = test (string_of_float x) x in
   List.iter test_float
     [0.; 1.; -2.; max_float; min_float; epsilon_float; nan];
-  for i = 0 to 1000 do
+  for _i = 0 to 1000 do
     test_float (Random.float max_float);
     test_float (Random.float min_float);
   done;


### PR DESCRIPTION
1: make unused variables explicit
all changes were extracted from
https://github.com/gasche/batteries-included.git#dune-preliminary-warnings