### PR TITLE
Dune preliminaries: unused rec keyword

### DIFF
--- a/src/batBitSet.ml
+++ b/src/batBitSet.ml
@@ -280,7 +280,7 @@ let enum t =
   let rec make n cnt =
     let cur = ref n in
     let cnt = ref cnt in
-    let rec next () =
+    let next () =
       match next_set_bit t !cur with
         Some elem ->
         decr cnt;

--- a/src/batList.mlv
+++ b/src/batList.mlv
@@ -761,7 +761,7 @@ let find_all p l =
   findnext dummy l;
   dummy.tl
 
-let rec findi p l =
+let findi p l =
   let rec loop n = function
     | [] -> raise Not_found
     | h :: t ->
@@ -769,28 +769,28 @@ let rec findi p l =
   in
   loop 0 l
 
-let rec index_of e l =
+let index_of e l =
   let rec loop n = function
     | []              -> None
     | h::_ when h = e -> Some n
     | _::t            -> loop ( n + 1 ) t
   in loop 0 l
 
-let rec index_ofq e l =
+let index_ofq e l =
   let rec loop n = function
     | []               -> None
     | h::_ when h == e -> Some n
     | _::t             -> loop ( n + 1 ) t
   in loop 0 l
 
-let rec rindex_of e l =
+let rindex_of e l =
   let rec loop n acc = function
     | []              -> acc
     | h::t when h = e -> loop ( n + 1) ( Some n ) t
     | _::t            -> loop ( n + 1 ) acc       t
   in loop 0 None l
 
-let rec rindex_ofq e l =
+let rindex_ofq e l =
   let rec loop n acc = function
     | []               -> acc
     | h::t when h == e -> loop ( n + 1) ( Some n ) t

--- a/src/batMap.ml
+++ b/src/batMap.ml
@@ -531,15 +531,15 @@ module Concrete = struct
        then cons_iter_from cmp k2 l (C (k, v, r, e))
        else cons_iter_from cmp k2 r e
 
-  let rec enum_next l () = match !l with
+  let enum_next l () = match !l with
       E -> raise BatEnum.No_more_elements
     | C (k, v, m, t) -> l := cons_iter m t; (k, v)
 
-  let rec enum_backwards_next l () = match !l with
+  let enum_backwards_next l () = match !l with
       E -> raise BatEnum.No_more_elements
     | C (k, v, m, t) -> l := rev_cons_iter m t; (k, v)
 
-  let rec enum_count l () =
+  let enum_count l () =
     let rec aux n = function
       | E -> n
       | C (_, _, m, t) -> aux (n + 1 + cardinal m) t
@@ -724,7 +724,7 @@ module Concrete = struct
     | Some d -> join t1 v d t2
     | None -> concat t1 t2
 
-  let rec merge f cmp12 s1 s2 =
+  let merge f cmp12 s1 s2 =
     let rec loop s1 s2 =
       match (s1, s2) with
       | (Empty, Empty) -> Empty
@@ -739,7 +739,7 @@ module Concrete = struct
         assert false in
     loop s1 s2
 
-  let rec merge_diverse f cmp1 s1 cmp2 s2 =
+  let merge_diverse f cmp1 s1 cmp2 s2 =
     (* This implementation does not presuppose that the comparison
        function of s1 and s2 are the same. It is necessary in the PMap
        case, were we can't enforce that the same comparison function is
@@ -827,7 +827,7 @@ module Concrete = struct
      the fast homogeneous implementation instead. This is the
      [heuristic_merge] function.
   *)
-  let rec ordered cmp s =
+  let ordered cmp s =
     if s = Empty then true else
       try
         ignore

--- a/src/batString.mlv
+++ b/src/batString.mlv
@@ -216,7 +216,7 @@ let index_after_n chr n str =
 
 let find_all str sub =
   (* enumerator *)
-  let rec next r () =
+  let next r () =
     try
       let i = find_from str !r sub in
       r := i+1;

--- a/src/batText.ml
+++ b/src/batText.ml
@@ -279,7 +279,7 @@ module Iter = struct
 
   (* Advance the iterator to the next position, and return current
      character: *)
-  let rec next iter =
+  let next iter =
     if UTF8.ByteIndex.at_end iter.leaf iter.idx then
       (* We are at the end of the current leaf, find another one: *)
       match next_leaf iter.rest with
@@ -298,7 +298,7 @@ module Iter = struct
     end
 
   (* Same thing but map leafs: *)
-  let rec next_map f iter =
+  let next_map f iter =
     if UTF8.ByteIndex.at_end iter.leaf iter.idx then
       match next_leaf iter.rest with
       | None ->


### PR DESCRIPTION
all changes were extracted from
https://github.com/gasche/batteries-included.git#dune-preliminary-warnings