### PR TITLE
rm trailing semicolons (unnecessary)

### DIFF
--- a/src/batFormat.mliv
+++ b/src/batFormat.mliv
@@ -86,7 +86,7 @@ open BatIO
 
 (** {6 Boxes} *)
 
-val open_box : int -> unit;;
+val open_box : int -> unit
 (** [open_box d] opens a new pretty-printing box
     with offset [d].
     This box is the general purpose pretty-printing box.
@@ -98,41 +98,41 @@ val open_box : int -> unit;;
     When a new line is printed in the box, [d] is added to the
     current indentation. *)
 
-val close_box : unit -> unit;;
+val close_box : unit -> unit
 (** Closes the most recently opened pretty-printing box. *)
 
 (** {6 Formatting functions} *)
 
-val print_string : string -> unit;;
+val print_string : string -> unit
 (** [print_string str] prints [str] in the current box. *)
 
-val print_as : int -> string -> unit;;
+val print_as : int -> string -> unit
 (** [print_as len str] prints [str] in the
     current box. The pretty-printer formats [str] as if
     it were of length [len]. *)
 
-val print_int : int -> unit;;
+val print_int : int -> unit
 (** Prints an integer in the current box. *)
 
-val print_float : float -> unit;;
+val print_float : float -> unit
 (** Prints a floating point number in the current box. *)
 
-val print_char : char -> unit;;
+val print_char : char -> unit
 (** Prints a character in the current box. *)
 
-val print_bool : bool -> unit;;
+val print_bool : bool -> unit
 (** Prints a boolean in the current box. *)
 
 (** {6 Break hints} *)
 
-val print_space : unit -> unit;;
+val print_space : unit -> unit
 (** [print_space ()] is used to separate items (typically to print
     a space between two words).
     It indicates that the line may be split at this
     point. It either prints one space or splits the line.
     It is equivalent to [print_break 1 0]. *)
 
-val print_cut : unit -> unit;;
+val print_cut : unit -> unit
 (** [print_cut ()] is used to mark a good break position.
     It indicates that the line may be split at this
     point. It either prints nothing or splits the line.
@@ -140,7 +140,7 @@ val print_cut : unit -> unit;;
     point, without printing spaces or adding indentation.
     It is equivalent to [print_break 0 0]. *)
 
-val print_break : int -> int -> unit;;
+val print_break : int -> int -> unit
 (** Inserts a break hint in a pretty-printing box.
     [print_break nspaces offset] indicates that the line may
     be split (a newline character is printed) at this point,
@@ -150,25 +150,25 @@ val print_break : int -> int -> unit;;
     the current indentation. If the line is not split,
     [nspaces] spaces are printed. *)
 
-val print_flush : unit -> unit;;
+val print_flush : unit -> unit
 (** Flushes the pretty printer: all opened boxes are closed,
     and all pending text is displayed. *)
 
-val print_newline : unit -> unit;;
+val print_newline : unit -> unit
 (** Equivalent to [print_flush] followed by a new line. *)
 
-val force_newline : unit -> unit;;
+val force_newline : unit -> unit
 (** Forces a newline in the current box. Not the normal way of
     pretty-printing, you should prefer break hints. *)
 
-val print_if_newline : unit -> unit;;
+val print_if_newline : unit -> unit
 (** Executes the next formatting command if the preceding line
     has just been split. Otherwise, ignore the next formatting
     command. *)
 
 (** {6 Margin} *)
 
-val set_margin : int -> unit;;
+val set_margin : int -> unit
 (** [set_margin d] sets the value of the right margin
     to [d] (in characters): this value is used to detect line
     overflows that leads to split lines.
@@ -176,12 +176,12 @@ val set_margin : int -> unit;;
     If [d] is too large, the right margin is set to the maximum
     admissible value (which is greater than [10^10]). *)
 
-val get_margin : unit -> int;;
+val get_margin : unit -> int
 (** Returns the position of the right margin. *)
 
 (** {6 Maximum indentation limit} *)
 
-val set_max_indent : int -> unit;;
+val set_max_indent : int -> unit
 (** [set_max_indent d] sets the value of the maximum
     indentation limit to [d] (in characters):
     once this limit is reached, boxes are rejected to the left,
@@ -190,12 +190,12 @@ val set_max_indent : int -> unit;;
     If [d] is too large, the limit is set to the maximum
     admissible value (which is greater than [10^10]). *)
 
-val get_max_indent : unit -> int;;
+val get_max_indent : unit -> int
 (** Return the value of the maximum indentation limit (in characters). *)
 
 (** {6 Formatting depth: maximum number of boxes allowed before ellipsis} *)
 
-val set_max_boxes : int -> unit;;
+val set_max_boxes : int -> unit
 (** [set_max_boxes max] sets the maximum number
     of boxes simultaneously opened.
     Material inside boxes nested deeper is printed as an
@@ -203,20 +203,20 @@ val set_max_boxes : int -> unit;;
     [get_ellipsis_text ()]).
     Nothing happens if [max] is smaller than 2. *)
 
-val get_max_boxes : unit -> int;;
+val get_max_boxes : unit -> int
 (** Returns the maximum number of boxes allowed before ellipsis. *)
 
-val over_max_boxes : unit -> bool;;
+val over_max_boxes : unit -> bool
 (** Tests if the maximum number of boxes allowed have already been opened. *)
 
 (** {6 Advanced formatting} *)
 
-val open_hbox : unit -> unit;;
+val open_hbox : unit -> unit
 (** [open_hbox ()] opens a new pretty-printing box.
     This box is ``horizontal'': the line is not split in this box
     (new lines may still occur inside boxes nested deeper). *)
 
-val open_vbox : int -> unit;;
+val open_vbox : int -> unit
 (** [open_vbox d] opens a new pretty-printing box
     with offset [d].
     This box is ``vertical'': every break hint inside this
@@ -224,7 +224,7 @@ val open_vbox : int -> unit;;
     When a new line is printed in the box, [d] is added to the
     current indentation. *)
 
-val open_hvbox : int -> unit;;
+val open_hvbox : int -> unit
 (** [open_hvbox d] opens a new pretty-printing box
     with offset [d].
     This box is ``horizontal-vertical'': it behaves as an
@@ -233,7 +233,7 @@ val open_hvbox : int -> unit;;
     When a new line is printed in the box, [d] is added to the
     current indentation. *)
 
-val open_hovbox : int -> unit;;
+val open_hovbox : int -> unit
 (** [open_hovbox d] opens a new pretty-printing box
     with offset [d].
     This box is ``horizontal or vertical'': break hints
@@ -244,13 +244,13 @@ val open_hovbox : int -> unit;;
 
 (** {6 Tabulations} *)
 
-val open_tbox : unit -> unit;;
+val open_tbox : unit -> unit
 (** Opens a tabulation box. *)
 
-val close_tbox : unit -> unit;;
+val close_tbox : unit -> unit
 (** Closes the most recently opened tabulation box. *)
 
-val print_tbreak : int -> int -> unit;;
+val print_tbreak : int -> int -> unit
 (** Break hint in a tabulation box.
     [print_tbreak spaces offset] moves the insertion point to
     the next tabulation ([spaces] being added to this position).
@@ -262,24 +262,24 @@ val print_tbreak : int -> int -> unit;;
     If a new line is printed, [offset] is added to the current
     indentation. *)
 
-val set_tab : unit -> unit;;
+val set_tab : unit -> unit
 (** Sets a tabulation mark at the current insertion point. *)
 
-val print_tab : unit -> unit;;
+val print_tab : unit -> unit
 (** [print_tab ()] is equivalent to [print_tbreak 0 0]. *)
 
 (** {6 Ellipsis} *)
 
-val set_ellipsis_text : string -> unit;;
+val set_ellipsis_text : string -> unit
 (** Set the text of the ellipsis printed when too many boxes
     are opened (a single dot, [.], by default). *)
 
-val get_ellipsis_text : unit -> string;;
+val get_ellipsis_text : unit -> string
 (** Return the text of the ellipsis. *)
 
 (** {6:tags Semantics Tags} *)
 
-type tag = string;;
+type tag = string
 
 (** {i Semantics tags} (or simply {e tags}) are used to decorate printed
     entities for user's defined purposes, e.g. setting font and giving size
@@ -328,30 +328,35 @@ type tag = string;;
     Tag marking and tag printing functions are user definable and can
     be set by calling [set_formatter_tag_functions]. *)
 
-val open_tag : tag -> unit;;
+val open_tag : tag -> unit
 (** [open_tag t] opens the tag named [t]; the [print_open_tag]
     function of the formatter is called with [t] as argument;
     the tag marker [mark_open_tag t] will be flushed into the output
     device of the formatter. *)
-val close_tag : unit -> unit;;
+
+val close_tag : unit -> unit
 (** [close_tag ()] closes the most recently opened tag [t].
     In addition, the [print_close_tag] function of the formatter is called
     with [t] as argument. The marker [mark_close_tag t] will be flushed
     into the output device of the formatter. *)
 
-val set_tags : bool -> unit;;
+val set_tags : bool -> unit
 (** [set_tags b] turns on or off the treatment of tags (default is off). *)
-val set_print_tags : bool -> unit;;
-val set_mark_tags : bool -> unit;;
-(** [set_print_tags b] turns on or off the printing of tags, while
-    [set_mark_tags b] turns on or off the output of tag markers. *)
-val get_print_tags : unit -> bool;;
-val get_mark_tags : unit -> bool;;
+
+val set_print_tags : bool -> unit
+(** [set_print_tags b] turns on or off the printing of tags. *)
+
+val set_mark_tags : bool -> unit
+(** [set_mark_tags b] turns on or off the output of tag markers. *)
+
+val get_print_tags : unit -> bool
+
+val get_mark_tags : unit -> bool
 (** Return the current status of tags printing and tags marking. *)
 
 (** {6 Redirecting the standard formatter output} *)
 
-val set_formatter_output : 'a output -> unit;;
+val set_formatter_output : 'a output -> unit
 (** Sets the output of the formatter to the given argument *)
 
 val set_formatter_output_functions :
@@ -450,12 +455,12 @@ val set_formatter_tag_functions :
 
 val get_formatter_tag_functions :
   unit -> formatter_tag_functions
-;;
+
 (** Return the current tag functions of the pretty-printer. *)
 
 (** {6 Multiple formatted output} *)
 
-type formatter=Format.formatter;;
+type formatter=Format.formatter
 (** Abstract data corresponding to a pretty-printer (also called a
     formatter) and all its machinery.
 
@@ -473,34 +478,34 @@ type formatter=Format.formatter;;
     (convenient to output material to strings for instance).
 *)
 
-val std_formatter : formatter;;
+val std_formatter : formatter
 (** The standard formatter used by the formatting functions
     above. It is defined as [formatter_of_out_channel stdout]. *)
 
-val err_formatter : formatter;;
+val err_formatter : formatter
 (** A formatter to use with formatting functions below for
     output to standard error. It is defined as
     [formatter_of_out_channel stderr]. *)
 
-val formatter_of_output : _ output -> formatter;;
+val formatter_of_output : _ output -> formatter
 (** [formatter_of_output out] returns a new formatter that
     writes to the corresponding output [out]. *)
 
-val formatter_of_buffer : Buffer.t -> formatter;;
+val formatter_of_buffer : Buffer.t -> formatter
 (** [formatter_of_buffer b] returns a new formatter writing to
     buffer [b]. As usual, the formatter has to be flushed at
     the end of pretty printing, using [pp_print_flush] or
     [pp_print_newline], to display all the pending material. *)
 
-val stdbuf : Buffer.t;;
+val stdbuf : Buffer.t
 (** The string buffer in which [str_formatter] writes. *)
 
-val str_formatter : formatter;;
+val str_formatter : formatter
 (** A formatter to use with formatting functions below for
     output to the [stdbuf] string buffer.
     [str_formatter] is defined as [formatter_of_buffer stdbuf]. *)
 
-val flush_str_formatter : unit -> string;;
+val flush_str_formatter : unit -> string
 (** Returns the material printed with [str_formatter], flushes
     the formatter and resets the corresponding buffer. *)
 
@@ -514,47 +519,47 @@ val make_formatter :
 
 (** {6 Basic functions to use with formatters} *)
 
-val pp_open_hbox : formatter -> unit -> unit;;
-val pp_open_vbox : formatter -> int -> unit;;
-val pp_open_hvbox : formatter -> int -> unit;;
-val pp_open_hovbox : formatter -> int -> unit;;
-val pp_open_box : formatter -> int -> unit;;
-val pp_close_box : formatter -> unit -> unit;;
-val pp_open_tag : formatter -> string -> unit;;
-val pp_close_tag : formatter -> unit -> unit;;
-val pp_print_string : formatter -> string -> unit;;
-val pp_print_as : formatter -> int -> string -> unit;;
-val pp_print_int : formatter -> int -> unit;;
-val pp_print_float : formatter -> float -> unit;;
-val pp_print_char : formatter -> char -> unit;;
-val pp_print_bool : formatter -> bool -> unit;;
-val pp_print_break : formatter -> int -> int -> unit;;
-val pp_print_cut : formatter -> unit -> unit;;
-val pp_print_space : formatter -> unit -> unit;;
-val pp_force_newline : formatter -> unit -> unit;;
-val pp_print_flush : formatter -> unit -> unit;;
-val pp_print_newline : formatter -> unit -> unit;;
-val pp_print_if_newline : formatter -> unit -> unit;;
-val pp_open_tbox : formatter -> unit -> unit;;
-val pp_close_tbox : formatter -> unit -> unit;;
-val pp_print_tbreak : formatter -> int -> int -> unit;;
-val pp_set_tab : formatter -> unit -> unit;;
-val pp_print_tab : formatter -> unit -> unit;;
-val pp_set_tags : formatter -> bool -> unit;;
-val pp_set_print_tags : formatter -> bool -> unit;;
-val pp_set_mark_tags : formatter -> bool -> unit;;
-val pp_get_print_tags : formatter -> unit -> bool;;
-val pp_get_mark_tags : formatter -> unit -> bool;;
-val pp_set_margin : formatter -> int -> unit;;
-val pp_get_margin : formatter -> unit -> int;;
-val pp_set_max_indent : formatter -> int -> unit;;
-val pp_get_max_indent : formatter -> unit -> int;;
-val pp_set_max_boxes : formatter -> int -> unit;;
-val pp_get_max_boxes : formatter -> unit -> int;;
-val pp_over_max_boxes : formatter -> unit -> bool;;
-val pp_set_ellipsis_text : formatter -> string -> unit;;
-val pp_get_ellipsis_text : formatter -> unit -> string;;
-val pp_set_formatter_out_channel : formatter -> Pervasives.out_channel -> unit;;
+val pp_open_hbox : formatter -> unit -> unit
+val pp_open_vbox : formatter -> int -> unit
+val pp_open_hvbox : formatter -> int -> unit
+val pp_open_hovbox : formatter -> int -> unit
+val pp_open_box : formatter -> int -> unit
+val pp_close_box : formatter -> unit -> unit
+val pp_open_tag : formatter -> string -> unit
+val pp_close_tag : formatter -> unit -> unit
+val pp_print_string : formatter -> string -> unit
+val pp_print_as : formatter -> int -> string -> unit
+val pp_print_int : formatter -> int -> unit
+val pp_print_float : formatter -> float -> unit
+val pp_print_char : formatter -> char -> unit
+val pp_print_bool : formatter -> bool -> unit
+val pp_print_break : formatter -> int -> int -> unit
+val pp_print_cut : formatter -> unit -> unit
+val pp_print_space : formatter -> unit -> unit
+val pp_force_newline : formatter -> unit -> unit
+val pp_print_flush : formatter -> unit -> unit
+val pp_print_newline : formatter -> unit -> unit
+val pp_print_if_newline : formatter -> unit -> unit
+val pp_open_tbox : formatter -> unit -> unit
+val pp_close_tbox : formatter -> unit -> unit
+val pp_print_tbreak : formatter -> int -> int -> unit
+val pp_set_tab : formatter -> unit -> unit
+val pp_print_tab : formatter -> unit -> unit
+val pp_set_tags : formatter -> bool -> unit
+val pp_set_print_tags : formatter -> bool -> unit
+val pp_set_mark_tags : formatter -> bool -> unit
+val pp_get_print_tags : formatter -> unit -> bool
+val pp_get_mark_tags : formatter -> unit -> bool
+val pp_set_margin : formatter -> int -> unit
+val pp_get_margin : formatter -> unit -> int
+val pp_set_max_indent : formatter -> int -> unit
+val pp_get_max_indent : formatter -> unit -> int
+val pp_set_max_boxes : formatter -> int -> unit
+val pp_get_max_boxes : formatter -> unit -> int
+val pp_over_max_boxes : formatter -> unit -> bool
+val pp_set_ellipsis_text : formatter -> string -> unit
+val pp_get_ellipsis_text : formatter -> unit -> string
+val pp_set_formatter_out_channel : formatter -> Pervasives.out_channel -> unit
 val pp_set_formatter_output_functions :
   formatter -> (string -> int -> int -> unit) -> (unit -> unit) -> unit
 
@@ -602,7 +607,7 @@ val pp_print_text : formatter -> string -> unit
   
 (** {6 [printf] like functions for pretty-printing.} *)
 
-val fprintf : formatter -> ('a, formatter, unit) format -> 'a;;
+val fprintf : formatter -> ('a, formatter, unit) format -> 'a
 
 (** [fprintf ff fmt arg1 ... argN] formats the arguments [arg1] to [argN]
     according to the format string [fmt], and outputs the resulting string on
@@ -667,13 +672,13 @@ val fprintf : formatter -> ('a, formatter, unit) format -> 'a;;
     It prints [x = 1] within a pretty-printing box.
 *)
 
-val printf : ('a, formatter, unit) format -> 'a;;
+val printf : ('a, formatter, unit) format -> 'a
 (** Same as [fprintf] above, but output on [std_formatter]. *)
 
-val eprintf : ('a, formatter, unit) format -> 'a;;
+val eprintf : ('a, formatter, unit) format -> 'a
 (** Same as [fprintf] above, but output on [err_formatter]. *)
 
-val sprintf : ('a, unit, string) format -> 'a;;
+val sprintf : ('a, unit, string) format -> 'a
 (** Same as [printf] above, but instead of printing on a formatter,
     returns a string containing the result of formatting the arguments.
     Note that the pretty-printer queue is flushed at the end of {e each
@@ -688,14 +693,14 @@ val sprintf : ('a, unit, string) format -> 'a;;
     buffer of your own: flushing the formatter and the buffer at the end of
     pretty-printing returns the desired string. *)
 
-##V>=4.01##val asprintf : ('a, formatter, unit, string) format4 -> 'a;;
+##V>=4.01##val asprintf : ('a, formatter, unit, string) format4 -> 'a
 ##V>=4.01##(** Same as [printf] above, but instead of printing on a formatter, returns a
 ##V>=4.01##    string containing the result of formatting the arguments. The type of
 ##V>=4.01##    asprintf is general enough to interact nicely with [%a] conversions.
 ##V>=4.01##    @since 4.01.0
 ##V>=4.01##*)
 
-val ifprintf : formatter -> ('a, formatter, unit) format -> 'a;;
+val ifprintf : formatter -> ('a, formatter, unit) format -> 'a
 (** Same as [fprintf] above, but does not print anything.
     Useful to ignore some material when conditionally printing.
     @since 3.10.0
@@ -717,36 +722,36 @@ val ikfprintf : (formatter -> 'a) -> formatter ->
     @since 3.12.0
 *)
 
-val ksprintf : (string -> 'a) -> ('b, unit, string, 'a) format4 -> 'b;;
+val ksprintf : (string -> 'a) -> ('b, unit, string, 'a) format4 -> 'b
 (** Same as [sprintf] above, but instead of returning the string,
     passes it to the first argument. *)
 
 (** {6 Deprecated} *)
 
-val bprintf : Buffer.t -> ('a, formatter, unit) format -> 'a;;
+val bprintf : Buffer.t -> ('a, formatter, unit) format -> 'a
 (** A deprecated and error prone function. Do not use it.
 
     If you need to print to some buffer [b], you must first define a
     formatter writing to [b], using [let to_b = formatter_of_buffer b]; then
     use regular calls to [Format.fprintf] on formatter [to_b]. *)
 
-val kprintf : (string -> 'a) -> ('b, unit, string, 'a) format4 -> 'b;;
+val kprintf : (string -> 'a) -> ('b, unit, string, 'a) format4 -> 'b
 (** A deprecated synonym for [ksprintf]. *)
 
 
 (** {6 Basic functions to use with formatters} *)
 
-val pp_set_formatter_output      : formatter -> _ output -> unit;;
+val pp_set_formatter_output      : formatter -> _ output -> unit
 
 (** {6 Deprecated}*)
 
-val set_formatter_out_channel : _ output -> unit;;
+val set_formatter_out_channel : _ output -> unit
 (** Redirect the pretty-printer output to the given channel.
     (All the output functions of the standard formatter are set to the
      default output functions printing to the given channel.) *)
 
-val formatter_of_out_channel : _ output -> formatter;;
+val formatter_of_out_channel : _ output -> formatter
 (** [formatter_of_out_channel oc] returns a new formatter that
     writes to the corresponding channel [oc]. *)
 
-val pp_set_formatter_out_channel : formatter -> _ output -> unit;;
+val pp_set_formatter_out_channel : formatter -> _ output -> unit

--- a/src/batGc.mliv
+++ b/src/batGc.mliv
@@ -241,7 +241,7 @@ external set : control -> unit = "caml_gc_set"
 external minor : unit -> unit = "caml_gc_minor"
 (** Trigger a minor collection. *)
 
-external major_slice : int -> int = "caml_gc_major_slice";;
+external major_slice : int -> int = "caml_gc_major_slice"
 (** Do a minor collection and a slice of major collection.  The argument
     is the size of the slice, 0 to use the automatically-computed
     slice size.  In all cases, the result is the computed slice size. *)
@@ -363,7 +363,7 @@ val finalise : ('a -> unit) -> 'a -> unit
 ##V>=4.4##    @since 2.11.0 and OCaml 4.04
 ##V>=4.4##*)
 
-val finalise_release : unit -> unit;;
+val finalise_release : unit -> unit
 (** A finalisation function may call [finalise_release] to tell the
     GC that it can launch the next finalisation function without waiting
     for the current one to return. *)

--- a/src/batLexing.mliv
+++ b/src/batLexing.mliv
@@ -49,7 +49,7 @@ type position = Lexing.position = {
     how the lexing engine will manage positions.
 *)
 
-val dummy_pos : position;;
+val dummy_pos : position
 (** A value of type [position], guaranteed to be different from any
     valid position.
 *)

--- a/src/batRandom.mli
+++ b/src/batRandom.mli
@@ -175,7 +175,7 @@ module State : sig
           use (and update) the given PRNG state instead of the default one.
       *)
 
-end;;
+end
 
 
 val get_state : unit -> State.t

--- a/src/batScanf.mli
+++ b/src/batScanf.mli
@@ -90,7 +90,7 @@
 (** {6 Scanning buffers} *)
 module Scanning : sig
 
-  type scanbuf = Scanf.Scanning.scanbuf;;
+  type scanbuf = Scanf.Scanning.scanbuf
   (** The type of scanning buffers. A scanning buffer is the source from which a
       formatted input function gets characters. The scanning buffer holds the
       current state of the scan, plus a function to get the next char from the
@@ -101,7 +101,7 @@ module Scanning : sig
       it is stored back in the scanning buffer and becomes the next
       character read. *)
 
-  val stdib : scanbuf;;
+  val stdib : scanbuf
   (** The scanning buffer reading from [stdin].
       [stdib] is equivalent to [Scanning.from_input stdin].
 
@@ -110,13 +110,13 @@ module Scanning : sig
       specifications must properly skip this character (simply add a ['\n']
       as the last character of the format string). *)
 
-  val from_string : string -> scanbuf;;
+  val from_string : string -> scanbuf
   (** [Scanning.from_string s] returns a scanning buffer which reads from the
       given string.
       Reading starts from the first character in the string.
       The end-of-input condition is set when the end of the string is reached. *)
 
-  val from_file : string -> scanbuf;;
+  val from_file : string -> scanbuf
   (** Bufferized file reading in text mode. The efficient and usual
       way to scan text mode files (in effect, [from_file] returns a
       scanning buffer that reads characters in large chunks, rather than one
@@ -124,10 +124,10 @@ module Scanning : sig
       [Scanning.from_file fname] returns a scanning buffer which reads
       from the given file [fname] in text mode. *)
 
-  val from_file_bin : string -> scanbuf;;
+  val from_file_bin : string -> scanbuf
   (** Bufferized file reading in binary mode. *)
 
-  val from_function : (unit -> char) -> scanbuf;;
+  val from_function : (unit -> char) -> scanbuf
   (** [Scanning.from_function f] returns a scanning buffer with the given
       function as its reading method.
 
@@ -136,19 +136,19 @@ module Scanning : sig
       When the function has no more character to provide, it must signal an
       end-of-input condition by raising the exception [End_of_file]. *)
 
-  val from_input : BatIO.input -> scanbuf;;
+  val from_input : BatIO.input -> scanbuf
   (** [Scanning.from_input ic] returns a scanning buffer which reads from the
       input channel [ic], starting at the current reading position. *)
 
-  val end_of_input : scanbuf -> bool;;
+  val end_of_input : scanbuf -> bool
   (** [Scanning.end_of_input ib] tests the end-of-input condition of the given
       scanning buffer. *)
 
-  val beginning_of_input : scanbuf -> bool;;
+  val beginning_of_input : scanbuf -> bool
   (** [Scanning.beginning_of_input ib] tests the beginning of input condition of
       the given scanning buffer. *)
 
-  val name_of_input : scanbuf -> string;;
+  val name_of_input : scanbuf -> string
   (** [Scanning.name_of_input ib] returns the name of the character source
       for the scanning buffer [ib]. *)
 
@@ -156,16 +156,16 @@ module Scanning : sig
      {6 Obsolete}
   *)
 
-  val from_channel : BatIO.input -> scanbuf;;
+  val from_channel : BatIO.input -> scanbuf
   (** @obsolete use {!from_input}*)
 
 
-end;;
+end
 
 (** {6 Type of formatted input functions} *)
 
 type ('a, 'b, 'c, 'd) scanner =
-  ('a, Scanning.scanbuf, 'b, 'c, 'a -> 'd, 'd) format6 -> 'c;;
+  ('a, Scanning.scanbuf, 'b, 'c, 'a -> 'd, 'd) format6 -> 'c
 (** The type of formatted input scanners: [('a, 'b, 'c, 'd) scanner] is the
     type of a formatted input function that reads from some scanning buffer
     according to some format string; more precisely, if [scan] is some
@@ -184,13 +184,13 @@ type ('a, 'b, 'c, 'd) scanner =
     then [bscanf ib "%r;" read_elem f] reads a value [v] of type [t] followed
     by a [';'] character, and returns [f v]. *)
 
-exception Scan_failure of string;;
+exception Scan_failure of string
 (** The exception that formatted input functions raise when the input cannot be
     read according to the given format. *)
 
 (** {6 The general formatted input function} *)
 
-val bscanf : Scanning.scanbuf -> ('a, 'b, 'c, 'd) scanner;;
+val bscanf : Scanning.scanbuf -> ('a, 'b, 'c, 'd) scanner
 (** [bscanf ib fmt r1 ... rN f] reads arguments for the function [f], from the
     scanning buffer [ib], according to the format string [fmt], and applies [f]
     to these values.
@@ -381,7 +381,7 @@ val bscanf : Scanning.scanbuf -> ('a, 'b, 'c, 'd) scanner;;
 
 (** {6 Specialized formatted input functions} *)
 
-val fscanf : in_channel -> ('a, 'b, 'c, 'd) scanner;;
+val fscanf : in_channel -> ('a, 'b, 'c, 'd) scanner
 (** Same as {!Scanf.bscanf}, but reads from the given channel.
 
     Warning: since all formatted input functions operate from a scanning
@@ -394,16 +394,16 @@ val fscanf : in_channel -> ('a, 'b, 'c, 'd) scanner;;
     As a consequence, never mixt direct low level reading and high level
     scanning from the same input channel. *)
 
-val sscanf : string -> ('a, 'b, 'c, 'd) scanner;;
+val sscanf : string -> ('a, 'b, 'c, 'd) scanner
 (** Same as {!Scanf.bscanf}, but reads from the given string. *)
 
-val scanf : ('a, 'b, 'c, 'd) scanner;;
+val scanf : ('a, 'b, 'c, 'd) scanner
 (** Same as {!Scanf.bscanf}, but reads from the predefined scanning
     buffer {!Scanf.Scanning.stdib} that is connected to [stdin]. *)
 
 val kscanf :
   Scanning.scanbuf -> (Scanning.scanbuf -> exn -> 'd) ->
-  ('a, 'b, 'c, 'd) scanner;;
+  ('a, 'b, 'c, 'd) scanner
 (** Same as {!Scanf.bscanf}, but takes an additional function argument
     [ef] that is called in case of error: if the scanning process or
     some conversion fails, the scanning function aborts and calls the
@@ -414,7 +414,7 @@ val kscanf :
 
 val bscanf_format :
   Scanning.scanbuf -> ('a, 'b, 'c, 'd, 'e, 'f) format6 ->
-  (('a, 'b, 'c, 'd, 'e, 'f) format6 -> 'g) -> 'g;;
+  (('a, 'b, 'c, 'd, 'e, 'f) format6 -> 'g) -> 'g
 (** [bscanf_format ib fmt f] reads a format string token from the scanning
     buffer [ib], according to the given format string [fmt], and applies [f] to
     the resulting format string value.
@@ -423,12 +423,12 @@ val bscanf_format :
 
 val sscanf_format :
   string -> ('a, 'b, 'c, 'd, 'e, 'f) format6 ->
-  (('a, 'b, 'c, 'd, 'e, 'f) format6 -> 'g) -> 'g;;
+  (('a, 'b, 'c, 'd, 'e, 'f) format6 -> 'g) -> 'g
 (** Same as {!Scanf.bscanf_format}, but reads from the given string. *)
 
 val format_from_string :
   string ->
-  ('a, 'b, 'c, 'd, 'e, 'f) format6 -> ('a, 'b, 'c, 'd, 'e, 'f) format6;;
+  ('a, 'b, 'c, 'd, 'e, 'f) format6 -> ('a, 'b, 'c, 'd, 'e, 'f) format6
 (** [format_from_string s fmt] converts a string argument to a format string,
     according to the given format string [fmt].
     @raise Scan_failure if [s], considered as a format string, does not

--- a/src/batSys.mliv
+++ b/src/batSys.mliv
@@ -302,7 +302,7 @@ val catch_break : bool -> unit
     terminate the program on user interrupt. *)
 
 
-val ocaml_version : string;;
+val ocaml_version : string
 (** [ocaml_version] is the version of OCaml.
     It is a string of the form ["major.minor[.patchlevel][+additional-info]"],
     where [major], [minor], and [patchlevel] are integers, and


### PR DESCRIPTION
all changes were extracted from
https://github.com/gasche/batteries-included.git#dune-preliminary-warnings