### PR TITLE
Exceptionless extended with reduce, min and max functions

### DIFF
--- a/src/batList.mliv
+++ b/src/batList.mliv
@@ -1073,6 +1073,29 @@ module Exceptionless : sig
   val last : 'a list -> 'a option
     (** [last l] returns either [Some x] where [x] is the last element of the list, or [None] if
         the list is empty. This function takes linear time. *)
+
+  val reduce : ('a -> 'a -> 'a) -> 'a list -> 'a option
+  (** [reduce f h::t] is [Some (fold_left f h t)]
+      and [reduce f []] is None. *)
+
+  val min_max : ?cmp:('a -> 'a -> int) -> 'a list -> ('a * 'a) option
+  (** [min_max l] returns either Some(s, l)
+      where s and l are respectively the smallest and biggest element of [l] as judged by
+      [Pervasives.compare] (by default) or None if [l] is empty.
+	  You can provide another comparison function via the optional [cmp] parameter.
+  *)
+
+  val max : ?cmp:('a -> 'a -> int) -> 'a list -> 'a option
+  (** [max l] returns either [Some x] where [x] is the largest value of the list as judged by
+      [Pervasives.compare] (by default) or [None] is the list is empty.
+	  You can provide another comparison function via the optional [cmp] parameter.
+  *)
+
+  val min : ?cmp:('a -> 'a -> int) -> 'a list -> 'a option
+  (** [min l] returns either [Some x] where [x] is the smallest value of the list as judged by
+      [Pervasives.compare] or [None] is the list is empty.
+	  You can provide another comparison function via the optional [cmp] parameter.
+  *)
 end
 
 (** {6 Infix submodule regrouping all infix operators} *)

--- a/src/batList.mliv
+++ b/src/batList.mliv
@@ -308,15 +308,17 @@ val fold_left_map : ('a -> 'b -> 'a * 'c) -> 'a -> 'b list -> 'a * 'c list
     @since 2.6.0
 *)
 
-val max : 'a list -> 'a
+val max : ?cmp:('a -> 'a -> int) -> 'a list -> 'a
 (** [max l] returns the largest value in [l] as judged by
-    [Pervasives.compare].
+    [Pervasives.compare] (by default). You can provide another
+    comparison function via the optional [cmp] parameter.
     @raise Invalid_argument on an empty list.
 *)
 
-val min : 'a list -> 'a
+val min : ?cmp:('a -> 'a -> int) -> 'a list -> 'a
 (** [min l] returns the smallest value in [l] as judged by
-    [Pervasives.compare].
+    [Pervasives.compare] (by default). You can provide another
+    comparison function via the optional [cmp] parameter.
     @raise Invalid_argument on an empty list.
 *)
 

--- a/src/batList.mlv
+++ b/src/batList.mlv
@@ -1407,8 +1407,14 @@ let reduce f = function
   | h :: t ->
       fold_left f h t
 
-let min l = reduce Pervasives.min l
-let max l = reduce Pervasives.max l
+let min ?cmp:(cmp = Pervasives.compare) l =
+  let min = BatOrd.min_comp cmp in
+  reduce min l
+
+let max ?cmp:(cmp = Pervasives.compare) l =
+  let max = BatOrd.max_comp cmp in
+  reduce max l
+
 let sum l = fold_left (+) 0 l
 (*$= sum & ~printer:string_of_int
   2 (sum [1;1])

--- a/src/batList.mlv
+++ b/src/batList.mlv
@@ -1594,6 +1594,20 @@ module Exceptionless = struct
     | [] -> None
     | [x] -> Some x
     | _ :: l -> last l
+
+  let reduce f = function
+    | [] -> None
+    | h :: t -> Some (fold_left f h t)
+
+  let min_max ?cmp:(cmp = Pervasives.compare) l =
+    try Some (min_max ~cmp l) with Invalid_argument _ -> None
+
+  let min ?cmp:(cmp = Pervasives.compare) l =
+   Option.map (fun (min_elt, _) -> min_elt) @@ min_max ~cmp l
+
+  let max ?cmp:(cmp = Pervasives.compare) l =
+   Option.map (fun (_, max_elt) -> max_elt) @@ min_max ~cmp l
+
 end
 
 


### PR DESCRIPTION
So I added a few functions to the ExceptionLess modules (with the obvious semantics). Tell me if there is anything wrong with the implementation.
I also took the liberty to generalize a bit the standard min and max functions by adding a default cmp argument, so they are consistent with the current definition of min_max function. Tell me if you think this change is unneeded or unwanted (maybe an optional argument has some runtime cost ? I actually have no idea). I can also put them in a separate PR.

I also tried to add some unit test but failed to have them compiling. I added this in the ExceptionLess module : 
```
  (*$T max
    max [] = None
    max [1] = Some 1
    max [1; 1] = Some 1
    max [1; -2; 3; 4; 5; 60; 7; 8] = Some 60
  *)
```
but the compiler complained with : 
```
File "src/batList.mlv", line 1635, characters 14-20:
Error: This expression has type 'weak89 option
       but an expression was expected of type int
```

Could you tell me how to fix that ?
Thanks