### PR TITLE
Add covariances to types of maps and sets

### DIFF
--- a/src/batMap.mliv
+++ b/src/batMap.mliv
@@ -534,7 +534,7 @@ module String : S with type key = string
     function, it is recommended to use the functorized maps provided
     by {!Make}.  *)
 
-type ('a, 'b) t
+type (+'a, +'b) t
 
 val empty : ('a, 'b) t
 (** The empty map, using [compare] as key comparison function. *)
@@ -973,7 +973,7 @@ module PMap : sig
       functor for additional safety.
   *)
 
-  type ('a, 'b) t
+  type ('a, +'b) t
 
   val empty : ('a, 'b) t
   (** The empty map, using [compare] as key comparison function. *)

--- a/src/batSet.mli
+++ b/src/batSet.mli
@@ -516,7 +516,7 @@ module String : S with type elt = string
     @author David Rajchenbach-Teller
 *)
 
-type 'a t
+type +'a t
 (** The type of sets. *)
 
 include BatEnum.Enumerable with type 'a enumerable = 'a t


### PR DESCRIPTION
I added covariance annotations to types of maps and sets. I also tried to add some tests that check that this allows to pass the value restriction and get proper polymorphism instead of weak polymorphism.

Maybe some other types in other files can be annotated like that, I had a look but did not do an extensive search.