### PR TITLE
opam file: Fix constraint (uses QCheck_ounit) and add missing conflict with some compiler variants

### DIFF
--- a/batteries.opam
+++ b/batteries.opam
@@ -23,9 +23,13 @@ depends: [
   "ocamlfind" {build & >= "1.5.3"}
   "ocamlbuild" {build}
   "qtest" {with-test & >= "2.5"}
-  "qcheck" {with-test & >= "0.6" & < "0.14"}
+  "qcheck" {with-test & >= "0.9" & < "0.14"}
   "benchmark" {with-test & >= "1.6"}
   "num"
+]
+conflicts: [
+  "base-effects"
+  "ocaml-option-no-flat-float-array"
 ]
 # url {
 #   src: "https://github.com/ocaml-batteries-team/batteries-included/archive/vXXX.tar.gz"


### PR DESCRIPTION
Upstreams changes made in https://github.com/ocaml/opam-repository/pull/20225