### PR TITLE
Improved a bit the error when Random.choice is called on an empty enum

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,10 @@ Changelog
 
 ## v3.5.1 (minor release)
 
+- improved BatRandom.choice error a bit when passing an empty enum
+#1080
+ (Nicolas Tollenaere)
+
 - expose BatHashtbl.stats : ('a, 'b) t -> statistics
   #1079
   (Francois Berenger, request by Simmo Saan)

--- a/src/batRandom.mliv
+++ b/src/batRandom.mliv
@@ -124,6 +124,7 @@ val enum_char : unit -> char BatEnum.t
 val choice : 'a BatEnum.t -> 'a
 (** [choice e] returns a randomly-chosen element of [e].
 
+	@raise Empty when applied to an empty enum.
     This function only works on finite enumerations with
     less than 2{^30} elements.*)
 

--- a/src/batRandom.mlv
+++ b/src/batRandom.mlv
@@ -78,9 +78,10 @@ let enum_bool () = BatEnum.from bool
 let enum_char () = BatEnum.from char
 
 let choice e =
-  if BatEnum.is_empty e then raise Empty;
-  BatEnum.drop (int (BatEnum.count e)) e;
-  BatEnum.get_exn e
+if BatEnum.is_empty e
+then raise Empty
+else (BatEnum.drop (int (BatEnum.count e)) e;
+		BatEnum.get_exn e)
 
 (* Reservoir sampling algorithm (see for instance
    http://en.wikipedia.org/wiki/Reservoir_sampling)

--- a/src/batRandom.mlv
+++ b/src/batRandom.mlv
@@ -21,6 +21,7 @@
  *)
 
 
+exception Empty
 let init      = Random.init
 let full_init = Random.full_init
 let self_init = Random.self_init
@@ -76,7 +77,10 @@ let enum_nativeint bound = BatEnum.from (fun () -> nativeint bound)
 let enum_bool () = BatEnum.from bool
 let enum_char () = BatEnum.from char
 
-let choice e = BatEnum.drop (int (BatEnum.count e)) e; BatEnum.get_exn e
+let choice e =
+  if BatEnum.is_empty e then raise Empty;
+  BatEnum.drop (int (BatEnum.count e)) e;
+  BatEnum.get_exn e
 
 (* Reservoir sampling algorithm (see for instance
    http://en.wikipedia.org/wiki/Reservoir_sampling)


### PR DESCRIPTION
Hi,

Until now this piece of code : 
```ocaml
 Random.choice @@ Enum.empty ()
```
returned an Exception Invalid_argument "Random.int" which is confusing - the error happened in function Random.int to which we pass the invalid argument 0.
I changed it to raise an exception Empty instead - which matches what happens in similar cases in most other modules. I hope the error message will then be a bit more tractable.