### PR TITLE
Support new OCaml 5 unix primitive names

### DIFF
--- a/src/batUnix.mlv
+++ b/src/batUnix.mlv
@@ -23,7 +23,8 @@
 include Unix
 
 ##V<4.8##external link : string -> string -> unit = "unix_link"
-##V>=4.8##external link : ?follow:bool -> string -> string -> unit = "unix_link"
+##V>=4.8####V<5.0##external link : ?follow:bool -> string -> string -> unit = "unix_link"
+##V>=5.0##external link : ?follow:bool -> string -> string -> unit = "caml_unix_link"
 
 ##V<4.2##let write_substring = write
 ##V<4.2##let single_write_substring = single_write


### PR DESCRIPTION
The compiler is considering ensuring all symbols in the Unix library are prefixed `caml_` for 5.0 (https://github.com/ocaml/ocaml/pull/10926).

This affects batteries only for the `unix_link` primitive which is updated here. I couldn't see that there was a way to specify a range of versions for `##V` markers, so apologies for the slightly convoluted way of selecting between 3 different `external` declarations!