### PR TITLE
include doc & remove invliad CI links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Batteries
 
 * provides a consistent API for otherwise independent libraries.
 
-[![Build Status](http://ci.cedeela.fr/buildStatus/icon?job=batteries)](http://ci.cedeela.fr/job/batteries)
+[Documentation](https://ocaml-batteries-team.github.io/batteries-included/hdoc2/)
 
 Building Batteries
 ------------------


### PR DESCRIPTION
close https://github.com/ocaml-batteries-team/batteries-included/issues/1077 fix https://github.com/ocaml-batteries-team/batteries-included/issues/1077

The ci is inaccessible by public 