### PR TITLE
change the way OCaml5's Stdlib module is supported (replacing Pervasives)

### DIFF
--- a/src/batArray.mlv
+++ b/src/batArray.mlv
@@ -22,7 +22,11 @@
 
 include Array
 
-##V>=5## module Pervasives = Stdlib
+##V>=5##module Pervasives = Stdlib
+
+##V>=5##(*$inject
+##V>=5##  module Pervasives = Stdlib
+##V>=5##*)
 
 type 'a t = 'a array
 type 'a enumerable = 'a t

--- a/src/batArray.mlv
+++ b/src/batArray.mlv
@@ -22,6 +22,8 @@
 
 include Array
 
+##V>=5## module Pervasives = Stdlib
+
 type 'a t = 'a array
 type 'a enumerable = 'a t
 type 'a mappable = 'a t

--- a/src/batDigest.mlv
+++ b/src/batDigest.mlv
@@ -21,6 +21,10 @@
 
 include Digest
 
+##V>=5##(*$inject
+##V>=5##  module Pervasives = Stdlib
+##V>=5##*)
+
 (*Imported from [Digest.input] -- the functions used take advantage of
   [BatIO.input] rather than [in_channel]*)
 let input inp = BatIO.really_nread inp 16

--- a/src/batDynArray.mlv
+++ b/src/batDynArray.mlv
@@ -20,6 +20,8 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *)
 
+##V>=5##module Pervasives = Stdlib
+
 
 type resizer_t = currslots:int -> oldlength:int -> newlength:int -> int
 

--- a/src/batEnum.mlv
+++ b/src/batEnum.mlv
@@ -21,6 +21,10 @@
 
 ##V>=5##module Pervasives = Stdlib
 
+##V>=5##(*$inject
+##V>=5##  module Pervasives = Stdlib
+##V>=5##*)
+
 (** {6 Representation} *)
 
 type 'a t = {

--- a/src/batEnum.mlv
+++ b/src/batEnum.mlv
@@ -19,6 +19,8 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *)
 
+##V>=5##module Pervasives = Stdlib
+
 (** {6 Representation} *)
 
 type 'a t = {
@@ -1326,7 +1328,7 @@ let combination ?(repeat=false) n k =
     | []    -> acc
     | h::tl -> conv (range + 1) ((h - range) :: acc) tl
     in conv 0 []
-  
+
   in let order_to_comb n p repeat ord =
     let rec get_comb n p ord acc =
       if n <= 0 || p <= 0 || ord < 0 then acc
@@ -1339,31 +1341,31 @@ let combination ?(repeat=false) n k =
               get_comb (n - 1) p (ord - b) acc
       )
     in let result = get_comb n p ord []
-  
+
     in if repeat then
        add_repetitions result
     else
        result
 
   and p = if repeat then n + k -1 else n
-  in let length = binomial p k 
+  in let length = binomial p k
   in let rec make_comb index =
     make
       ~next:(fun () ->
         if !index = length then
           raise No_more_elements
         else
-          let next = order_to_comb p k repeat !index 
+          let next = order_to_comb p k repeat !index
           in incr index; next
       )
       ~count:(fun () -> length - !index)
       ~clone:(fun () -> make_comb (ref !index))
   in make_comb (ref 0)
-  
+
 (*$T combination
   (combination               3 3 |> count) = 1
   (combination ~repeat:true  3 3 |> count) = 10
-  (combination ~repeat:true 29 3 |> count) = 4495 
+  (combination ~repeat:true 29 3 |> count) = 4495
   (combination ~repeat:true  3 3 |> List.of_enum ) = \
     [  [3; 3; 3]; [3; 3; 2]; [3; 3; 1]; [3; 2; 2]; [3; 2; 1]; [3; 1; 1]; \
        [2; 2; 2]; [2; 2; 1]; [2; 1; 1]; \

--- a/src/batFile.ml
+++ b/src/batFile.ml
@@ -187,7 +187,7 @@ let open_temporary_out ?mode ?(prefix="ocaml") ?(suffix="tmp") ?temp_dir () : (_
   let out          = output_channel ~cleanup:true cout   in
   (match mode with
    | Some l when List.mem `delete_on_exit l ->
-     Pervasives.at_exit (fun () ->
+     at_exit (fun () ->
        try
          BatIO.close_out out;
          Sys.remove name

--- a/src/batFloat.mliv
+++ b/src/batFloat.mliv
@@ -19,7 +19,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *)
 
-
+##V>=5##module Pervasives := Stdlib
 
 (**Operations on floating-point numbers.
 

--- a/src/batFloat.mlv
+++ b/src/batFloat.mlv
@@ -23,6 +23,10 @@ open BatNumber
 
 ##V>=5##module Pervasives = Stdlib
 
+##V>=5##(*$inject
+##V>=5##  module Pervasives = Stdlib
+##V>=5##*)
+
 module BaseFloat = struct
   type t = float
   let zero, one = 0., 1.

--- a/src/batFloat.mlv
+++ b/src/batFloat.mlv
@@ -21,6 +21,8 @@
 
 open BatNumber
 
+##V>=5##module Pervasives = Stdlib
+
 module BaseFloat = struct
   type t = float
   let zero, one = 0., 1.

--- a/src/batFormat.mliv
+++ b/src/batFormat.mliv
@@ -21,6 +21,8 @@
 
 open BatIO
 
+##V>=5## module Pervasives := Stdlib
+
 (** Pretty printing.
 
     This module implements a pretty-printing facility to format text

--- a/src/batHashcons.mlv
+++ b/src/batHashcons.mlv
@@ -29,6 +29,8 @@ module Sys = BatSys
 module Hashtbl = BatHashtbl
 module Array = BatArray
 
+##V>=5##module Pervasives = Stdlib
+
 type 'a hobj = {
   obj   : 'a ;
   tag   : int ;

--- a/src/batHeap.ml
+++ b/src/batHeap.ml
@@ -18,7 +18,11 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *)
 
-let min x y = if Pervasives.compare x y <= 0 then x else y
+let min x y =
+  if x <= y then
+    x
+  else
+    y
 
 (** binomial trees *)
 type 'a bt = {
@@ -40,7 +44,7 @@ let size bh = bh.size
 let link bt1 bt2 =
   assert (bt1.rank = bt2.rank) ;
   let rank = bt1.rank + 1 in
-  let leq = Pervasives.compare bt1.root bt2.root <= 0 in
+  let leq = bt1.root <= bt2.root in
   let root = if leq then bt1.root else bt2.root in
   let kids = if leq then bt2 :: bt1.kids else bt1 :: bt2.kids in
   { rank = rank ; root = root ; kids = kids }
@@ -115,7 +119,7 @@ let rec find_min_tree ts ~kfail ~ksuccess =
         ksuccess t
     | t :: ts ->
         find_min_tree ts ~kfail ~ksuccess:(fun u ->
-          if Pervasives.compare t.root u.root <= 0 then
+          if t.root <= u.root then
             ksuccess t
           else
             ksuccess u)
@@ -128,7 +132,7 @@ let rec del_min_tree bts ~kfail ~ksuccess =
         ksuccess t []
     | t :: ts ->
         del_min_tree ts ~kfail ~ksuccess:(fun u uts ->
-          if Pervasives.compare t.root u.root <= 0 then
+          if t.root <= u.root then
             ksuccess t ts
           else
             ksuccess u (t :: uts))

--- a/src/batHeap.ml
+++ b/src/batHeap.ml
@@ -168,7 +168,7 @@ let to_list bh =
 *)
 
 (*$Q to_list ; insert ; empty
-   (Q.list Q.int) ~count:10 (fun l -> to_list (List.fold_left insert empty l) = List.sort Pervasives.compare l)
+   (Q.list Q.int) ~count:10 (fun l -> to_list (List.fold_left insert empty l) = List.sort compare l)
 *)
 
 let elems = to_list

--- a/src/batIO.ml
+++ b/src/batIO.ml
@@ -713,7 +713,7 @@ let to_input_channel inp =
     let out          = output_channel cout                    in
     copy inp out;
     close_out out;
-    Pervasives.open_in_bin name
+    open_in_bin name
 
 
 

--- a/src/batInnerIO.mlv
+++ b/src/batInnerIO.mlv
@@ -20,6 +20,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *)
 
+##V>=5##module Pervasives = Stdlib
 
 type 'a weak_set = ('a, unit) BatInnerWeaktbl.t
 let weak_create size     = BatInnerWeaktbl.create size

--- a/src/batInnerShuffle.ml
+++ b/src/batInnerShuffle.ml
@@ -15,8 +15,8 @@ let array_shuffle ?state a =
   Q.(array_of_size Gen.(2--15) small_int) (fun a -> \
     let a' = Array.copy a in \
     array_shuffle a'; \
-    (Array.to_list a' |> List.sort Pervasives.compare) = \
-     (Array.to_list a |> List.sort Pervasives.compare))
+    (Array.to_list a' |> List.sort BatInt.compare) = \
+     (Array.to_list a |> List.sort BatInt.compare))
 *)
 
 (*$R

--- a/src/batInt.ml
+++ b/src/batInt.ml
@@ -227,12 +227,12 @@ module BaseSafeInt = struct
       operators with their safe counterparts *)
 
   let add a b =
-    let c = Pervasives.( + ) a b in
+    let c = a + b in
     if a < 0 && b < 0 && c >= 0 || a > 0 && b > 0 && c <= 0 then raise Overflow
     else c
 
   let sub a b =
-    let c = Pervasives.( - ) a b in
+    let c = a - b in
     if a < 0 && b > 0 && c >= 0 || a > 0 && b < 0 && c <= 0 then raise Overflow
     else c
 
@@ -256,7 +256,7 @@ module BaseSafeInt = struct
   (* Uses a formula taken from Hacker's Delight, chapter "Overflow Detection",
      plus a fast-path check (see comment above) *)
   let mul (a: int) (b: int) : int =
-    let open Pervasives in
+    (* let open Pervasives in *)
     let c = a * b in
     if (a lor b) asr mul_shift_bits = 0
     || not ((a = min_int && b < 0) || (b <> 0 && c / b <> a)) then

--- a/src/batInt.mlv
+++ b/src/batInt.mlv
@@ -19,6 +19,11 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *)
 
+##V>=5##module Pervasives = Stdlib
+
+##V>=5##(*$inject
+##V>=5##  module Pervasives = Stdlib
+##V>=5##*)
 
 open BatNumber
 

--- a/src/batInt32.mlv
+++ b/src/batInt32.mlv
@@ -28,7 +28,7 @@ let to_byte n = Int32.logand 0xffl n |> Int32.to_int |> Char.chr
 let of_byte b = Char.code b |> Int32.of_int
 
 (*$Q to_byte; of_byte
-  Q.char (fun c -> Pervasives.(=) (to_byte (of_byte c)) c)
+  Q.char (fun c -> to_byte (of_byte c) = c)
 *)
 
 (*$T to_byte

--- a/src/batLazyList.mlv
+++ b/src/batLazyList.mlv
@@ -20,6 +20,10 @@
 
 ##V>=5##module Pervasives = Stdlib
 
+##V>=5##(*$inject
+##V>=5##  module Pervasives = Stdlib
+##V>=5##*)
+
 (** {6 Exceptions} *)
 
 exception No_more_elements

--- a/src/batLazyList.mlv
+++ b/src/batLazyList.mlv
@@ -18,6 +18,8 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *)
 
+##V>=5##module Pervasives = Stdlib
+
 (** {6 Exceptions} *)
 
 exception No_more_elements

--- a/src/batList.mliv
+++ b/src/batList.mliv
@@ -21,6 +21,8 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *)
 
+##V>=5##module Pervasives := Stdlib
+
 (** Additional and modified functions for lists.
 
     The OCaml standard library provides a module for list functions.

--- a/src/batList.mlv
+++ b/src/batList.mlv
@@ -21,6 +21,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *)
 
+##V>=5##module Pervasives = Stdlib
 
 (* ::VH:: GLUE with StdLib *)
 let merge = List.merge

--- a/src/batList.mlv
+++ b/src/batList.mlv
@@ -23,6 +23,10 @@
 
 ##V>=5##module Pervasives = Stdlib
 
+##V>=5##(*$inject
+##V>=5##  module Pervasives = Stdlib
+##V>=5##*)
+
 (* ::VH:: GLUE with StdLib *)
 let merge = List.merge
 let fast_sort = List.fast_sort

--- a/src/batLog.mli
+++ b/src/batLog.mli
@@ -67,7 +67,7 @@ val log : ?fp:string -> string -> unit
 
     @since 2.0; was [printf] in 1.x
 *)
-val logf: ?fp:string -> ('a, unit output, unit) Pervasives.format -> 'a
+val logf: ?fp:string -> ('a, unit output, unit) format -> 'a
 
 (** [fatal s] logs the message [s] and then calls [exit 1].  This
     exits the program with return code 1.  *)
@@ -76,7 +76,7 @@ val fatal : ?fp:string -> string -> 'a
 (** [fatalf] allows a format string (as [Printf.printf])and the
     arguments to that format string to build the logging message.
     Exits the program with return code 1. *)
-val fatalf: ?fp:string -> ('a, unit output, unit) Pervasives.format -> 'a
+val fatalf: ?fp:string -> ('a, unit output, unit) format -> 'a
 
 module type Config = sig
   type t
@@ -93,7 +93,7 @@ module Make (S:Config) : sig
   (** As [Printf.printf], only the message is printed to the logging
       output and prefixed with status information per the current flags and
       the currently set prefix. *)
-  val logf: ?fp:string -> ('a, S.t output, unit) Pervasives.format -> 'a
+  val logf: ?fp:string -> ('a, S.t output, unit) format -> 'a
 
   (** [fatal s] logs the message [s] and then calls [exit 1].  This
       exits the program with return code 1.  *)
@@ -102,7 +102,7 @@ module Make (S:Config) : sig
   (** [fatalf] allows a format string (as [Printf.printf])and the
       arguments to that format string to build the logging message.
       Exits the program with return code 1. *)
-  val fatalf: ?fp:string -> ('a, S.t output, unit) Pervasives.format -> 'a
+  val fatalf: ?fp:string -> ('a, S.t output, unit) format -> 'a
 
 end
 

--- a/src/batMap.mliv
+++ b/src/batMap.mliv
@@ -19,6 +19,8 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *)
 
+##V>=5##module Pervasives := Stdlib
+
 (** Association tables over ordered types.
 
     This module implements applicative association tables, also known as

--- a/src/batMap.mlv
+++ b/src/batMap.mlv
@@ -20,6 +20,8 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *)
 
+##V>=5##module Pervasives = Stdlib
+
 (* A concrete implementation for the direct balanced maps structure,
    without carrying the ordering information with the data.
 

--- a/src/batMap.mlv
+++ b/src/batMap.mlv
@@ -22,6 +22,10 @@
 
 ##V>=5##module Pervasives = Stdlib
 
+##V>=5##(*$inject
+##V>=5##  module Pervasives = Stdlib
+##V>=5##*)
+
 (* A concrete implementation for the direct balanced maps structure,
    without carrying the ordering information with the data.
 

--- a/src/batOption.mlv
+++ b/src/batOption.mlv
@@ -19,7 +19,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *)
 
-##V<=5##module Pervasives = Stdlib
+##V>=5##module Pervasives = Stdlib
 
 type 'a t = 'a option
 

--- a/src/batOption.mlv
+++ b/src/batOption.mlv
@@ -19,6 +19,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *)
 
+##V<=5##module Pervasives = Stdlib
 
 type 'a t = 'a option
 

--- a/src/batOrd.mlv
+++ b/src/batOrd.mlv
@@ -1,3 +1,6 @@
+
+##V>=5##module Pervasives = Stdlib
+
 type order = Lt | Eq | Gt
 
 type 'a comp = 'a -> 'a -> int

--- a/src/batPervasives.mliv
+++ b/src/batPervasives.mliv
@@ -31,6 +31,8 @@
 
 open BatIO
 
+##V>=5## module Pervasives := Stdlib
+
 (** The initially opened module.
 
     This module provides the basic operations over the built-in types

--- a/src/batPervasives.mlv
+++ b/src/batPervasives.mlv
@@ -22,7 +22,8 @@
  *)
 
 
-open Pervasives
+##V<5##open Pervasives
+##V>=5##open Stdlib
 open BatEnum
 
 let input_lines ch =

--- a/src/batPrintf.mliv
+++ b/src/batPrintf.mliv
@@ -20,6 +20,8 @@
 
 open BatInnerIO
 
+##V>=5## module Pervasives := Stdlib
+
 (** Formatted output functions (also known as unparsing).
 
     @author Xavier Leroy

--- a/src/batPrintf.mlv
+++ b/src/batPrintf.mlv
@@ -509,7 +509,7 @@ let bprintf2 buf fmt = kbprintf2 ignore buf fmt
     mkprintf ignore out fmt
    ]*)
 
-type ('a, 'b, 'c) t = ('a, 'b, 'c) Pervasives.format
+type ('a, 'b, 'c) t = ('a, 'b, 'c) format
 
 let kfprintf        = mkprintf
 let bprintf         = Printf.bprintf

--- a/src/batSeq.mlv
+++ b/src/batSeq.mlv
@@ -18,6 +18,8 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *)
 
+##V>=5##module Pervasives = Stdlib
+
 type 'a node =
 ##V>=4.7## 'a Stdlib.Seq.node =
   | Nil

--- a/src/batSet.mlv
+++ b/src/batSet.mlv
@@ -19,7 +19,11 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *)
 
-##V>=5## module Pervasives = Stdlib
+##V>=5##module Pervasives = Stdlib
+
+##V>=5##(*$inject
+##V>=5##  module Pervasives = Stdlib
+##V>=5##*)
 
 module type OrderedType = BatInterfaces.OrderedType
 (** Input signature of the functor {!Set.Make}. *)

--- a/src/batSet.mlv
+++ b/src/batSet.mlv
@@ -19,6 +19,8 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *)
 
+##V>=5## module Pervasives = Stdlib
+
 module type OrderedType = BatInterfaces.OrderedType
 (** Input signature of the functor {!Set.Make}. *)
 

--- a/src/batTuple.mlv
+++ b/src/batTuple.mlv
@@ -20,6 +20,8 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *)
 
+##V>=5##module Pervasives = Stdlib
+
 module Tuple2 = struct
   type ('a,'b) t = 'a * 'b
 

--- a/src/batUnix.mlv
+++ b/src/batUnix.mlv
@@ -19,6 +19,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *)
 
+##V>=5##module Pervasives = Stdlib
 
 include Unix
 

--- a/src/batteries.mlv
+++ b/src/batteries.mlv
@@ -1,7 +1,8 @@
 (* open this to extend all Foo with BatFoo *)
 
 module Legacy = struct
-  include Pervasives
+##V<5##  include Pervasives
+##V>=5##  include Stdlib
   module Arg = Arg
   module Array = Array
   module ArrayLabels = ArrayLabels

--- a/src/pervasives.mlv
+++ b/src/pervasives.mlv
@@ -1,3 +1,0 @@
-
-##V<5## include Pervasives
-##V>=5## include Stdlib

--- a/testsuite/test_digest.ml
+++ b/testsuite/test_digest.ml
@@ -3,9 +3,9 @@ open OUnit
 (*1. Compute the digest of this file using Legacy.Digest*)
 
 let legacy_result () =
-  let inp    = Pervasives.open_in_bin Sys.argv.(0) in
+  let inp    = open_in_bin Sys.argv.(0) in
   let result = Digest.channel inp (-1) in
-    Pervasives.close_in inp;
+    close_in inp;
     result
 
 (*2. Compute the digest of this file using Batteries.Digest*)

--- a/testsuite/test_file.ml
+++ b/testsuite/test_file.ml
@@ -23,7 +23,7 @@ let read_mmap    name =
 
 let temp_file ?(autoclean = true) pref suff =
   let tf = Filename.temp_file pref suff in
-  if autoclean then Pervasives.at_exit (fun () -> try Unix.unlink tf with _ -> ()) ;
+  if autoclean then at_exit (fun () -> try Unix.unlink tf with _ -> ()) ;
   tf
 
 (**Actual tests*)
@@ -108,10 +108,10 @@ let test_append () =
 
 let test_lines_of () =
   let file_lines_of fn =
-    let ic = Pervasives.open_in fn in
+    let ic = open_in fn in
     BatEnum.suffix_action
-      (fun () -> Pervasives.close_in ic)
-      (BatEnum.from (fun () -> try Pervasives.input_line ic with End_of_file -> raise BatEnum.No_more_elements))
+      (fun () -> close_in ic)
+      (BatEnum.from (fun () -> try input_line ic with End_of_file -> raise BatEnum.No_more_elements))
   in
   try
     let open Batteries in


### PR DESCRIPTION
I try to not put all files under pre-processing to minimize the change.
The previous way it was managed was not compiling for ocaml<5.