### PR TITLE
Fix compilation on OCaml 5.0.0~beta1

### DIFF
--- a/src/batBytes.mliv
+++ b/src/batBytes.mliv
@@ -766,3 +766,5 @@ let s = Bytes.of_string "hello"
 ##V>=4.4##external unsafe_fill:  t -> int -> int -> char -> unit = "caml_fill_bytes" [@@noalloc]
 
 ##V>=4.09##external unsafe_blit_string : string -> int -> t -> int -> int -> unit = "caml_blit_string" [@@noalloc]
+
+##V>=5.0##val unsafe_escape : bytes -> bytes

--- a/src/batPrintexc.mliv
+++ b/src/batPrintexc.mliv
@@ -416,3 +416,12 @@ val print : _ BatInnerIO.output -> exn -> unit
 ##V>=4.12##
 ##V>=4.12##    @since 3.3.0 and 4.12
 ##V>=4.12##*)
+
+(**/**)
+
+(**  {1 Obj printer}
+  Unsafe printer used in this module and exposed to the other standard library
+   module
+*)
+
+##V>=5.0##val string_of_extension_constructor: Obj.t -> string


### PR DESCRIPTION
Two functions were added since the alpha release in https://github.com/ocaml/ocaml/pull/11423 and https://github.com/ocaml/ocaml/pull/11509.
This fixes compatibility test compilation:
```
+ ocamlfind ocamlc -c -g -annot -bin-annot -safe-string -no-alias-deps -strict-sequence -w -3 -w -29 -package num,str,camlp-streams,unix -warn-error -50 -package bytes -I src -I qtest -I benchsuite -I toplevel -I build -I testsuite -I benchsuite/lib -o src/batteries_compattest.cmo src/batteries_compattest.ml
File "src/batteries_compattest.ml", line 13, characters 18-23:
13 |   module Bytes = (Bytes : module type of Legacy.Bytes)
                       ^^^^^
Error: Signature mismatch:
       ...
       The value `unsafe_escape' is required but not provided
       File "bytes.mli", line 757, characters 0-34: Expected declaration
Command exited with code 2.
Compilation unsuccessful after building 203 targets (201 cached) in 00:00:00.
```
```
+ ocamlfind ocamlc -c -warn-error +26 -g -annot -bin-annot -safe-string -no-alias-deps -strict-sequence -w -3 -w -29 -package num,str,camlp-streams,unix -warn-error -50 -package bytes -package oUnit,qcheck -I src -I qtest -I benchsuite -I toplevel -I build -I testsuite -I benchsuite/lib -o src/batteries_compattest.cmo src/batteries_compattest.ml
File "src/batteries_compattest.ml", line 58, characters 5-13:
58 |     (Printexc: sig
          ^^^^^^^^
Error: Signature mismatch:
       ...
       The value `string_of_extension_constructor' is required but not provided
       File "printexc.mli", line 421, characters 0-52: Expected declaration
Command exited with code 2.
Compilation unsuccessful after building 227 targets (32 cached) in 00:00:04.
```