### PR TITLE
Fix Pervasives in make doc

### DIFF
--- a/src/batteries.mllib
+++ b/src/batteries.mllib
@@ -92,4 +92,3 @@ BatInnerPervasives
   Batteries
   BatteriesExceptionless
   Extlib
-  Pervasives


### PR DESCRIPTION
Closes #1096.

It was first added in #1086 and mostly undone in #1087. This single entry was forgotten and `make doc` looks up this list.