### PR TITLE
Fixes to allow batteries to be vendored in other packages

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -4,7 +4,7 @@
  (synopsis "A community-maintained standard library extension")
  (modules (:standard \ ("batteries_compattest" batteriesThread batRMutex batMutex)))
  (preprocess
-  (action (run build/prefilter.exe %{input-file})))
+  (action (run %{project_root}/build/prefilter.exe %{input-file})))
  (flags (:standard -w -3-32-52))
  (libraries num str camlp-streams unix)
  (inline_tests

--- a/src/dune
+++ b/src/dune
@@ -1,18 +1,24 @@
 (library
- (name batteries)
- (public_name batteries)
+ (name batteries_unthreaded)
+ (public_name batteries.unthreaded)
  (synopsis "A community-maintained standard library extension")
- (modules (:standard \ batteries_compattest))
+ (modules (:standard \ ("batteries_compattest" batteriesThread batRMutex batMutex)))
  (preprocess
   (action (run build/prefilter.exe %{input-file})))
  (flags (:standard -w -3-32-52))
- (libraries num str camlp-streams threads)
+ (libraries num str camlp-streams unix)
  (inline_tests
    (backend qtest_batteries)
    (deps %{project_root}/qtest/qtest_preamble.ml)
  )
  (wrapped false)
 )
+
+(library
+ (public_name batteries)
+ (libraries batteries.unthreaded threads)
+ (modules batteriesThread batRMutex batMutex)
+ (wrapped false))
 
 (rule
   (action (copy# batConcreteQueue_402.ml batConcreteQueue.ml))


### PR DESCRIPTION
This fixes two problems I ran into when trying to use opam-monorepo to vendor batteries inside a monorepo project.