### PR TITLE
Expose batteries.top library via dune and other dune library changes

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,8 +1,8 @@
 (library
  (name batteries_unthreaded)
  (public_name batteries.unthreaded)
- (synopsis "A community-maintained standard library extension")
- (modules (:standard \ ("batteries_compattest" batteriesThread batRMutex batMutex)))
+ (synopsis "Batteries Included (for use in unthreaded programs)")
+ (modules (:standard \ batteries_compattest batteriesThread batRMutex batMutex))
  (preprocess
   (action (run %{project_root}/build/prefilter.exe %{input-file})))
  (flags (:standard -w -3-32-52))
@@ -15,10 +15,20 @@
 )
 
 (library
+ (name batteries)
  (public_name batteries)
- (libraries batteries.unthreaded threads)
+ (synopsis "Batteries Included is a community-maintained standard library extension")
  (modules batteriesThread batRMutex batMutex)
- (wrapped false))
+ (preprocess
+  (action (run %{project_root}/build/prefilter.exe %{input-file})))
+ (flags (:standard -w -3-32-52))
+ (libraries batteries.unthreaded threads)
+ (inline_tests
+   (backend qtest_batteries)
+   (deps %{project_root}/qtest/qtest_preamble.ml)
+ )
+ (wrapped false)
+)
 
 (rule
   (action (copy# batConcreteQueue_402.ml batConcreteQueue.ml))

--- a/src/dune
+++ b/src/dune
@@ -58,7 +58,7 @@
  (name batteries_compattest)
  (modules batteries_compattest)
  (preprocess
-  (action (run build/prefilter.exe %{input-file})))
+  (action (run %{project_root}/build/prefilter.exe %{input-file})))
  (libraries batteries))
 
 ; documentation works!

--- a/toplevel/dune
+++ b/toplevel/dune
@@ -1,5 +1,6 @@
 (library
- (name batteries_toplevel)
+ (name batteries_top)
+ (public_name batteries.top)
  (synopsis "Bytecode toplevel support for Batteries")
  (libraries num threads str compiler-libs batteries)
  (modules batteriesHelp)


### PR DESCRIPTION
#1104 did the unthreaded vs threaded library split in dune, which I had also planned on. But here's a few extra changes to polish the setup.

### Changes
1. Expose batteries.top library. This is currently different from the ocamlbuild setup, but it's not possible to have dune produce special `toploop` stuff into `META` automatically. Also, many other libraries have a top sublibrary, so it's a sensible pattern to go for.
2. Use prefilter and qtest also for threaded batteries in dune (#1104).
4. Use current `META.in` descriptions for dune libraries. Just to get the dune build as close to the ocamlbuild one.
5. Fix prefilter path in `batteries_compattest` a la #1104.