### PR TITLE
Use '=' for the underline in the changelog title

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,5 @@
 Changelog
----------
+=========
 
 ## NEXT_RELEASE
 


### PR DESCRIPTION
Using '-' for underines in markdown is equilavent to a H2 heading. Since all the version headings in the changelog use the prefix '##', also H2, they appear at the same level as the title. This confuses the dune-release program which expects the title to be a lower heading level than the rest of the file. Underlines made of `=` are H1 headings.