### PR TITLE
Add Simmo Saan to maintainers, remove ocamlbuild CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,66 +6,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    strategy:
-      fail-fast: false
-
-      matrix:
-        os:
-          - ubuntu-latest
-        ocaml-compiler:
-          - 5.0.0
-          - 4.14.x
-          - 4.13.x
-          - 4.12.x
-          - 4.11.x
-          - 4.10.x
-          - 4.09.x
-          - 4.08.x
-          - 4.07.x
-          - 4.06.x
-          - 4.05.x
-          - 4.04.x
-          - 4.03.x
-        test:
-          - true
-
-        include:
-          - os: ubuntu-latest
-            ocaml-compiler: 4.02.3
-            test: false
-          - os: macos-latest
-            ocaml-compiler: 4.14.x
-            test: true
-          - os: macos-latest
-            ocaml-compiler: 5.0.0
-            test: true
-
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Set up OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2
-        with:
-          ocaml-compiler: ${{ matrix.ocaml-compiler }}
-
-      - name: Install dependencies
-        run: opam install . --deps-only
-
-      - name: Install test dependencies
-        if: ${{ matrix.test }}
-        run: opam install . --deps-only --with-test
-
-      - name: Build
-        run: opam exec -- make all
-
-      - name: Test
-        if: ${{ matrix.test }}
-        run: opam exec -- make test
-
   build-dune:
     strategy:
       fail-fast: false

--- a/batteries.opam
+++ b/batteries.opam
@@ -6,6 +6,7 @@ maintainer: [
   "Francois Berenger <unixjunkie@sdf.org>"
   "Gabriel Scherer <gabriel.scherer@gmail.com>"
   "Thibault Suzanne <thi.suzanne@gmail.com>"
+  "Simmo Saan <simmo.saan@gmail.com>"
 ]
 authors: ["OCaml batteries-included team"]
 license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"

--- a/dune-project
+++ b/dune-project
@@ -12,7 +12,8 @@
  "Cedric Cellier <rixed@happyleptic.org>"
  "Francois Berenger <unixjunkie@sdf.org>"
  "Gabriel Scherer <gabriel.scherer@gmail.com>"
- "Thibault Suzanne <thi.suzanne@gmail.com>")
+ "Thibault Suzanne <thi.suzanne@gmail.com>"
+ "Simmo Saan <simmo.saan@gmail.com>")
 (license "LGPL-2.1-or-later with OCaml-LGPL-linking-exception")
 
 (package


### PR DESCRIPTION
Small follow-up to #1109.

The CI job with `make` is failing because the ocamlbuild dependency is no longer declared and installed. Once I get fully rid of ocamlbuild stuff, we could have a much smaller Makefile that just does respective dune calls.