### PR TITLE
BatString: fix possible stack overflow on split_on_string_comp

### DIFF
--- a/src/batString.mlv
+++ b/src/batString.mlv
@@ -343,6 +343,16 @@ let tail s pos =
   let slen = length s in
   if pos >= slen then "" else sub s pos (slen - pos)
 
+let repeat s n =
+  let buf = Buffer.create ( n * (String.length s) ) in
+  for _i = 1 to n do Buffer.add_string buf s done;
+  Buffer.contents buf
+(*$T repeat
+   repeat "fo" 4 = "fofofofo"
+   repeat "fo" 0 = ""
+   repeat "" 4 = ""
+*)
+
 (*$T left
   left "abc" 1 = "a"
   left "ab" 3 = "ab"
@@ -432,6 +442,7 @@ let split_on_string ~by str = split_on_string_comp ~by str
   split_on_string ~by:"/" "/a/b/c//" = [""; "a"; "b"; "c"; ""; ""]
   split_on_string ~by:"FOO" "FOOaFOObFOOcFOOFOO" = [""; "a"; "b"; "c"; ""; ""]
   split_on_string ~by:"//" "before///after" = ["before"; "/after"] (* bug/issue #1088 *)
+  List.length (split_on_string ~by:" " (repeat " " 10000000)) = 10000001 (* testing for stack overflow, #1111 *)
 *)
 
 let split_on_char sep str =
@@ -926,16 +937,6 @@ let rev_in_place s =
 *)
 
 let in_place_mirror = rev_in_place
-
-let repeat s n =
-  let buf = Buffer.create ( n * (String.length s) ) in
-  for _i = 1 to n do Buffer.add_string buf s done;
-  Buffer.contents buf
-(*$T repeat
-   repeat "fo" 4 = "fofofofo"
-   repeat "fo" 0 = ""
-   repeat "" 4 = ""
-*)
 
 let rev s =
   let len = String.length s in

--- a/src/batString.mlv
+++ b/src/batString.mlv
@@ -406,12 +406,15 @@ let split_on_string_comp ?(on_empty=[""]) ~by:sep str =
       if curr = len then
         List.rev ("" :: acc) (* for compatibility with old behavior *)
       else
-        try
-          let i = find_from str curr sep in
+        match
+          try Some (find_from str curr sep)
+          with | Not_found -> None
+        with
+        | Some i ->
           let tok = sub str curr (i - curr) in
           let next = i + seplen in
           loop (tok :: acc) next
-        with Not_found ->
+        | None ->
           let rest = sub str curr (len - curr) in
           List.rev (rest :: acc)
     in


### PR DESCRIPTION
The exception handler should not cover the recursive call.

--

Hello, I noticed that `split_on_string` would stack overflow for long strings, like so:
```
$ ocaml
        OCaml version 4.13.0

      _______________________________
    [| +   | |   Batteries 3.6.0  - |
     |_____|_|______________________|
      _______________________________
     | -  Type '#help;;'      | | + |]
     |________________________|_|___|


# BatString.split_on_string " " (BatString.repeat " " 10000000);;
Warning 6 [labels-omitted]: label by was omitted in the application of this function.
Stack overflow during evaluation (looping recursion?).
```
Seems to me like this is a sensible fix for it. Maybe a test can also be added to the list below?

Thanks!