### PR TITLE
Add workaround for missing batteriesConfig dependency in inline tests

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -9,7 +9,8 @@
  (libraries num str camlp-streams unix bigarray)
  (inline_tests
    (backend qtest_batteries)
-   (deps %{project_root}/qtest/qtest_preamble.ml)
+   (deps %{project_root}/qtest/qtest_preamble.ml
+    batteriesConfig.ml batConcreteQueue.ml) ; workaround for dune inline test runner not properly depending on generated modules: https://github.com/ocaml/opam-repository/pull/24327#issuecomment-1709839625
  )
  (wrapped false)
 )


### PR DESCRIPTION
Hopefully fixes this issue: https://github.com/ocaml/opam-repository/pull/24327#issuecomment-1709839625.

I could reproduce it by commenting out the `test` stanza in `src/dune` and running `dune clean && dune build @src/runtest`. After these changes that problem no longer appears for me like that, so hopefully it's also fixed for the CI.