### PR TITLE
Add Stdlib type equality to Set.Make, Map.Make and Hashtbl.Make

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## NEXT_RELEASE
+
+- Add Stdlib type equality to Set.Make, Map.Make and Hashtbl.Make
+  #1132
+  (Simmo Saan)
+
 ## v3.8.0 (minor release)
 
 - support OCaml 5.2 

--- a/src/batHashtbl.ml
+++ b/src/batHashtbl.ml
@@ -673,7 +673,7 @@ sig
 end
 
 
-module Make(H: HashedType): (S with type key = H.t) =
+module Make(H: HashedType): (S with type key = H.t and type 'a t = 'a Hashtbl.Make (H).t) =
 struct
   include Hashtbl.Make(H)
   external to_hash : 'a t -> (key, 'a) Hashtbl.t = "%identity"

--- a/src/batHashtbl.mli
+++ b/src/batHashtbl.mli
@@ -512,7 +512,7 @@ sig
 end
 (** The output signature of the functor {!Hashtbl.Make}. *)
 
-module Make (H : HashedType) : S with type key = H.t
+module Make (H : HashedType) : S with type key = H.t and type 'a t = 'a Hashtbl.Make (H).t
 (** Functor building an implementation of the hashtable structure.
     The functor [Hashtbl.Make] returns a structure containing
     a type [key] of keys and a type ['a t] of hash tables

--- a/src/batMap.mli
+++ b/src/batMap.mli
@@ -515,7 +515,7 @@ sig
 end
 
 
-module Make (Ord : BatInterfaces.OrderedType) : S with type key = Ord.t
+module Make (Ord : BatInterfaces.OrderedType) : S with type key = Ord.t with type 'a t = 'a Map.Make (Ord).t
 (** Functor building an implementation of the map structure
     given a totally ordered type.
 *)

--- a/src/batSet.mli
+++ b/src/batSet.mli
@@ -475,7 +475,7 @@ module IRopeSet   : S with type elt = BatRope.t
 
  *)
 
-module Make (Ord : OrderedType) : S with type elt = Ord.t
+module Make (Ord : OrderedType) : S with type elt = Ord.t and type t = Set.Make (Ord).t
 (** Functor building an implementation of the set structure
     given a totally ordered type.
 


### PR DESCRIPTION
For most types batteries already has such type equalities, but crucially for `BatSet.Make`, `BatMap.Make` and `BatHashtbl.Make` they were missing. Containers has the same type equalities exposed.

These are particularly useful for when batteries lags behind `Stdlib` (which can often happen nowadays) and one wants to use some functions from batteries, but also new ones from `Stdlib`. This type equality makes it at least possible without having to immediately patch batteries every time and wait for a release.