### PR TITLE
Update GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
         os:
           - ubuntu-latest
         ocaml-compiler:
-          - 5.2.0
-          - 5.1.0
-          - 5.0.0
+          - 5.2.x
+          - 5.1.x
+          - 5.0.x
           - 4.14.x
           - 4.13.x
           - 4.12.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
         os:
           - ubuntu-latest
         ocaml-compiler:
+          - 5.2.0
           - 5.1.0
           - 5.0.0
           - 4.14.x


### PR DESCRIPTION
The CI on ee91f7899976584c87d92c3c1363e0a748cd9a9c fails miserably because ubuntu-latest is now 24.04 and doesn't have darcs. The new version of setup-ocaml fixes the problem.

Updating OCaml versions in the CI while at it.