### PR TITLE
BatHashcons: port various optimizations and fixes from upstream

### DIFF
--- a/src/batHashcons.ml
+++ b/src/batHashcons.ml
@@ -116,6 +116,7 @@ struct
       newt.limit <- t.limit + 100 ;          (* prevent resizing of newt *)
       iter (add newt) t ;
       t.table <- newt.table ;
+      t.totsize <- newt.totsize
     end
 
   and add t d =

--- a/src/batHashcons.ml
+++ b/src/batHashcons.ml
@@ -128,7 +128,7 @@ struct
     if !i < sz then begin
       Weak.set bucket !i (Some d)
     end else begin
-      let newsz = Pervasives.min (sz + 3) (Sys.max_array_length - 1) in
+      let newsz = next_sz sz in
       if newsz <= sz then
         failwith "Hashcons.Make: hash bucket cannot grow more" ;
       let newbucket = Weak.create newsz in

--- a/src/batHashcons.ml
+++ b/src/batHashcons.ml
@@ -147,7 +147,7 @@ struct
     let i = ref 0 in
     while !i < sz && BatOption.is_none !found do
       match Weak.get bucket !i with
-      | Some v as opt when HT.equal v.obj d ->
+      | Some v as opt when v.hcode = hcode && HT.equal v.obj d ->
         found := opt
       | _ -> incr i
     done;

--- a/src/batHashcons.ml
+++ b/src/batHashcons.ml
@@ -116,7 +116,6 @@ struct
       newt.limit <- t.limit + 100 ;          (* prevent resizing of newt *)
       iter (add newt) t ;
       t.table <- newt.table ;
-      t.limit <- t.limit + 2 ;
     end
 
   and add t d =

--- a/src/batHashcons.ml
+++ b/src/batHashcons.ml
@@ -123,24 +123,21 @@ struct
     let index = d.hcode mod (Array.length t.table) in
     let bucket = t.table.(index) in
     let sz = Weak.length bucket in
-    let rec loop i =
-      if i >= sz then begin
-        let newsz = Pervasives.min (sz + 3) (Sys.max_array_length - 1) in
-        if newsz <= sz then
-          failwith "Hashcons.Make: hash bucket cannot grow more" ;
-        let newbucket = Weak.create newsz in
-        Weak.blit bucket 0 newbucket 0 sz ;
-        Weak.set newbucket i (Some d) ;
-        t.table.(index) <- newbucket ;
-        t.totsize <- t.totsize + (newsz - sz) ;
-        if t.totsize > t.limit * Array.length t.table then resize t ;
-      end else begin
-        if Weak.check bucket i
-        then loop (i + 1)
-        else Weak.set bucket i (Some d)
-      end
-    in
-    loop 0
+    let i = ref 0 in
+    while !i < sz && Weak.check bucket !i do incr i done;
+    if !i < sz then begin
+      Weak.set bucket !i (Some d)
+    end else begin
+      let newsz = Pervasives.min (sz + 3) (Sys.max_array_length - 1) in
+      if newsz <= sz then
+        failwith "Hashcons.Make: hash bucket cannot grow more" ;
+      let newbucket = Weak.create newsz in
+      Weak.blit bucket 0 newbucket 0 sz ;
+      Weak.set newbucket sz (Some d) ;
+      t.table.(index) <- newbucket ;
+      t.totsize <- t.totsize + (newsz - sz) ;
+      if t.totsize > t.limit * Array.length t.table then resize t ;
+    end
 
   let hashcons t d =
     let hcode = (HT.hash d) land Pervasives.max_int in

--- a/src/batHashcons.ml
+++ b/src/batHashcons.ml
@@ -153,12 +153,8 @@ struct
         add t hdata ;
         hdata
       end else begin
-        match Weak.get_copy bucket i with
-        | Some v when HT.equal v.obj d ->
-          begin match Weak.get bucket i with
-            | Some v -> v
-            | None -> loop (i + 1)
-          end
+        match Weak.get bucket i with
+        | Some v when HT.equal v.obj d -> v
         | _ -> loop (i + 1)
       end
     in

--- a/src/batHashcons.ml
+++ b/src/batHashcons.ml
@@ -144,18 +144,20 @@ struct
     let index = hcode mod (Array.length t.table) in
     let bucket = t.table.(index) in
     let sz = Weak.length bucket in
-    let rec loop i =
-      if i >= sz then begin
-        let hdata = { hcode = hcode ; tag = gentag () ; obj = d } in
-        add t hdata ;
-        hdata
-      end else begin
-        match Weak.get bucket i with
-        | Some v when HT.equal v.obj d -> v
-        | _ -> loop (i + 1)
-      end
-    in
-    loop 0
+    let found = ref None in
+    let i = ref 0 in
+    while !i < sz && BatOption.is_none !found do
+      match Weak.get bucket !i with
+      | Some v as opt when HT.equal v.obj d ->
+        found := opt
+      | _ -> incr i
+    done;
+    match !found with
+    | Some v -> v
+    | None ->
+      let hdata = { hcode = hcode ; tag = gentag () ; obj = d } in
+      add t hdata ;
+      hdata
 end
 
 module H = struct


### PR DESCRIPTION
The `BatHashcons` implementation originates from
https://github.com/ocaml-batteries-team/batteries-included/blob/f6e091266599aea93c8a94115cf08f50e88c5dd0/src/batHashcons.ml#L21-L24
which now lives at https://github.com/backtracking/ocaml-hashcons/.

That itself is based on a copy of the internals of `Stdlib.Weak`. Over the many years, `Stdlib.Weak` has seen various optimizations and fixes: https://github.com/backtracking/ocaml-hashcons/commit/81679509e0d6839e95d7bec7abc038c139c88dd7, https://github.com/backtracking/ocaml-hashcons/commit/46ce4e602a185fe7e6797e267fef788a9a84a0ca, https://github.com/backtracking/ocaml-hashcons/pull/16, https://github.com/backtracking/ocaml-hashcons/pull/17, https://github.com/backtracking/ocaml-hashcons/pull/18 and https://github.com/backtracking/ocaml-hashcons/commit/4d10dc7721be74e87fff7538a268a37d40c898b7.

This PR ports all of them also to Batteries.