### PR TITLE
Add opam-repository-archive to CI for OCaml versions < 4.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,12 @@ jobs:
           - 4.13.x
           - 4.12.x
           - 4.11.x
-          - 4.10.x
-          - 4.09.x
-          - 4.08.x
-          - 4.07.x
-          - 4.06.x
+          - ocaml-base-compiler.4.10.2
+          - ocaml-base-compiler.4.09.1
+          - ocaml-base-compiler.4.08.1
+          - ocaml-base-compiler.4.07.1
+          - ocaml-base-compiler.4.06.1
+          - ocaml-base-compiler.4.05.0
         test:
           - true
 
@@ -48,6 +49,9 @@ jobs:
       - name: Set up OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v3
         with:
+          opam-repositories: |
+            default: git+https://github.com/ocaml/opam-repository.git
+            archive: git+https://github.com/ocaml/opam-repository-archive.git
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
       - name: Install dependencies


### PR DESCRIPTION
The official opam-repository has recently gone through some archival of old OCaml compiler versions.
These could just be removed from the CI but I think using opam-repository-archive, which still contains them, is a better approach.

Since these versions are in the bounds that Batteries claims to support and given the legacy role of Batteries, I think it's worth having them in this CI, even if they won't be in opam-ci anymore.
This way it'll hopefully be more clear if some change breaks the support for very old versions and the decision to possibly drop their support in the future could be made intentionally, not accidentally.